### PR TITLE
extract shared cookbook modules + move EngineAdapter to protocol.py

### DIFF
--- a/cookbook/bulletin_hooks.py
+++ b/cookbook/bulletin_hooks.py
@@ -1,0 +1,206 @@
+"""Shared Modal Volume bulletin-board hooks for publish + rollout gating.
+
+Two hooks that any trainer (slime, miles, ...) plugs into via its
+``custom_delta_pre_push_path`` and ``custom_rollout_request_hook_path``:
+
+- :func:`commit_and_wake` — advance the ``latest`` pointer, commit the Volume,
+  and best-effort wake the Flash rollout pool.
+- :func:`gated_rollout_request_hook` — pin each rollout request to a bounded-
+  staleness weight version so unusable (too-stale) rollouts are never generated.
+
+Both hooks read their config off the trainer's ``args`` namespace (the trainer's
+``--custom-config-path`` setattr's every key onto ``args``). The only
+trainer-specific axis is the env-var fallback for the Flash app / class name;
+callers pass those as ``app_name_env`` / ``cls_name_env``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from stitch.bulletin import FilesystemBulletinBoard
+from stitch.protocol import parse_weight_identity
+from stitch.providers.modal import commit_volume, discover_flash_targets, volume_reloader, wake_targets
+
+
+logger = logging.getLogger(__name__)
+
+
+# ── Publish hook ──────────────────────────────────────────────────────────────
+
+
+def commit_and_wake(
+    args: Any,
+    version_dir: str,
+    rollout_engines: list[Any],
+    *,
+    app_name_env: str,
+    cls_name_env: str,
+) -> None:
+    """Trainer ``custom_delta_pre_push_path`` hook (publish-only, bulletin board).
+
+    The trainer has written ``weight_v{N}/`` to the Modal Volume. Advance the
+    committed ``latest`` pointer, commit the Volume so the rollout pool's
+    ``reload`` sees the new version, then best-effort wake the Flash pool. The
+    sidecars self-sync (wake RPC, periodic poll, startup), so a missed wake only
+    costs latency.
+
+    ``app_name_env`` / ``cls_name_env`` are the env-var names the trainer uses
+    for the Flash app and server class (e.g. ``"SLIME_DELTA_APP_NAME"``).
+    """
+    del rollout_engines
+    version = parse_weight_identity(Path(version_dir).name)
+    rank = distributed_rank()
+
+    # Rank 0 owns the `latest` pointer and writes it before committing, so the
+    # committed bulletin is self-consistent for the poll/startup path. The pointer
+    # lives at the transport root (the Volume mount) and is self-identifying —
+    # `<run_id>/weight_vN` — while the trainer wrote the version dir under the run
+    # partition (update_weight_disk_dir = <root>/<run_id>), so a new run is a
+    # forward move of the pointer, never a colliding rewind.
+    if version is not None and rank in (None, 0):
+        FilesystemBulletinBoard(_transport_root(args), layout="slime").write_latest(
+            _run_id(args), version
+        )
+    commit_volume(_volume_name(args))
+
+    if version is None or rank not in (None, 0):
+        return
+    # Waking warm containers is a best-effort latency optimization: a transient
+    # Modal control-plane error must not kill the training step — `latest` is
+    # already committed and sidecars self-sync on their next poll.
+    try:
+        app_name = getattr(args, "rollout_modal_flash_app_name", None) or os.environ[app_name_env]
+        cls_name = getattr(args, "rollout_modal_flash_server_cls_name", None) or os.getenv(
+            cls_name_env, "Server"
+        )
+        wake_targets(discover_flash_targets(app_name=app_name, cls_name=cls_name), version)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Best-effort rollout wake failed for version %s; sidecars will self-sync",
+            version,
+            exc_info=True,
+        )
+
+
+# ── Staleness-gated rollout requests ──────────────────────────────────────────
+
+
+class CachedLatestPointer:
+    """TTL-cached ``(run_id, version)`` from the bulletin board's ``latest`` pointer.
+
+    The per-request hook gets no rollout_id, so the staleness floor is derived
+    out-of-band from the published ``latest`` pointer (the publish hook already
+    advanced + committed it). TTL-cached with a Volume reload so a (possibly
+    cross-node) rollout actor sees rank-0's committed pointer without a Volume
+    reload per request.
+    """
+
+    def __init__(self) -> None:
+        self.version: int = 0
+        self.run_id: str | None = None
+        self._refreshed_at: float = -1e9
+        self._board: FilesystemBulletinBoard | None = None
+
+    async def get(self, args: Any, ttl: float = 2.0) -> int:
+        now = time.monotonic()
+        if self._board is None:
+            self._board = _gate_board(args)
+        if now - self._refreshed_at >= ttl:
+            self._refreshed_at = now
+            try:
+                await self._board.refresh()
+                run_id, version = self._board.read_latest()
+                # Staleness floor is per-run (version restarts at 1 each run); on a
+                # run change adopt the new run's pointer immediately so the floor
+                # isn't pinned to a finished run's higher version number.
+                self.run_id = run_id
+                self.version = int(version)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "gate: could not read latest published version; using cached %s",
+                    self.version,
+                    exc_info=True,
+                )
+        return self.version
+
+
+_latest_cache = CachedLatestPointer()
+
+
+async def gated_rollout_request_hook(args: Any, sample: Any, request: dict[str, Any]) -> None:
+    """Trainer ``custom_rollout_request_hook_path``: gate each rollout on
+    ``weight_version - k`` so unusable (too-stale) rollouts are never generated.
+
+    A request pinned to ``min_required_version = latest - lag`` is admitted only
+    by a replica within ``lag`` versions of the newest weights; a lagging replica
+    returns a retryable 409 (which also nudges it to sync forward), so the trainer
+    never spends rollout compute on weights staler than its bound. ``min`` mode
+    (not ``exact``) lets the request cross in_place commits without being quiesced.
+    """
+    mode = str(getattr(args, "rollout_request_weight_version_mode", "min"))
+    if mode != "none":
+        latest = await _latest_cache.get(args)
+        lag = int(getattr(args, "rollout_request_weight_version_lag", 0))
+        target = max(0, latest - lag)
+        key = "exact_version" if mode == "exact" else "min_required_version"
+        request["payload"]["weight_version"] = {key: target}
+
+    request["max_retries"] = int(getattr(args, "rollout_request_retry_attempts", request.get("max_retries", 60)))
+    request["retry_sleep"] = float(getattr(args, "rollout_request_retry_sleep", request.get("retry_sleep", 1.0)))
+
+    session_id = getattr(sample, "session_id", None)
+    if session_id:
+        header = str(getattr(args, "rollout_session_affinity_header", "x-session-affinity"))
+        headers = dict(request.get("headers") or {})
+        headers.setdefault(header, session_id)
+        request["headers"] = headers
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+def distributed_rank() -> int | None:
+    """Return the torch distributed rank, or None if not initialized."""
+    try:
+        import torch.distributed as dist
+
+        if dist.is_available() and dist.is_initialized():
+            return int(dist.get_rank())
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _volume_name(args: Any) -> str:
+    return str(getattr(args, "update_weight_delta_volume_name", None) or os.environ["DELTA_VOLUME_NAME"])
+
+
+def bulletin_root(args: Any) -> str:
+    """Where the trainer writes version dirs: ``<transport_root>/<run_id>``."""
+    return str(
+        getattr(args, "update_weight_disk_dir", None)
+        or os.environ.get("DELTA_BULLETIN_ROOT", "/delta-bulletin")
+    )
+
+
+def _transport_root(args: Any) -> str:
+    """The Volume mount root that holds the canonical ``latest`` pointer and that
+    the sidecar boards are rooted at — the parent of the per-run write dir."""
+    return str(Path(bulletin_root(args)).parent)
+
+
+def _run_id(args: Any) -> str:
+    """The run partition (chain identity). Passed explicitly via custom_config,
+    falling back to the basename of the per-run write dir."""
+    return str(getattr(args, "run_id", None) or Path(bulletin_root(args)).name)
+
+
+def _gate_board(args: Any) -> FilesystemBulletinBoard:
+    vol = getattr(args, "update_weight_delta_volume_name", None) or os.environ.get("DELTA_VOLUME_NAME")
+    refresh = volume_reloader(vol) if vol else None
+    return FilesystemBulletinBoard(_transport_root(args), refresh=refresh, layout="slime")

--- a/cookbook/miles_disagg/helpers.py
+++ b/cookbook/miles_disagg/helpers.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import subprocess
 import time
 import urllib.error
 import urllib.request
@@ -46,9 +47,7 @@ def start_sglang_sidecar(
     volume_name: str,
     commit_mode: str,
     debug_requests: bool = False,
-) -> "subprocess.Popen":
-    import subprocess
-
+) -> subprocess.Popen:
     from cookbook.sidecar_process import start_sglang_sidecar as _start
 
     return _start(

--- a/cookbook/miles_disagg/helpers.py
+++ b/cookbook/miles_disagg/helpers.py
@@ -1,11 +1,9 @@
-"""Ray cluster, sidecar process, and smoke-check helpers for the miles example.
+"""Trainer-specific helpers for the miles_disagg example.
 
-The miles twin of cookbook/slime_disagg/helpers.py. The Ray bring-up, sidecar
-launch, and Flash-pool smoke check are trainer-agnostic and identical; only
-``prepare_miles_config`` / ``build_train_cmd`` (which source the miles model
-script and run miles' train.py/train_async.py) and the sidecar module path
-differ. Ray helpers were originally adapted from
-https://github.com/modal-projects/multinode-training-guide.
+Ray cluster, sidecar, and process helpers are shared across trainers via
+:mod:`cookbook.ray_cluster` and :mod:`cookbook.sidecar_process`. This module
+provides miles-specific config preparation, train command building, and the
+Flash pool smoke check.
 """
 
 from __future__ import annotations
@@ -13,144 +11,57 @@ from __future__ import annotations
 import json
 import os
 import shlex
-import signal
-import socket
-import subprocess
 import time
 import urllib.error
 import urllib.request
-from pathlib import Path
 from typing import Any
 
 from stitch.providers.modal import discover_flash_targets, resolve_flash_gateway_url
 
-RAY_START_TIMEOUT = 240
-RAY_WORKER_JOIN_TIMEOUT = 180
+# Re-export shared helpers so existing callers (modal_train.py) don't break.
+from cookbook.ray_cluster import (  # noqa: F401
+    RAY_START_TIMEOUT,
+    RAY_WORKER_JOIN_TIMEOUT,
+    get_modal_cluster_context,
+    start_ray_head,
+    start_ray_worker,
+    training_nodes,
+)
+from cookbook.sidecar_process import (  # noqa: F401
+    terminate_process,
+    wait_http,
+)
 
 
-# ── Ray cluster ───────────────────────────────────────────────────────────────
+SIDECAR_MODULE = "cookbook.miles_disagg.sidecar"
 
 
-def training_nodes(cfg: Any) -> int:
-    nodes = int(getattr(cfg, "actor_num_nodes", 1))
-    if getattr(cfg, "use_critic", False) or getattr(cfg, "advantage_estimator", None) == "ppo":
-        nodes += int(getattr(cfg, "critic_num_nodes", nodes))
-    return nodes
+def start_sglang_sidecar(
+    *,
+    sidecar_port: int,
+    sglang_port: int,
+    bulletin_root: str,
+    local_checkpoint_dir: str,
+    base_checkpoint_dir: str,
+    volume_name: str,
+    commit_mode: str,
+    debug_requests: bool = False,
+) -> "subprocess.Popen":
+    import subprocess
 
+    from cookbook.sidecar_process import start_sglang_sidecar as _start
 
-def get_modal_cluster_context(n_nodes: int) -> tuple[int, str, str]:
-    """Return (rank, master_addr, my_ip) for the current Modal cluster."""
-    import modal.experimental
-
-    try:
-        info = modal.experimental.get_cluster_info()
-    except Exception:  # noqa: BLE001
-        if n_nodes == 1:
-            ip = _get_local_ip()
-            return 0, ip, ip
-        raise
-    actual_nodes = len(info.container_ipv4_ips)
-    if actual_nodes == 0 and n_nodes == 1:
-        ip = _get_local_ip()
-        return 0, ip, ip
-    if actual_nodes != n_nodes:
-        raise RuntimeError(f"cluster size mismatch: expected {n_nodes} node(s), got {actual_nodes}")
-    return info.rank, info.container_ipv4_ips[0], info.container_ipv4_ips[info.rank]
-
-
-def _get_local_ip() -> str:
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-        try:
-            sock.connect(("8.8.8.8", 80))
-            return sock.getsockname()[0]
-        except OSError:
-            return socket.gethostbyname(socket.gethostname())
-
-
-def start_ray_head(my_ip: str, n_nodes: int, *, ray_port: int) -> None:
-    """Start the Ray head node and wait for all workers to join."""
-    import ray
-
-    start_cmd = [
-        "ray",
-        "start",
-        "--head",
-        f"--node-ip-address={my_ip}",
-        f"--port={ray_port}",
-        "--disable-usage-stats",
-        "--include-dashboard=false",
-    ]
-    try:
-        subprocess.run(start_cmd, check=True, timeout=RAY_START_TIMEOUT)
-    except subprocess.TimeoutExpired as exc:
-        _print_ray_logs()
-        raise RuntimeError(f"Ray head node did not finish startup within {RAY_START_TIMEOUT}s") from exc
-    except subprocess.CalledProcessError as exc:
-        _print_ray_logs()
-        raise RuntimeError(f"Ray head node failed to start with exit code {exc.returncode}") from exc
-
-    last_error = ""
-    for _ in range(RAY_START_TIMEOUT):
-        try:
-            ray.init(address=f"{my_ip}:{ray_port}")
-            break
-        except Exception as exc:  # noqa: BLE001
-            last_error = f"{type(exc).__name__}: {exc}"
-            time.sleep(1)
-    else:
-        _print_ray_logs()
-        raise RuntimeError(f"Ray head node failed to start before timeout: {last_error}")
-
-    for _ in range(RAY_WORKER_JOIN_TIMEOUT):
-        alive = [n for n in ray.nodes() if n["Alive"]]
-        print(f"Waiting for workers: {len(alive)}/{n_nodes} alive")
-        if len(alive) == n_nodes:
-            break
-        time.sleep(1)
-    else:
-        _print_ray_logs()
-        raise RuntimeError(f"Timed out waiting for all {n_nodes} Ray nodes to join")
-
-
-def start_ray_worker(my_ip: str, master_addr: str, *, ray_port: int) -> None:
-    """Join this container to the Ray cluster as a worker node."""
-    subprocess.run(
-        [
-            "ray",
-            "start",
-            f"--node-ip-address={my_ip}",
-            "--address",
-            f"{master_addr}:{ray_port}",
-            "--disable-usage-stats",
-        ],
-        check=True,
-        timeout=RAY_START_TIMEOUT,
+    return _start(
+        sidecar_module=SIDECAR_MODULE,
+        sidecar_port=sidecar_port,
+        sglang_port=sglang_port,
+        bulletin_root=bulletin_root,
+        local_checkpoint_dir=local_checkpoint_dir,
+        base_checkpoint_dir=base_checkpoint_dir,
+        volume_name=volume_name,
+        commit_mode=commit_mode,
+        debug_requests=debug_requests,
     )
-
-
-def _print_ray_logs() -> None:
-    log_dir = Path("/tmp/ray/session_latest/logs")
-    for name in (
-        "dashboard.log",
-        "dashboard.err",
-        "gcs_server.out",
-        "gcs_server.err",
-        "raylet.out",
-        "raylet.err",
-        "monitor.out",
-        "monitor.err",
-    ):
-        path = log_dir / name
-        if not path.exists():
-            continue
-        print(f"===== {path} =====")
-        try:
-            lines = path.read_text(errors="replace").splitlines()
-        except OSError as exc:
-            print(f"could not read {path}: {exc}")
-            continue
-        for line in lines[-80:]:
-            print(line)
 
 
 # ── miles launch ──────────────────────────────────────────────────────────────
@@ -220,76 +131,6 @@ def build_train_cmd(miles_cfg: Any, miles_root: str) -> str:
         )
         return f"bash -c {shlex.quote(inner)}"
     return f"python3 {train_script} {shlex.join(miles_cfg.cli_args())}"
-
-
-# ── Sidecar process ───────────────────────────────────────────────────────────
-
-
-def start_sglang_sidecar(
-    *,
-    sidecar_port: int,
-    sglang_port: int,
-    bulletin_root: str,
-    local_checkpoint_dir: str,
-    base_checkpoint_dir: str,
-    volume_name: str,
-    commit_mode: str,
-    debug_requests: bool = False,
-) -> subprocess.Popen:
-    cmd = [
-        "python3",
-        "-m",
-        "cookbook.miles_disagg.sidecar",
-        "--host",
-        "0.0.0.0",
-        "--port",
-        str(sidecar_port),
-        "--upstream-url",
-        f"http://127.0.0.1:{sglang_port}",
-        "--bulletin-root",
-        bulletin_root,
-        "--local-checkpoint-dir",
-        local_checkpoint_dir,
-        "--base-checkpoint-dir",
-        base_checkpoint_dir,
-        "--volume-name",
-        volume_name,
-        "--commit-mode",
-        commit_mode,
-    ]
-    if debug_requests:
-        cmd.append("--debug-requests")
-    print("Starting sidecar:", " ".join(cmd))
-    return subprocess.Popen(cmd, start_new_session=True)
-
-
-def wait_http(url: str, process: subprocess.Popen | None, timeout: int) -> None:
-    deadline = time.time() + timeout
-    last_error: str | None = None
-    while time.time() < deadline:
-        if process is not None and process.poll() is not None:
-            raise RuntimeError(f"process exited while waiting for {url}: code={process.returncode}")
-        try:
-            with urllib.request.urlopen(url, timeout=5) as resp:
-                if 200 <= resp.status < 500:
-                    return
-        except (urllib.error.URLError, TimeoutError, OSError) as exc:
-            last_error = f"{type(exc).__name__}: {exc}"
-        time.sleep(2)
-    raise TimeoutError(f"Timed out waiting for {url}; last error: {last_error}")
-
-
-def terminate_process(process: subprocess.Popen | None) -> None:
-    if process is None or process.poll() is not None:
-        return
-    try:
-        os.killpg(process.pid, signal.SIGTERM)
-        process.wait(timeout=20)
-    except Exception:
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except Exception:
-            pass
 
 
 # ── Flash pool smoke check ────────────────────────────────────────────────────

--- a/cookbook/miles_disagg/hooks.py
+++ b/cookbook/miles_disagg/hooks.py
@@ -1,184 +1,32 @@
-"""Modal publish + rollout-gating hooks for the miles_disagg bulletin board.
+"""Modal publish + rollout-gating hooks for the miles_disagg example.
 
-The miles twin of cookbook/slime_disagg/hooks.py. miles' publish-only disk-delta
-updater writes ``weight_v{N}/`` to the Modal Volume bulletin board and calls
-``custom_delta_pre_push_path`` (``commit_and_wake``) before advancing; the
-elastic Flash pool of SGLang servers + stitch sidecars self-syncs from it. The
-per-request ``custom_rollout_request_hook_path`` (``gated_rollout_request_hook``)
-pins each rollout to a bounded-staleness weight version.
-
-Both hooks read their config off the miles ``args`` namespace: miles'
-``--custom-config-path`` setattr's every YAML key onto ``args``, so the bulletin
-identity (volume, app, run_id) and the gate knobs that modal_train ships there
-are visible to ``getattr(args, ...)`` here. Nothing engine-specific lives in
-these hooks — they only layer on the Modal Volume durability + pool wake.
+Thin wrappers around :mod:`cookbook.bulletin_hooks` with the miles-specific
+env-var fallbacks for the Flash app / server class name.
 """
 
 from __future__ import annotations
 
-import logging
-import os
-import time
-from pathlib import Path
 from typing import Any
 
-from stitch.bulletin import FilesystemBulletinBoard
-from stitch.protocol import parse_weight_identity
-from stitch.providers.modal import commit_volume, discover_flash_targets, volume_reloader, wake_targets
-
-
-logger = logging.getLogger(__name__)
+from cookbook.bulletin_hooks import (
+    CachedLatestPointer,
+    bulletin_root,
+    commit_and_wake as _commit_and_wake,
+    distributed_rank,
+    gated_rollout_request_hook,
+)
 
 
 def commit_and_wake(args: Any, version_dir: str, rollout_engines: list[Any]) -> None:
-    """miles ``custom_delta_pre_push_path`` hook (publish-only, bulletin board).
-
-    miles has written ``weight_v{N}/`` to the Modal Volume. Advance the committed
-    ``latest`` pointer, commit the Volume so the rollout pool's ``reload`` sees the
-    new version, then best-effort wake the Flash pool. The sidecars self-sync (wake
-    RPC, periodic poll, startup), so a missed wake only costs latency.
-
-    Called by miles with ``version_dir`` = the per-version ``weight_v{N}`` dir
-    (or the disk-dir root on the baseline call, where parse returns None), and an
-    empty ``rollout_engines`` list in publish-only mode.
-    """
-    del rollout_engines
-    version = parse_weight_identity(Path(version_dir).name)
-    rank = _distributed_rank()
-
-    # Rank 0 owns the `latest` pointer and writes it before committing, so the
-    # committed bulletin is self-consistent for the poll/startup path. The pointer
-    # lives at the transport root (the Volume mount) and is self-identifying —
-    # `<run_id>/weight_vN` — while miles wrote the version dir under the run
-    # partition (update_weight_disk_dir = <root>/<run_id>), so a new run is a
-    # forward move of the pointer, never a colliding rewind.
-    if version is not None and rank in (None, 0):
-        FilesystemBulletinBoard(_transport_root(args), layout="slime").write_latest(
-            _run_id(args), version
-        )
-    commit_volume(_volume_name(args))
-
-    if version is None or rank not in (None, 0):
-        # version is None on the baseline call (disk-dir root); only rank 0 wakes.
-        return
-    # Waking warm containers is a best-effort latency optimization: a transient
-    # Modal control-plane error must not kill the training step — `latest` is
-    # already committed and sidecars self-sync on their next poll.
-    try:
-        app_name = getattr(args, "rollout_modal_flash_app_name", None) or os.environ["MILES_DELTA_APP_NAME"]
-        cls_name = getattr(args, "rollout_modal_flash_server_cls_name", None) or os.getenv(
-            "MILES_DELTA_SERVER_CLS_NAME", "Server"
-        )
-        wake_targets(discover_flash_targets(app_name=app_name, cls_name=cls_name), version)
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "Best-effort rollout wake failed for version %s; sidecars will self-sync",
-            version,
-            exc_info=True,
-        )
-
-
-def _distributed_rank() -> int | None:
-    try:
-        import torch.distributed as dist
-
-        if dist.is_available() and dist.is_initialized():
-            return int(dist.get_rank())
-    except Exception:  # noqa: BLE001
-        return None
-    return None
-
-
-def _volume_name(args: Any) -> str:
-    return str(getattr(args, "update_weight_delta_volume_name", None) or os.environ["DELTA_VOLUME_NAME"])
-
-
-def _bulletin_root(args: Any) -> str:
-    """Where miles writes version dirs: ``<transport_root>/<run_id>``."""
-    return str(
-        getattr(args, "update_weight_disk_dir", None)
-        or os.environ.get("DELTA_BULLETIN_ROOT", "/delta-bulletin")
+    """miles ``custom_delta_pre_push_path`` hook (publish-only, bulletin board)."""
+    _commit_and_wake(
+        args,
+        version_dir,
+        rollout_engines,
+        app_name_env="MILES_DELTA_APP_NAME",
+        cls_name_env="MILES_DELTA_SERVER_CLS_NAME",
     )
 
 
-def _transport_root(args: Any) -> str:
-    """The Volume mount root that holds the canonical ``latest`` pointer and that
-    the sidecar boards are rooted at — the parent of the per-run write dir."""
-    return str(Path(_bulletin_root(args)).parent)
-
-
-def _run_id(args: Any) -> str:
-    """The run partition (chain identity). Passed explicitly via custom_config,
-    falling back to the basename of the per-run write dir."""
-    return str(getattr(args, "run_id", None) or Path(_bulletin_root(args)).name)
-
-
-# ── Staleness-gated rollout requests ──────────────────────────────────────────
-
-# Cache of the latest published version for the gate. The per-request hook gets no
-# rollout_id, so the staleness floor is derived out-of-band from the published
-# `latest` pointer (the publish hook already advanced + committed it). TTL-cached
-# with a Volume reload so a (possibly cross-node) rollout actor sees rank-0's
-# committed pointer without a Volume reload per request.
-_latest_cache: dict[str, Any] = {"version": 0, "run_id": None, "at": -1e9, "board": None}
-
-
-def _gate_board(args: Any) -> FilesystemBulletinBoard:
-    vol = getattr(args, "update_weight_delta_volume_name", None) or os.environ.get("DELTA_VOLUME_NAME")
-    refresh = volume_reloader(vol) if vol else None
-    # The pointer lives at the transport root (the mount), not the per-run write dir.
-    return FilesystemBulletinBoard(_transport_root(args), refresh=refresh, layout="slime")
-
-
-async def _latest_published(args: Any, ttl: float = 2.0) -> int:
-    now = time.monotonic()
-    if _latest_cache["board"] is None:
-        _latest_cache["board"] = _gate_board(args)
-    if now - _latest_cache["at"] >= ttl:
-        _latest_cache["at"] = now  # claim the refresh slot before awaiting -> no reload herd
-        try:
-            await _latest_cache["board"].refresh()
-            run_id, version = _latest_cache["board"].read_latest()
-            # Staleness floor is per-run (version restarts at 1 each run); on a run
-            # change adopt the new run's pointer immediately so the floor isn't
-            # pinned to a finished run's higher version number.
-            _latest_cache["run_id"] = run_id
-            _latest_cache["version"] = int(version)
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "gate: could not read latest published version; using cached %s",
-                _latest_cache["version"],
-                exc_info=True,
-            )
-    return _latest_cache["version"]
-
-
-async def gated_rollout_request_hook(args: Any, sample: Any, request: dict[str, Any]) -> None:
-    """miles ``custom_rollout_request_hook_path``: gate each rollout on
-    ``weight_version - k`` so unusable (too-stale) rollouts are never generated.
-
-    miles calls this as ``hook(args, sample, request)`` with
-    ``request = {"url", "payload", "headers", "max_retries", "retry_sleep"}`` and
-    expects it to mutate ``request`` in place. A request pinned to
-    ``min_required_version = latest - lag`` is admitted only by a replica within
-    ``lag`` versions of the newest weights; a lagging replica returns a retryable
-    409 (which also nudges it to sync forward). ``min`` mode (not ``exact``) lets
-    the request cross in_place commits without being quiesced.
-    """
-    mode = str(getattr(args, "rollout_request_weight_version_mode", "min"))
-    if mode != "none":
-        latest = await _latest_published(args)
-        lag = int(getattr(args, "rollout_request_weight_version_lag", 0))
-        target = max(0, latest - lag)
-        key = "exact_version" if mode == "exact" else "min_required_version"
-        request["payload"]["weight_version"] = {key: target}
-
-    request["max_retries"] = int(getattr(args, "rollout_request_retry_attempts", request.get("max_retries", 60)))
-    request["retry_sleep"] = float(getattr(args, "rollout_request_retry_sleep", request.get("retry_sleep", 1.0)))
-
-    session_id = getattr(sample, "session_id", None)
-    if session_id:
-        header = str(getattr(args, "rollout_session_affinity_header", "x-session-affinity"))
-        headers = dict(request.get("headers") or {})
-        headers.setdefault(header, session_id)
-        request["headers"] = headers
+# Re-export for the trainer's custom_rollout_request_hook_path.
+__all__ = ["commit_and_wake", "gated_rollout_request_hook"]

--- a/cookbook/miles_disagg/hooks.py
+++ b/cookbook/miles_disagg/hooks.py
@@ -9,10 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from cookbook.bulletin_hooks import (
-    CachedLatestPointer,
-    bulletin_root,
     commit_and_wake as _commit_and_wake,
-    distributed_rank,
     gated_rollout_request_hook,
 )
 

--- a/cookbook/ray_cluster.py
+++ b/cookbook/ray_cluster.py
@@ -1,0 +1,139 @@
+"""Ray cluster bring-up helpers for multi-node Modal training.
+
+Shared across cookbook trainers (slime, miles, etc.). Originally adapted from
+https://github.com/modal-projects/multinode-training-guide.
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+
+RAY_START_TIMEOUT = 240
+RAY_WORKER_JOIN_TIMEOUT = 180
+
+
+def training_nodes(cfg: Any) -> int:
+    nodes = int(getattr(cfg, "actor_num_nodes", 1))
+    if getattr(cfg, "use_critic", False) or getattr(cfg, "advantage_estimator", None) == "ppo":
+        nodes += int(getattr(cfg, "critic_num_nodes", nodes))
+    return nodes
+
+
+def get_modal_cluster_context(n_nodes: int) -> tuple[int, str, str]:
+    """Return (rank, master_addr, my_ip) for the current Modal cluster."""
+    import modal.experimental
+
+    try:
+        info = modal.experimental.get_cluster_info()
+    except Exception:  # noqa: BLE001
+        if n_nodes == 1:
+            ip = _get_local_ip()
+            return 0, ip, ip
+        raise
+    actual_nodes = len(info.container_ipv4_ips)
+    if actual_nodes == 0 and n_nodes == 1:
+        ip = _get_local_ip()
+        return 0, ip, ip
+    if actual_nodes != n_nodes:
+        raise RuntimeError(f"cluster size mismatch: expected {n_nodes} node(s), got {actual_nodes}")
+    return info.rank, info.container_ipv4_ips[0], info.container_ipv4_ips[info.rank]
+
+
+def _get_local_ip() -> str:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        try:
+            sock.connect(("8.8.8.8", 80))
+            return sock.getsockname()[0]
+        except OSError:
+            return socket.gethostbyname(socket.gethostname())
+
+
+def start_ray_head(my_ip: str, n_nodes: int, *, ray_port: int) -> None:
+    """Start the Ray head node and wait for all workers to join."""
+    import ray
+
+    start_cmd = [
+        "ray",
+        "start",
+        "--head",
+        f"--node-ip-address={my_ip}",
+        f"--port={ray_port}",
+        "--disable-usage-stats",
+        "--include-dashboard=false",
+    ]
+    try:
+        subprocess.run(start_cmd, check=True, timeout=RAY_START_TIMEOUT)
+    except subprocess.TimeoutExpired as exc:
+        _print_ray_logs()
+        raise RuntimeError(f"Ray head node did not finish startup within {RAY_START_TIMEOUT}s") from exc
+    except subprocess.CalledProcessError as exc:
+        _print_ray_logs()
+        raise RuntimeError(f"Ray head node failed to start with exit code {exc.returncode}") from exc
+
+    last_error = ""
+    for _ in range(RAY_START_TIMEOUT):
+        try:
+            ray.init(address=f"{my_ip}:{ray_port}")
+            break
+        except Exception as exc:  # noqa: BLE001
+            last_error = f"{type(exc).__name__}: {exc}"
+            time.sleep(1)
+    else:
+        _print_ray_logs()
+        raise RuntimeError(f"Ray head node failed to start before timeout: {last_error}")
+
+    for _ in range(RAY_WORKER_JOIN_TIMEOUT):
+        alive = [n for n in ray.nodes() if n["Alive"]]
+        print(f"Waiting for workers: {len(alive)}/{n_nodes} alive")
+        if len(alive) == n_nodes:
+            break
+        time.sleep(1)
+    else:
+        _print_ray_logs()
+        raise RuntimeError(f"Timed out waiting for all {n_nodes} Ray nodes to join")
+
+
+def start_ray_worker(my_ip: str, master_addr: str, *, ray_port: int) -> None:
+    """Join this container to the Ray cluster as a worker node."""
+    subprocess.run(
+        [
+            "ray",
+            "start",
+            f"--node-ip-address={my_ip}",
+            "--address",
+            f"{master_addr}:{ray_port}",
+            "--disable-usage-stats",
+        ],
+        check=True,
+        timeout=RAY_START_TIMEOUT,
+    )
+
+
+def _print_ray_logs() -> None:
+    log_dir = Path("/tmp/ray/session_latest/logs")
+    for name in (
+        "dashboard.log",
+        "dashboard.err",
+        "gcs_server.out",
+        "gcs_server.err",
+        "raylet.out",
+        "raylet.err",
+        "monitor.out",
+        "monitor.err",
+    ):
+        path = log_dir / name
+        if not path.exists():
+            continue
+        print(f"===== {path} =====")
+        try:
+            lines = path.read_text(errors="replace").splitlines()
+        except OSError as exc:
+            print(f"could not read {path}: {exc}")
+            continue
+        for line in lines[-80:]:
+            print(line)

--- a/cookbook/sidecar_process.py
+++ b/cookbook/sidecar_process.py
@@ -1,0 +1,87 @@
+"""Sidecar process launch + HTTP liveness helpers.
+
+Shared across cookbook trainers (slime, miles, etc.). The sidecar module path is
+parameterized so each trainer can wire its own sidecar entry point.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import time
+import urllib.error
+import urllib.request
+
+
+def start_sglang_sidecar(
+    *,
+    sidecar_module: str,
+    sidecar_port: int,
+    sglang_port: int,
+    bulletin_root: str,
+    local_checkpoint_dir: str,
+    base_checkpoint_dir: str,
+    volume_name: str,
+    commit_mode: str,
+    debug_requests: bool = False,
+) -> subprocess.Popen:
+    """Launch the weight-sync sidecar as a subprocess.
+
+    ``sidecar_module`` is the Python module path (e.g.
+    ``"cookbook.slime_disagg.sidecar"``).
+    """
+    cmd = [
+        "python3",
+        "-m",
+        sidecar_module,
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(sidecar_port),
+        "--upstream-url",
+        f"http://127.0.0.1:{sglang_port}",
+        "--bulletin-root",
+        bulletin_root,
+        "--local-checkpoint-dir",
+        local_checkpoint_dir,
+        "--base-checkpoint-dir",
+        base_checkpoint_dir,
+        "--volume-name",
+        volume_name,
+        "--commit-mode",
+        commit_mode,
+    ]
+    if debug_requests:
+        cmd.append("--debug-requests")
+    print("Starting sidecar:", " ".join(cmd))
+    return subprocess.Popen(cmd, start_new_session=True)
+
+
+def wait_http(url: str, process: subprocess.Popen | None, timeout: int) -> None:
+    deadline = time.time() + timeout
+    last_error: str | None = None
+    while time.time() < deadline:
+        if process is not None and process.poll() is not None:
+            raise RuntimeError(f"process exited while waiting for {url}: code={process.returncode}")
+        try:
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                if 200 <= resp.status < 500:
+                    return
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+        time.sleep(2)
+    raise TimeoutError(f"Timed out waiting for {url}; last error: {last_error}")
+
+
+def terminate_process(process: subprocess.Popen | None) -> None:
+    if process is None or process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=20)
+    except Exception:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except Exception:
+            pass

--- a/cookbook/slime_disagg/helpers.py
+++ b/cookbook/slime_disagg/helpers.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import subprocess
 import time
 import urllib.error
 import urllib.request
@@ -46,9 +47,7 @@ def start_sglang_sidecar(
     volume_name: str,
     commit_mode: str,
     debug_requests: bool = False,
-) -> "subprocess.Popen":
-    import subprocess
-
+) -> subprocess.Popen:
     from cookbook.sidecar_process import start_sglang_sidecar as _start
 
     return _start(

--- a/cookbook/slime_disagg/helpers.py
+++ b/cookbook/slime_disagg/helpers.py
@@ -1,7 +1,9 @@
-"""Ray cluster, sidecar process, and smoke-check helpers for the example.
+"""Trainer-specific helpers for the slime_disagg example.
 
-Ray helpers were originally adapted from
-https://github.com/modal-projects/multinode-training-guide.
+Ray cluster, sidecar, and process helpers are shared across trainers via
+:mod:`cookbook.ray_cluster` and :mod:`cookbook.sidecar_process`. This module
+provides slime-specific config preparation, train command building, and the
+Flash pool smoke check.
 """
 
 from __future__ import annotations
@@ -9,144 +11,57 @@ from __future__ import annotations
 import json
 import os
 import shlex
-import signal
-import socket
-import subprocess
 import time
 import urllib.error
 import urllib.request
-from pathlib import Path
 from typing import Any
 
 from stitch.providers.modal import discover_flash_targets, resolve_flash_gateway_url
 
-RAY_START_TIMEOUT = 240
-RAY_WORKER_JOIN_TIMEOUT = 180
+# Re-export shared helpers so existing callers (modal_train.py) don't break.
+from cookbook.ray_cluster import (  # noqa: F401
+    RAY_START_TIMEOUT,
+    RAY_WORKER_JOIN_TIMEOUT,
+    get_modal_cluster_context,
+    start_ray_head,
+    start_ray_worker,
+    training_nodes,
+)
+from cookbook.sidecar_process import (  # noqa: F401
+    terminate_process,
+    wait_http,
+)
 
 
-# ── Ray cluster ───────────────────────────────────────────────────────────────
+SIDECAR_MODULE = "cookbook.slime_disagg.sidecar"
 
 
-def training_nodes(cfg: Any) -> int:
-    nodes = int(getattr(cfg, "actor_num_nodes", 1))
-    if getattr(cfg, "use_critic", False) or getattr(cfg, "advantage_estimator", None) == "ppo":
-        nodes += int(getattr(cfg, "critic_num_nodes", nodes))
-    return nodes
+def start_sglang_sidecar(
+    *,
+    sidecar_port: int,
+    sglang_port: int,
+    bulletin_root: str,
+    local_checkpoint_dir: str,
+    base_checkpoint_dir: str,
+    volume_name: str,
+    commit_mode: str,
+    debug_requests: bool = False,
+) -> "subprocess.Popen":
+    import subprocess
 
+    from cookbook.sidecar_process import start_sglang_sidecar as _start
 
-def get_modal_cluster_context(n_nodes: int) -> tuple[int, str, str]:
-    """Return (rank, master_addr, my_ip) for the current Modal cluster."""
-    import modal.experimental
-
-    try:
-        info = modal.experimental.get_cluster_info()
-    except Exception:  # noqa: BLE001
-        if n_nodes == 1:
-            ip = _get_local_ip()
-            return 0, ip, ip
-        raise
-    actual_nodes = len(info.container_ipv4_ips)
-    if actual_nodes == 0 and n_nodes == 1:
-        ip = _get_local_ip()
-        return 0, ip, ip
-    if actual_nodes != n_nodes:
-        raise RuntimeError(f"cluster size mismatch: expected {n_nodes} node(s), got {actual_nodes}")
-    return info.rank, info.container_ipv4_ips[0], info.container_ipv4_ips[info.rank]
-
-
-def _get_local_ip() -> str:
-    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-        try:
-            sock.connect(("8.8.8.8", 80))
-            return sock.getsockname()[0]
-        except OSError:
-            return socket.gethostbyname(socket.gethostname())
-
-
-def start_ray_head(my_ip: str, n_nodes: int, *, ray_port: int) -> None:
-    """Start the Ray head node and wait for all workers to join."""
-    import ray
-
-    start_cmd = [
-        "ray",
-        "start",
-        "--head",
-        f"--node-ip-address={my_ip}",
-        f"--port={ray_port}",
-        "--disable-usage-stats",
-        "--include-dashboard=false",
-    ]
-    try:
-        subprocess.run(start_cmd, check=True, timeout=RAY_START_TIMEOUT)
-    except subprocess.TimeoutExpired as exc:
-        _print_ray_logs()
-        raise RuntimeError(f"Ray head node did not finish startup within {RAY_START_TIMEOUT}s") from exc
-    except subprocess.CalledProcessError as exc:
-        _print_ray_logs()
-        raise RuntimeError(f"Ray head node failed to start with exit code {exc.returncode}") from exc
-
-    last_error = ""
-    for _ in range(RAY_START_TIMEOUT):
-        try:
-            ray.init(address=f"{my_ip}:{ray_port}")
-            break
-        except Exception as exc:  # noqa: BLE001
-            last_error = f"{type(exc).__name__}: {exc}"
-            time.sleep(1)
-    else:
-        _print_ray_logs()
-        raise RuntimeError(f"Ray head node failed to start before timeout: {last_error}")
-
-    for _ in range(RAY_WORKER_JOIN_TIMEOUT):
-        alive = [n for n in ray.nodes() if n["Alive"]]
-        print(f"Waiting for workers: {len(alive)}/{n_nodes} alive")
-        if len(alive) == n_nodes:
-            break
-        time.sleep(1)
-    else:
-        _print_ray_logs()
-        raise RuntimeError(f"Timed out waiting for all {n_nodes} Ray nodes to join")
-
-
-def start_ray_worker(my_ip: str, master_addr: str, *, ray_port: int) -> None:
-    """Join this container to the Ray cluster as a worker node."""
-    subprocess.run(
-        [
-            "ray",
-            "start",
-            f"--node-ip-address={my_ip}",
-            "--address",
-            f"{master_addr}:{ray_port}",
-            "--disable-usage-stats",
-        ],
-        check=True,
-        timeout=RAY_START_TIMEOUT,
+    return _start(
+        sidecar_module=SIDECAR_MODULE,
+        sidecar_port=sidecar_port,
+        sglang_port=sglang_port,
+        bulletin_root=bulletin_root,
+        local_checkpoint_dir=local_checkpoint_dir,
+        base_checkpoint_dir=base_checkpoint_dir,
+        volume_name=volume_name,
+        commit_mode=commit_mode,
+        debug_requests=debug_requests,
     )
-
-
-def _print_ray_logs() -> None:
-    log_dir = Path("/tmp/ray/session_latest/logs")
-    for name in (
-        "dashboard.log",
-        "dashboard.err",
-        "gcs_server.out",
-        "gcs_server.err",
-        "raylet.out",
-        "raylet.err",
-        "monitor.out",
-        "monitor.err",
-    ):
-        path = log_dir / name
-        if not path.exists():
-            continue
-        print(f"===== {path} =====")
-        try:
-            lines = path.read_text(errors="replace").splitlines()
-        except OSError as exc:
-            print(f"could not read {path}: {exc}")
-            continue
-        for line in lines[-80:]:
-            print(line)
 
 
 # ── SLIME launch ──────────────────────────────────────────────────────────────
@@ -181,76 +96,6 @@ def build_train_cmd(slime_cfg: Any, slime_root: str) -> str:
         )
         return f"bash -c {shlex.quote(inner)}"
     return f"python3 {train_script} {shlex.join(slime_cfg.cli_args())}"
-
-
-# ── Sidecar process ───────────────────────────────────────────────────────────
-
-
-def start_sglang_sidecar(
-    *,
-    sidecar_port: int,
-    sglang_port: int,
-    bulletin_root: str,
-    local_checkpoint_dir: str,
-    base_checkpoint_dir: str,
-    volume_name: str,
-    commit_mode: str,
-    debug_requests: bool = False,
-) -> subprocess.Popen:
-    cmd = [
-        "python3",
-        "-m",
-        "cookbook.slime_disagg.sidecar",
-        "--host",
-        "0.0.0.0",
-        "--port",
-        str(sidecar_port),
-        "--upstream-url",
-        f"http://127.0.0.1:{sglang_port}",
-        "--bulletin-root",
-        bulletin_root,
-        "--local-checkpoint-dir",
-        local_checkpoint_dir,
-        "--base-checkpoint-dir",
-        base_checkpoint_dir,
-        "--volume-name",
-        volume_name,
-        "--commit-mode",
-        commit_mode,
-    ]
-    if debug_requests:
-        cmd.append("--debug-requests")
-    print("Starting sidecar:", " ".join(cmd))
-    return subprocess.Popen(cmd, start_new_session=True)
-
-
-def wait_http(url: str, process: subprocess.Popen | None, timeout: int) -> None:
-    deadline = time.time() + timeout
-    last_error: str | None = None
-    while time.time() < deadline:
-        if process is not None and process.poll() is not None:
-            raise RuntimeError(f"process exited while waiting for {url}: code={process.returncode}")
-        try:
-            with urllib.request.urlopen(url, timeout=5) as resp:
-                if 200 <= resp.status < 500:
-                    return
-        except (urllib.error.URLError, TimeoutError, OSError) as exc:
-            last_error = f"{type(exc).__name__}: {exc}"
-        time.sleep(2)
-    raise TimeoutError(f"Timed out waiting for {url}; last error: {last_error}")
-
-
-def terminate_process(process: subprocess.Popen | None) -> None:
-    if process is None or process.poll() is not None:
-        return
-    try:
-        os.killpg(process.pid, signal.SIGTERM)
-        process.wait(timeout=20)
-    except Exception:
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except Exception:
-            pass
 
 
 # ── Flash pool smoke check ────────────────────────────────────────────────────
@@ -334,4 +179,3 @@ def _post_json(url: str, payload: dict, *, timeout: float) -> dict:
     )
     with urllib.request.urlopen(request, timeout=timeout) as resp:
         return json.load(resp)
-

--- a/cookbook/slime_disagg/hooks.py
+++ b/cookbook/slime_disagg/hooks.py
@@ -9,10 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 from cookbook.bulletin_hooks import (
-    CachedLatestPointer,
-    bulletin_root,
     commit_and_wake as _commit_and_wake,
-    distributed_rank,
     gated_rollout_request_hook,
 )
 

--- a/cookbook/slime_disagg/hooks.py
+++ b/cookbook/slime_disagg/hooks.py
@@ -1,175 +1,32 @@
-"""Modal publish hook for the slime_disagg bulletin-board example.
+"""Modal publish + rollout-gating hooks for the slime_disagg example.
 
-The canonical path: slime publish-only writes ``weight_v{N}/`` + a ``latest``
-pointer straight to the Modal Volume bulletin board (rename works on a Volume),
-and the elastic Flash pool of SGLang servers + stitch sidecars self-syncs from
-it. This hook only layers on the Modal-specific concerns — Volume durability and
-a best-effort rollout-pool wake. None of the standalone hot-load shim machinery
-(front door, HTTP ``/hot_load``, auth headers, S3-copy) belongs here.
+Thin wrappers around :mod:`cookbook.bulletin_hooks` with the slime-specific
+env-var fallbacks for the Flash app / server class name.
 """
 
 from __future__ import annotations
 
-import logging
-import os
-import time
-from pathlib import Path
 from typing import Any
 
-from stitch.bulletin import FilesystemBulletinBoard
-from stitch.protocol import parse_weight_identity
-from stitch.providers.modal import commit_volume, discover_flash_targets, volume_reloader, wake_targets
-
-
-logger = logging.getLogger(__name__)
+from cookbook.bulletin_hooks import (
+    CachedLatestPointer,
+    bulletin_root,
+    commit_and_wake as _commit_and_wake,
+    distributed_rank,
+    gated_rollout_request_hook,
+)
 
 
 def commit_and_wake(args: Any, version_dir: str, rollout_engines: list[Any]) -> None:
-    """SLIME ``custom_delta_pre_push_path`` hook (publish-only, bulletin board).
-
-    slime has written ``weight_v{N}/`` to the Modal Volume. Advance the committed
-    ``latest`` pointer, commit the Volume so the rollout pool's ``reload`` sees
-    the new version, then best-effort wake the Flash pool. The sidecars self-sync
-    (wake RPC, periodic poll, startup), so a missed wake only costs latency.
-    """
-    del rollout_engines
-    version = parse_weight_identity(Path(version_dir).name)
-    rank = _distributed_rank()
-
-    # Rank 0 owns the `latest` pointer and writes it before committing, so the
-    # committed bulletin is self-consistent for the poll/startup path (slime's own
-    # latest write is post-hook and uncommitted). Every rank commits its shards.
-    # The pointer lives at the transport root (the Volume mount) and is
-    # self-identifying — `<run_id>/weight_vN` — while slime wrote the version dir
-    # under the run partition (update_weight_disk_dir = <root>/<run_id>), so a new
-    # run is a forward move of the pointer, never a colliding rewind.
-    if version is not None and rank in (None, 0):
-        FilesystemBulletinBoard(_transport_root(args), layout="slime").write_latest(
-            _run_id(args), version
-        )
-    commit_volume(_volume_name(args))
-
-    if version is None or rank not in (None, 0):
-        # version is None on the baseline call (disk-dir root); only rank 0 wakes.
-        return
-    # Waking warm containers is a best-effort latency optimization: a transient
-    # Modal control-plane error must not kill the training step — `latest` is
-    # already committed and sidecars self-sync on their next poll.
-    try:
-        app_name = getattr(args, "rollout_modal_flash_app_name", None) or os.environ["SLIME_DELTA_APP_NAME"]
-        cls_name = getattr(args, "rollout_modal_flash_server_cls_name", None) or os.getenv(
-            "SLIME_DELTA_SERVER_CLS_NAME", "Server"
-        )
-        wake_targets(discover_flash_targets(app_name=app_name, cls_name=cls_name), version)
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "Best-effort rollout wake failed for version %s; sidecars will self-sync",
-            version,
-            exc_info=True,
-        )
-
-
-def _distributed_rank() -> int | None:
-    try:
-        import torch.distributed as dist
-
-        if dist.is_available() and dist.is_initialized():
-            return int(dist.get_rank())
-    except Exception:  # noqa: BLE001
-        return None
-    return None
-
-
-def _volume_name(args: Any) -> str:
-    return str(getattr(args, "update_weight_delta_volume_name", None) or os.environ["DELTA_VOLUME_NAME"])
-
-
-def _bulletin_root(args: Any) -> str:
-    """Where slime writes version dirs: ``<transport_root>/<run_id>``."""
-    return str(
-        getattr(args, "update_weight_disk_dir", None)
-        or os.environ.get("DELTA_BULLETIN_ROOT", "/delta-bulletin")
+    """SLIME ``custom_delta_pre_push_path`` hook (publish-only, bulletin board)."""
+    _commit_and_wake(
+        args,
+        version_dir,
+        rollout_engines,
+        app_name_env="SLIME_DELTA_APP_NAME",
+        cls_name_env="SLIME_DELTA_SERVER_CLS_NAME",
     )
 
 
-def _transport_root(args: Any) -> str:
-    """The Volume mount root that holds the canonical ``latest`` pointer and that
-    the sidecar boards are rooted at — the parent of the per-run write dir."""
-    return str(Path(_bulletin_root(args)).parent)
-
-
-def _run_id(args: Any) -> str:
-    """The run partition (chain identity). Passed explicitly via custom_config,
-    falling back to the basename of the per-run write dir."""
-    return str(getattr(args, "run_id", None) or Path(_bulletin_root(args)).name)
-
-
-# ── M3: staleness-gated rollout requests ──────────────────────────────────────
-
-# Cache of the latest published version for the gate. The per-request hook gets no
-# rollout_id, so the staleness floor is derived out-of-band from the published
-# `latest` pointer (the publish hook already advanced + committed it). TTL-cached
-# with a Volume reload so a (possibly cross-node) rollout actor sees rank-0's
-# committed pointer without a Volume reload per request.
-_latest_cache: dict[str, Any] = {"version": 0, "run_id": None, "at": -1e9, "board": None}
-
-
-def _gate_board(args: Any) -> FilesystemBulletinBoard:
-    vol = getattr(args, "update_weight_delta_volume_name", None) or os.environ.get("DELTA_VOLUME_NAME")
-    refresh = volume_reloader(vol) if vol else None
-    # The pointer lives at the transport root (the mount), not the per-run write dir.
-    return FilesystemBulletinBoard(_transport_root(args), refresh=refresh, layout="slime")
-
-
-async def _latest_published(args: Any, ttl: float = 2.0) -> int:
-    now = time.monotonic()
-    if _latest_cache["board"] is None:
-        _latest_cache["board"] = _gate_board(args)
-    if now - _latest_cache["at"] >= ttl:
-        _latest_cache["at"] = now  # claim the refresh slot before awaiting -> no reload herd
-        try:
-            await _latest_cache["board"].refresh()
-            run_id, version = _latest_cache["board"].read_latest()
-            # Staleness floor is per-run (version restarts at 1 each run); on a run
-            # change adopt the new run's pointer immediately so the floor isn't
-            # pinned to a finished run's higher version number.
-            _latest_cache["run_id"] = run_id
-            _latest_cache["version"] = int(version)
-        except Exception:  # noqa: BLE001
-            logger.warning(
-                "gate: could not read latest published version; using cached %s",
-                _latest_cache["version"],
-                exc_info=True,
-            )
-    return _latest_cache["version"]
-
-
-async def gated_rollout_request_hook(args: Any, sample: Any, request: dict[str, Any]) -> None:
-    """SLIME ``custom_rollout_request_hook_path`` (M3): gate each rollout on
-    ``weight_version - k`` so unusable (too-stale) rollouts are never generated.
-
-    The per-request hook receives no rollout_id, so the staleness floor is derived
-    out-of-band from the published ``latest`` pointer (see ``_latest_published``).
-    A request pinned to ``min_required_version = latest - lag`` is admitted only by
-    a replica within ``lag`` versions of the newest weights; a lagging replica
-    returns a retryable 409 (which also nudges it to sync forward), so the trainer
-    never spends rollout compute on weights staler than its bound. ``min`` mode
-    (not ``exact``) lets the request cross in_place commits without being quiesced.
-    """
-    mode = str(getattr(args, "rollout_request_weight_version_mode", "min"))
-    if mode != "none":
-        latest = await _latest_published(args)
-        lag = int(getattr(args, "rollout_request_weight_version_lag", 0))
-        target = max(0, latest - lag)
-        key = "exact_version" if mode == "exact" else "min_required_version"
-        request["payload"]["weight_version"] = {key: target}
-
-    request["max_retries"] = int(getattr(args, "rollout_request_retry_attempts", request.get("max_retries", 60)))
-    request["retry_sleep"] = float(getattr(args, "rollout_request_retry_sleep", request.get("retry_sleep", 1.0)))
-
-    session_id = getattr(sample, "session_id", None)
-    if session_id:
-        header = str(getattr(args, "rollout_session_affinity_header", "x-session-affinity"))
-        headers = dict(request.get("headers") or {})
-        headers.setdefault(header, session_id)
-        request["headers"] = headers
+# Re-export for the trainer's custom_rollout_request_hook_path.
+__all__ = ["commit_and_wake", "gated_rollout_request_hook"]

--- a/cookbook/slime_disagg/hooks_test.py
+++ b/cookbook/slime_disagg/hooks_test.py
@@ -8,6 +8,7 @@ from argparse import Namespace
 from pathlib import Path
 from unittest import mock
 
+import cookbook.bulletin_hooks as bulletin_hooks
 from cookbook.slime_disagg import hooks
 
 
@@ -26,10 +27,10 @@ class CommitAndWakeTest(unittest.TestCase):
             )
 
             with mock.patch.dict(os.environ, {"DELTA_VOLUME_NAME": "delta-volume"}), mock.patch.object(
-                hooks, "_distributed_rank", return_value=0
-            ), mock.patch.object(hooks, "commit_volume") as commit_volume, mock.patch.object(
-                hooks, "discover_flash_targets", return_value=["https://c"]
-            ), mock.patch.object(hooks, "wake_targets") as wake_targets:
+                bulletin_hooks, "distributed_rank", return_value=0
+            ), mock.patch.object(bulletin_hooks, "commit_volume") as commit_volume, mock.patch.object(
+                bulletin_hooks, "discover_flash_targets", return_value=["https://c"]
+            ), mock.patch.object(bulletin_hooks, "wake_targets") as wake_targets:
                 hooks.commit_and_wake(args, str(version_dir), [])
 
             # The canonical pointer lives at the transport root and is self-identifying.
@@ -45,9 +46,9 @@ class CommitAndWakeTest(unittest.TestCase):
             # The baseline call passes the disk-dir root, not a weight_v{N} dir.
             args = Namespace(update_weight_disk_dir=str(disk_dir), run_id="run-a")
             with mock.patch.dict(os.environ, {"DELTA_VOLUME_NAME": "delta-volume"}), mock.patch.object(
-                hooks, "_distributed_rank", return_value=0
-            ), mock.patch.object(hooks, "commit_volume") as commit_volume, mock.patch.object(
-                hooks, "wake_targets"
+                bulletin_hooks, "distributed_rank", return_value=0
+            ), mock.patch.object(bulletin_hooks, "commit_volume") as commit_volume, mock.patch.object(
+                bulletin_hooks, "wake_targets"
             ) as wake_targets:
                 hooks.commit_and_wake(args, str(disk_dir), [])
 
@@ -62,9 +63,9 @@ class CommitAndWakeTest(unittest.TestCase):
             (disk_dir / "weight_v000002").mkdir(parents=True)
             args = Namespace(update_weight_disk_dir=str(disk_dir), run_id="run-a")
             with mock.patch.dict(os.environ, {"DELTA_VOLUME_NAME": "delta-volume"}), mock.patch.object(
-                hooks, "_distributed_rank", return_value=3
-            ), mock.patch.object(hooks, "commit_volume") as commit_volume, mock.patch.object(
-                hooks, "wake_targets"
+                bulletin_hooks, "distributed_rank", return_value=3
+            ), mock.patch.object(bulletin_hooks, "commit_volume") as commit_volume, mock.patch.object(
+                bulletin_hooks, "wake_targets"
             ) as wake_targets:
                 hooks.commit_and_wake(args, str(disk_dir / "weight_v000002"), [])
 
@@ -84,11 +85,16 @@ class GateTest(unittest.TestCase):
                 # the staleness gate cares only about the version within the run.
                 (root / "latest").write_text("run-a/weight_v000005", encoding="utf-8")
                 args = Namespace(update_weight_disk_dir=str(disk_dir), run_id="run-a")
-                hooks._latest_cache.update({"version": 0, "run_id": None, "at": -1e9, "board": None})
+                # Reset the module-level cache before each test.
+                cache = bulletin_hooks._latest_cache
+                cache.version = 0
+                cache.run_id = None
+                cache._refreshed_at = -1e9
+                cache._board = None
                 with mock.patch.dict(os.environ, {}, clear=True):
-                    version = await hooks._latest_published(args)
+                    version = await cache.get(args)
                 self.assertEqual(version, 5)
-                self.assertEqual(hooks._latest_cache["run_id"], "run-a")
+                self.assertEqual(cache.run_id, "run-a")
 
         asyncio.run(run())
 

--- a/src/stitch/__init__.py
+++ b/src/stitch/__init__.py
@@ -2,6 +2,7 @@
 
 from stitch.protocol import (
     Artifact,
+    EngineAdapter,
     RolloutPoolState,
     RolloutReplicaState,
     SyncState,
@@ -14,6 +15,7 @@ from stitch.protocol import (
 
 __all__ = [
     "Artifact",
+    "EngineAdapter",
     "RolloutPoolState",
     "RolloutReplicaState",
     "SyncState",

--- a/src/stitch/protocol.py
+++ b/src/stitch/protocol.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 
 PROTOCOL_VERSION = 1
@@ -516,3 +516,37 @@ def _bool(value: Any) -> bool:
     if isinstance(value, str):
         return value.lower() in {"1", "true", "yes"}
     return bool(value)
+
+
+@runtime_checkable
+class EngineAdapter(Protocol):
+    """Contract for rollout engine adapters driven by :class:`WeightSyncManager`.
+
+    An adapter bridges the sync manager to one inference engine instance.
+    Required methods are called during every version commit; optional methods
+    (``prepare``, ``reset``) are probed with ``getattr`` at startup and on run
+    switches, so adapters may omit them.
+
+    See :class:`stitch.engines.sglang.SGLangDiskDeltaAdapter` for the canonical
+    implementation.
+    """
+
+    backend: str
+
+    async def flush_cache(self) -> None:
+        """Evict all cached state (KV, radix tree). Called before ``apply_manifest``
+        in quiesce mode; skipped in in_place mode."""
+        ...
+
+    async def apply_manifest(self, manifest: VersionManifest, version_path: str) -> None:
+        """Apply one published weight version to the engine."""
+        ...
+
+    async def pause_generation(self) -> None:
+        """Pause the engine's scheduler in place. Required for ``commit_mode="in_place"``;
+        in-flight requests stay resident and resume after ``continue_generation``."""
+        ...
+
+    async def continue_generation(self) -> None:
+        """Resume the engine's scheduler after a pause."""
+        ...

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, Protocol
 
 from stitch.bulletin import BulletinBoard
 from stitch.protocol import (
+    EngineAdapter,
     SyncState,
     VersionManifest,
     WeightVersionPolicy,
@@ -28,24 +29,6 @@ class PolicyViolation(Exception):
     def __init__(self, error: Mapping[str, Any]) -> None:
         super().__init__(error["error"]["message"])
         self.error = error
-
-
-class EngineAdapter(Protocol):
-    backend: str
-
-    async def flush_cache(self) -> None: ...
-
-    async def apply_manifest(self, manifest: VersionManifest, version_path: str) -> None: ...
-
-    # Required only for commit_mode="in_place".
-    async def pause_generation(self) -> None: ...
-
-    async def continue_generation(self) -> None: ...
-
-    # Optional: one-time engine preparation run before the first sync (e.g.
-    # materializing the host-local base checkpoint deltas are applied onto).
-    # startup_sync probes for it defensively, so adapters may omit it.
-    async def prepare(self) -> None: ...
 
 
 class RolloutSyncManager(Protocol):


### PR DESCRIPTION
## Summary

The slime_disagg and miles_disagg cookbook examples were ~95% copy-pasted across hooks (~180 lines each) and helpers (~340-380 lines each). Bug fixes in one had to be manually ported, and they were already silently diverging. Three changes:

**1. `cookbook/bulletin_hooks.py`** — shared publish + gate hooks

```python
# Before: two identical 180-line modules differing only in env-var name
# cookbook/slime_disagg/hooks.py:  os.environ["SLIME_DELTA_APP_NAME"]
# cookbook/miles_disagg/hooks.py:  os.environ["MILES_DELTA_APP_NAME"]

# After: shared implementation parameterized on env-var names
def commit_and_wake(args, version_dir, rollout_engines, *, app_name_env, cls_name_env): ...
async def gated_rollout_request_hook(args, sample, request): ...

# Each trainer's hooks.py becomes a thin wrapper:
def commit_and_wake(args, version_dir, rollout_engines):
    _commit_and_wake(args, version_dir, rollout_engines,
                     app_name_env="SLIME_DELTA_APP_NAME", cls_name_env="SLIME_DELTA_SERVER_CLS_NAME")
```

Also replaces the module-level `_latest_cache: dict[str, Any]` with a typed `CachedLatestPointer` class.

**2. `cookbook/ray_cluster.py` + `cookbook/sidecar_process.py`** — shared deployment scaffolding

Extracts the identical Ray cluster helpers (`start_ray_head`, `start_ray_worker`, `get_modal_cluster_context`, `training_nodes`) and sidecar process management (`start_sglang_sidecar` parameterized on `sidecar_module`, `wait_http`, `terminate_process`). Each trainer's `helpers.py` re-exports these so `modal_train.py` callers need no import changes.

**3. `EngineAdapter` Protocol → `protocol.py`**

Moves `EngineAdapter(Protocol)` from `sync.py` to `protocol.py` where all protocol definitions live, adds docstrings to each method documenting the commit-sequence contract, marks `@runtime_checkable`, and exports from `stitch.__init__`. The optional `prepare`/`reset` methods are no longer listed in the Protocol (they're probed with `getattr` at runtime).

Link to Devin session: https://modal.devinenterprise.com/sessions/5e5183d5a4ef4f638ed9755f37d2a386
Requested by: @jvmncs