### PR TITLE
docs: remove overlap-drain-fix references from in_place commit mode

### DIFF
--- a/cookbook/slime_disagg/README.md
+++ b/cookbook/slime_disagg/README.md
@@ -100,4 +100,4 @@ Bounding the per-run replay with periodic recovery anchors is left for later.
 Sidecars default to `quiesce` commit mode, which drains in-flight requests
 before applying a delta. The `in_place` mode (set `SIDECAR_COMMIT_MODE` in
 the config module) applies without draining and relies on version-namespaced
-KV keys. It needs an SGLang build with the overlap-drain fix.
+KV keys.

--- a/cookbook/slime_disagg/configs/moonlight_disagg.py
+++ b/cookbook/slime_disagg/configs/moonlight_disagg.py
@@ -38,9 +38,7 @@ DELTA_BULLETIN_ROOT = "/delta-bulletin"
 # M3: in_place commit applies weights without draining in-flight rollouts. Stale
 # KV is isolated per weight version by the sidecar's extra_key stamping (so old
 # requests keep decoding on their version's KV and it drains as they finish);
-# min-version pins cross commits freely, only exact pins are quiesced. (The
-# overlap-drain race the docs warned about is a tiny, un-reproduced window in the
-# overlap-spec path, so we don't gate on the patched build.)
+# min-version pins cross commits freely, only exact pins are quiesced.
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_DEBUG_REQUESTS = True
 

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
@@ -13,8 +13,7 @@ DELTA_BULLETIN_ROOT = "/delta-bulletin"
 # the engine, applies, and resumes — in-flight requests keep decoding on stale
 # KV and cross-version isolation comes from extra_key stamping, so commits stop
 # blocking behind over-generation/eval stragglers and skip the full-tree flush.
-# It relies on the targeted SGLang build's overlap-drain fix. "quiesce" is the
-# safe fallback that drains in-flight requests before applying.
+# "quiesce" is the safe fallback that drains in-flight requests before applying.
 SIDECAR_COMMIT_MODE = "in_place"
 
 # Log every versioned sidecar proxy request (start/end + injected rid) at INFO,

--- a/cookbook/slime_disagg/sidecar.py
+++ b/cookbook/slime_disagg/sidecar.py
@@ -81,9 +81,8 @@ def main() -> None:
         help=(
             "in_place (default): pause/apply/continue without flushing; "
             "in-flight requests keep decoding on stale KV and version isolation "
-            "comes from extra_key stamping. Relies on the engine's overlap-drain "
-            "fix. quiesce: wait out active requests and flush before applying "
-            "(safe on any build)."
+            "comes from extra_key stamping. quiesce: wait out active requests "
+            "and flush before applying."
         ),
     )
     parser.add_argument(

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -204,10 +204,8 @@ class WeightSyncManager(RolloutAdmissionGate):
     - ``in_place``: pause the engine in place, apply without flushing, and
       continue — in-flight requests resume decoding on their existing KV.
       Cross-version KV isolation comes from the sidecar stamping a composed,
-      version-namespaced ``extra_key`` onto every proxied request. Requires
-      an engine build with the overlap-drain fix; without it a forward in
-      flight at pause time can race the weight mutation. Only exact-version
-      requests are quiesced/gated.
+      version-namespaced ``extra_key`` onto every proxied request. Only
+      exact-version requests are quiesced/gated.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary
Removes all mention of the SGLang "overlap-drain fix" across docs/comments. The race it warned about was never reproduced and may have been theoretical, so claiming `in_place` commit mode requires a special patched SGLang build is misleading.

Comment/docstring-only change — no logic touched. The legitimate `drain` semantics of `quiesce` mode (and exact-pin draining) are left intact; only the "needs a build with the overlap-drain fix" / "overlap-drain race" claims are stripped.

Touched:
- `src/stitch/sync.py` — `WeightSyncManager` commit-mode docstring: drop "Requires an engine build with the overlap-drain fix; without it a forward in flight at pause time can race the weight mutation."
- `cookbook/slime_disagg/sidecar.py` — `--commit-mode` help text: drop "Relies on the engine's overlap-drain fix."
- `cookbook/slime_disagg/README.md` — drop "It needs an SGLang build with the overlap-drain fix."
- `cookbook/slime_disagg/configs/moonlight_disagg.py` — drop the parenthetical about the "un-reproduced window in the overlap-spec path".
- `cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py` — drop "It relies on the targeted SGLang build's overlap-drain fix."

Link to Devin session: https://modal.devinenterprise.com/sessions/19f9d9f0f77046cbbabead025e76ad71
Requested by: @jvmncs