### PR TITLE
perf(sync): compose multi-version catch-up into one engine reload

### DIFF
--- a/src/stitch/protocol.py
+++ b/src/stitch/protocol.py
@@ -539,7 +539,15 @@ class EngineAdapter(Protocol):
         ...
 
     async def apply_manifest(self, manifest: VersionManifest, version_path: str) -> None:
-        """Apply one published weight version to the engine."""
+        """Bring the engine to ``manifest.version``, replaying every intermediate
+        version from the currently applied one up to the target.
+
+        The sync manager composes a multi-version catch-up into a single call
+        (it verifies chain contiguity, then invokes this once for the whole
+        tail), so an adapter MUST advance across all skipped versions, not just
+        apply ``manifest`` as a single delta off the previous one. The canonical
+        adapter satisfies this because slime's ``apply_deltas`` chain-replays
+        from the applied version to ``manifest.version``."""
         ...
 
     async def pause_generation(self) -> None:

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -353,34 +353,47 @@ class WeightSyncManager(RolloutAdmissionGate):
 
             self.sync_state = SyncState.PREFETCHING
             self.last_sync_error = None
+
+            # Verify the whole tail is a contiguous chain before touching the
+            # engine, so a broken chain fails before any pause/apply. apply_deltas
+            # re-verifies each step's base_version internally as it replays.
+            expected_base = self.current_version
+            target_manifest: VersionManifest | None = None
             for version in range(self.current_version + 1, latest + 1):
                 manifest = self.board.read_manifest(self.current_run_id, version)
-                if manifest.base_version != self.current_version:
+                if manifest.base_version != expected_base:
                     raise RuntimeError(
                         f"cannot apply version {version}: manifest base "
-                        f"{manifest.base_version} != current {self.current_version}"
+                        f"{manifest.base_version} != expected {expected_base}"
                     )
-                version_path = str(self.board.version_dir(self.current_run_id, version))
-                self.sync_state = SyncState.PREPARING
+                expected_base = version
+                target_manifest = manifest
+            assert target_manifest is not None  # latest > current_version, so the loop ran
+            target_path = str(self.board.version_dir(self.current_run_id, latest))
 
-                async def apply(manifest: VersionManifest = manifest, version_path: str = version_path) -> None:
-                    # quiesce flushes before applying; in_place skips the flush
-                    # (the gate paused the engine and stale KV resumes as-is).
-                    if self.commit_mode != "in_place":
-                        await self.engine.flush_cache()
-                    self.sync_state = SyncState.COMMITTING
-                    await self.engine.apply_manifest(manifest, version_path)
+            # Compose the tail and reload once: apply_manifest(target) replays
+            # every delta from the applied version up to `latest` host-side, then
+            # does a single engine reload — not one reload per intermediate version.
+            self.sync_state = SyncState.PREPARING
 
-                # on_applied bumps current_version under the gate (before
-                # continue_generation in in_place mode), so a request can never
-                # be admitted observing the stale version on mutated weights.
-                await self.commit_version(
-                    apply=apply,
-                    on_applied=lambda version=version: setattr(self, "current_version", version),
-                    pause=self.engine.pause_generation,
-                    resume=self.engine.continue_generation,
-                )
-                self.sync_state = SyncState.PREFETCHING
+            async def apply(manifest: VersionManifest = target_manifest, version_path: str = target_path) -> None:
+                # quiesce flushes before applying; in_place skips the flush
+                # (the gate paused the engine and stale KV resumes as-is).
+                if self.commit_mode != "in_place":
+                    await self.engine.flush_cache()
+                self.sync_state = SyncState.COMMITTING
+                await self.engine.apply_manifest(manifest, version_path)
+
+            # on_applied bumps current_version under the gate (before
+            # continue_generation in in_place mode), so a request can never be
+            # admitted observing the stale version on mutated weights.
+            await self.commit_version(
+                apply=apply,
+                on_applied=lambda: setattr(self, "current_version", latest),
+                pause=self.engine.pause_generation,
+                resume=self.engine.continue_generation,
+            )
+            self.sync_state = SyncState.PREFETCHING
 
             # Reached the board's latest for this run as captured at pass start; a
             # version published mid-pass is picked up by the next reconcile tick.

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -65,7 +65,7 @@ class FakeEngine:
 
 
 class SyncManagerTest(unittest.TestCase):
-    def test_startup_sync_applies_transition_chain(self) -> None:
+    def test_startup_sync_composes_tail_into_one_apply(self) -> None:
         async def run() -> None:
             with tempfile.TemporaryDirectory() as tmp:
                 board = FilesystemBulletinBoard(tmp)
@@ -78,7 +78,10 @@ class SyncManagerTest(unittest.TestCase):
 
                 self.assertEqual(manager.current_version, 2)
                 self.assertEqual(manager.sync_state, SyncState.IDLE)
-                self.assertEqual([v for v, _ in engine.applies], [1, 2])
+                # A multi-version catch-up composes the tail host-side and reloads
+                # once: a single apply at the target version, not one per version.
+                self.assertEqual([v for v, _ in engine.applies], [2])
+                self.assertEqual(engine.flushes, 1)
 
         asyncio.run(run())
 
@@ -96,7 +99,8 @@ class SyncManagerTest(unittest.TestCase):
                 await manager.startup_sync()
                 self.assertEqual(manager.current_run_id, "run-a")
                 self.assertEqual(manager.current_version, 2)
-                self.assertEqual([v for v, _ in engine.applies], [1, 2])
+                # The two-version tail is composed into one apply at the target.
+                self.assertEqual([v for v, _ in engine.applies], [2])
 
                 # A new run forks at base with its version space restarting at 1.
                 _write_slime_version(root / "run-b", 1, 0)


### PR DESCRIPTION
## Summary

On a multi-version catch-up, `WeightSyncManager._sync_once` looped version-by-version and ran a **full** `commit_version` + `engine.apply_manifest` **per intermediate version** — i.e. N pauses and N full `update_weights_from_disk` reloads to get from version `k` to `k+N`. But the host-side apply (`apply_deltas`) already chain-replays the entire tail in a single call, so the loop was only multiplying the expensive part: the engine reload. Engine reload scales with the *number of versions*, and this made it the dominant cost on every deep catch-up (and the per-version pause bounds async throughput in `in_place` mode).

This collapses the loop into a single composed commit:

```python
# before: one commit + one full reload PER version
for version in range(current+1, latest+1):
    manifest = read_manifest(version)
    assert manifest.base_version == current
    commit_version(apply=apply_manifest(manifest, v_path), on_applied=current:=version)

# after: verify the whole chain up front, then ONE commit at the target
expected_base = current
for version in range(current+1, latest+1):       # cheap manifest reads only
    manifest = read_manifest(version)
    assert manifest.base_version == expected_base # contiguity, pre-pause
    expected_base = version
commit_version(
    apply=apply_manifest(target_manifest, target_path),  # apply_deltas replays the whole tail
    on_applied=current:=latest,
)
```

Net: **one pause, one host-apply, one engine reload regardless of tail depth**, instead of N of each. No protocol/format change; correctness is preserved because:
- the contiguity check is done in a pre-pass (a broken chain still raises *before* any pause/apply), and `apply_deltas` re-verifies each step's `base_version` internally as it replays;
- `current_version` advances straight to `latest` under the commit gate (before `continue_generation` in `in_place` mode), so a request can never be admitted observing a stale version on mutated weights.

The single-version path (the common steady-state case) is unchanged in behavior — the loop simply runs once.

This is Step 1 of the engine-reload sub-plan (the pure-stitch, zero-SGLang-change piece). Step 2 (reload only the *changed* tensors) and Step 3 (instrumentation) build on this.

## Test changes

`sync_test.py` had two tests asserting the old per-version behavior (`engine.applies == [1, 2]`). Updated to assert the intended composed behavior: a single apply at the target version (`== [2]`) plus a single `flush` (`engine.flushes == 1`), proving the tail is composed into one commit. All 45 tests pass.


Link to Devin session: https://modal.devinenterprise.com/sessions/19f9d9f0f77046cbbabead025e76ad71
Requested by: @jvmncs
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/stitch/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->