### PR TITLE
Consolidate cookbook trainers onto a shared sidecar/serving/launch spine

### DIFF
--- a/cookbook/bulletin_hooks.py
+++ b/cookbook/bulletin_hooks.py
@@ -22,6 +22,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from cookbook.rollout_control import apply_session_affinity, distributed_rank
 from stitch.bulletin import FilesystemBulletinBoard
 from stitch.protocol import BASE_VERSION, PointerRewind, parse_weight_identity
 from stitch.providers.modal import commit_volume, discover_flash_targets, volume_reloader, wake_targets
@@ -186,27 +187,11 @@ async def gated_rollout_request_hook(args: Any, sample: Any, request: dict[str, 
     request["max_retries"] = int(getattr(args, "rollout_request_retry_attempts", request.get("max_retries", 60)))
     request["retry_sleep"] = float(getattr(args, "rollout_request_retry_sleep", request.get("retry_sleep", 1.0)))
 
-    session_id = getattr(sample, "session_id", None)
-    if session_id:
-        header = str(getattr(args, "rollout_session_affinity_header", "x-session-affinity"))
-        headers = dict(request.get("headers") or {})
-        headers.setdefault(header, session_id)
-        request["headers"] = headers
+    header = str(getattr(args, "rollout_session_affinity_header", "x-session-affinity"))
+    apply_session_affinity(request, getattr(sample, "session_id", None), header)
 
 
 # ── Shared helpers ────────────────────────────────────────────────────────────
-
-
-def distributed_rank() -> int | None:
-    """Return the torch distributed rank, or None if not initialized."""
-    try:
-        import torch.distributed as dist
-
-        if dist.is_available() and dist.is_initialized():
-            return int(dist.get_rank())
-    except Exception:  # noqa: BLE001
-        return None
-    return None
 
 
 def _volume_name(args: Any) -> str:

--- a/cookbook/miles_disagg/helpers.py
+++ b/cookbook/miles_disagg/helpers.py
@@ -1,23 +1,20 @@
 """Trainer-specific helpers for the miles_disagg example.
 
-Ray cluster, sidecar, and process helpers are shared across trainers via
-:mod:`cookbook.ray_cluster` and :mod:`cookbook.sidecar_process`. This module
-provides miles-specific config preparation, train command building, and the
-Flash pool smoke check.
+Thin wrappers over the shared launch spine: Ray-cluster/sidecar/process helpers
+come from :mod:`cookbook.ray_cluster` / :mod:`cookbook.sidecar_process`, and
+config-prep / train-command / smoke-check / host-RAM monitor come from
+:mod:`cookbook.trainer_helpers`. This module only supplies the miles-specific
+axes: the sidecar module path, the config-field tuple to materialize, the
+model-script attribute, and that the rollout pool scales from zero (wake on
+demand).
 """
 
 from __future__ import annotations
 
-import json
-import os
-import shlex
 import subprocess
-import time
-import urllib.error
-import urllib.request
 from typing import Any
 
-from stitch.providers.modal import discover_flash_targets, resolve_flash_gateway_url
+from cookbook.miles_disagg.configs.base import YAML_CONFIG_FIELDS
 
 # Re-export shared helpers so existing callers (modal_train.py) don't break.
 from cookbook.ray_cluster import (  # noqa: F401
@@ -31,6 +28,14 @@ from cookbook.ray_cluster import (  # noqa: F401
 from cookbook.sidecar_process import (  # noqa: F401
     terminate_process,
     wait_http,
+)
+from cookbook.trainer_helpers import (  # noqa: F401
+    VersionAheadError,
+    build_train_cmd as _build_train_cmd,
+    materialize_node_local_yaml,
+    prepare_config,
+    smoke_flash_pool as _smoke_flash_pool,
+    start_host_mem_monitor,
 )
 
 
@@ -63,9 +68,6 @@ def start_sglang_sidecar(
     )
 
 
-# ── miles launch ──────────────────────────────────────────────────────────────
-
-
 def prepare_miles_config(miles_cfg: Any, tmpdir: str) -> None:
     """Resolve HF repo IDs to local paths and materialize inline YAML configs.
 
@@ -73,70 +75,12 @@ def prepare_miles_config(miles_cfg: Any, tmpdir: str) -> None:
     NVFP4 base and bf16 masters), so the ``startswith("/")`` guard skips them; a
     repo-id-shaped value (if any) is snapshot-downloaded from the HF cache.
     """
-    from huggingface_hub import snapshot_download
-    import yaml
-
-    from cookbook.miles_disagg.configs.base import YAML_CONFIG_FIELDS
-
-    for attr in ("hf_checkpoint", "load", "ref_load", "critic_load"):
-        if (val := getattr(miles_cfg, attr, None)) and not str(val).startswith("/"):
-            setattr(miles_cfg, attr, snapshot_download(val, local_files_only=True))
-
-    for field in YAML_CONFIG_FIELDS:
-        if isinstance(val := getattr(miles_cfg, field, None), dict):
-            path = os.path.join(tmpdir, f"{field}.yaml")
-            with open(path, "w") as f:
-                yaml.dump(val, f)
-            setattr(miles_cfg, field, path)
-
-
-def materialize_node_local_yaml(miles_cfg: Any, field: str, dest_dir: str = "/root/.miles_node_yaml") -> None:
-    """Materialize a per-actor-read YAML config to a deterministic node-local path.
-
-    Some config files (notably ``te_precision_config_file``, which
-    ``load_quantization_recipe`` re-reads on every Ray actor during model build)
-    are read independently on each trainer node — not just parsed once on the head.
-    ``prepare_miles_config`` writes them under ``tempfile.mkdtemp()`` on the head
-    only, so on a multi-node cluster the other containers can't see that path.
-
-    Call this on EVERY node (SPMD train()), before the rank-0 gate: each node
-    writes identical content (from the shared payload) to the same fixed path, so
-    the path the head embeds in the args resolves locally on all actors. No volume
-    commit/reload race — Ray actors are long-lived and wouldn't see post-start
-    volume writes anyway.
-    """
-    import yaml
-
-    if isinstance(val := getattr(miles_cfg, field, None), dict):
-        os.makedirs(dest_dir, exist_ok=True)
-        path = os.path.join(dest_dir, f"{field}.yaml")
-        with open(path, "w") as f:
-            yaml.dump(val, f)
-        setattr(miles_cfg, field, path)
+    prepare_config(miles_cfg, tmpdir, YAML_CONFIG_FIELDS)
 
 
 def build_train_cmd(miles_cfg: Any, miles_root: str) -> str:
-    """Build the training command, sourcing model arch args if needed.
-
-    miles' train.py / train_async.py live at the repo root and consume the
-    ``MODEL_ARGS`` bash array defined by the sourced model script, exactly like
-    slime's launcher.
-    """
-    train_script = f"{miles_root}/{'train_async.py' if miles_cfg.async_mode else 'train.py'}"
-    if miles_cfg.miles_model_script:
-        inner = (
-            f"source {miles_root}/{miles_cfg.miles_model_script} && "
-            f"python3 {train_script} ${{MODEL_ARGS[@]}} {shlex.join(miles_cfg.cli_args())}"
-        )
-        return f"bash -c {shlex.quote(inner)}"
-    return f"python3 {train_script} {shlex.join(miles_cfg.cli_args())}"
-
-
-# ── Flash pool smoke check ────────────────────────────────────────────────────
-
-
-class VersionAheadError(RuntimeError):
-    """Raised when a monotonic rollout pool has already advanced past a smoke version."""
+    """Build the training command, sourcing miles' model arch args if needed."""
+    return _build_train_cmd(miles_cfg, miles_root, model_script_attr="miles_model_script")
 
 
 def smoke_flash_pool(
@@ -148,128 +92,14 @@ def smoke_flash_pool(
     expect_min_containers: int,
     timeout_seconds: int,
 ) -> None:
-    """Wake the elastic pool on demand and confirm it serves at the expected
-    weight version.
-
-    The pool has no warm floor (min_containers=0), so a completion sent to the
-    Flash gateway is what scales it 0->1; Flash holds the request during the
-    container's cold start (model load + FP4 kernel tuning), so the warmup uses a
-    generous timeout. ``expect_min_containers`` is advisory only — a value > 0
-    just means "also confirm at least one direct container reports the version."
-    """
-    deadline = time.time() + timeout_seconds
-    last_error: str | None = None
-    while True:
-        try:
-            _check_flash_pool_once(app_name, cls_name, model_name, weight_version)
-            return
-        except VersionAheadError:
-            raise
-        except Exception as exc:  # noqa: BLE001
-            last_error = f"{type(exc).__name__}: {exc}"
-        if time.time() >= deadline:
-            raise TimeoutError(f"Flash pool smoke did not pass before timeout: {last_error}")
-        print(f"Waiting for Flash pool to wake/serve: {last_error}")
-        time.sleep(10)
-
-
-def _check_flash_pool_once(app_name: str, cls_name: str, model_name: str, expected: int) -> None:
-    gateway = resolve_flash_gateway_url(app_name, cls_name)
-    print(f"Gateway URL: {gateway}")
-
-    # Wake the (scaled-to-zero) pool and wait for a container to serve. Flash
-    # holds the request through the cold start, so the timeout must exceed it.
-    payload = {
-        "model": model_name,
-        "messages": [{"role": "user", "content": "Reply with exactly OK."}],
-        "max_tokens": 8,
-        "temperature": 0,
-        "weight_version": {"exact_version": expected},
-        "chat_template_kwargs": {"enable_thinking": False},
-    }
-    data = _post_json(f"{gateway}/v1/chat/completions", payload, timeout=900)
-    print(f"Gateway completion: {data}")
-    start, end = int(data.get("weight_version_start", -1)), int(data.get("weight_version_end", -1))
-    if start > expected or end > expected:
-        raise VersionAheadError(f"gateway served version {start}->{end}, already past expected {expected}")
-    if start != expected or end != expected:
-        raise RuntimeError(f"unexpected gateway weight metadata: {data}")
-
-    # The pool is warm now; confirm each live container reports the version.
-    targets = discover_flash_targets(app_name, cls_name)
-    print(f"Direct container URLs ({len(targets)}):")
-    for target in [gateway, *targets]:
-        info = _get_json(f"{target}/server_info", timeout=30)
-        print(f"{target} server_info={info}")
-        current = int(info["current_version"])
-        if current > expected:
-            raise VersionAheadError(f"{target} current_version={current} already passed expected {expected}")
-        if current != expected:
-            raise RuntimeError(f"{target} current_version={current} expected {expected}")
-
-
-def _get_json(url: str, *, timeout: float) -> dict:
-    with urllib.request.urlopen(url, timeout=timeout) as resp:
-        return json.load(resp)
-
-
-def _post_json(url: str, payload: dict, *, timeout: float) -> dict:
-    request = urllib.request.Request(
-        url,
-        data=json.dumps(payload).encode(),
-        headers={"Content-Type": "application/json"},
+    """Smoke the scale-from-zero miles rollout pool (min_containers=0): the
+    completion wakes it, then each warmed container is confirmed at the version."""
+    _smoke_flash_pool(
+        app_name=app_name,
+        cls_name=cls_name,
+        model_name=model_name,
+        weight_version=weight_version,
+        expect_min_containers=expect_min_containers,
+        timeout_seconds=timeout_seconds,
+        wake_on_demand=True,
     )
-    with urllib.request.urlopen(request, timeout=timeout) as resp:
-        return json.load(resp)
-
-
-def start_host_mem_monitor(interval_s: int = 20) -> None:
-    """Log this node's host-RAM trajectory to stdout from a daemon thread.
-
-    The trainer can OOM-kill on host-RAM exhaustion (the publish/update_weights
-    full-model gather is the peak consumer), but Megatron only reports GPU memory
-    and the kill leaves no durable peak behind. This logs MemTotal/MemAvailable +
-    the container cgroup usage every ``interval_s`` so a live ``modal app logs -f``
-    shows exactly which phase blows the ~1.95 TiB B200:8 node and how high it peaks.
-    Runs on EVERY node (called from the SPMD enter()), so whichever rank OOMs has
-    its own trace. Best-effort: never raises."""
-    import threading
-
-    host = socket.gethostname()
-
-    def _meminfo() -> tuple[float, float]:
-        total = avail = 0.0
-        try:
-            with open("/proc/meminfo") as f:
-                for line in f:
-                    if line.startswith("MemTotal:"):
-                        total = int(line.split()[1]) / 1024 / 1024  # GiB
-                    elif line.startswith("MemAvailable:"):
-                        avail = int(line.split()[1]) / 1024 / 1024
-        except Exception:  # noqa: BLE001
-            pass
-        return total, avail
-
-    def _cgroup_used_gib() -> float:
-        for path in ("/sys/fs/cgroup/memory.current",  # cgroup v2
-                     "/sys/fs/cgroup/memory/memory.usage_in_bytes"):  # v1
-            try:
-                with open(path) as f:
-                    return int(f.read().strip()) / 1024**3
-            except Exception:  # noqa: BLE001
-                continue
-        return -1.0
-
-    def _loop() -> None:
-        while True:
-            total, avail = _meminfo()
-            used = total - avail
-            cg = _cgroup_used_gib()
-            print(
-                f"[hostmem] {host} used={used:.0f}GiB avail={avail:.0f}GiB "
-                f"total={total:.0f}GiB cgroup_used={cg:.0f}GiB",
-                flush=True,
-            )
-            time.sleep(interval_s)
-
-    threading.Thread(target=_loop, daemon=True, name="host-mem-monitor").start()

--- a/cookbook/miles_disagg/modal_train.py
+++ b/cookbook/miles_disagg/modal_train.py
@@ -189,10 +189,13 @@ if getattr(exp, "PATCH_GLM4MOE_EXPERT_BIAS_FP32", False):
 # Local source mounted at container start (no rebuild on code edits). Modal puts
 # /root on PYTHONPATH, so both packages import from subprocesses (the sidecar, Ray
 # workers). MUST come after any .run_commands() above (Modal forbids run_commands
-# after a non-copy local mount).
+# after a non-copy local mount). The whole cookbook package is mounted (not just
+# the per-trainer subdir) so the trainer and the `python3 -m
+# cookbook.miles_disagg.sidecar` subprocess can import the shared cookbook spine
+# (helpers/hooks/sidecar) the thin adapters delegate to.
 image = image.add_local_python_source("stitch").add_local_dir(
-    Path(__file__).parent,
-    remote_path="/root/cookbook/miles_disagg",
+    Path(__file__).parent.parent,
+    remote_path="/root/cookbook",
     ignore=["**/__pycache__"],
 )
 

--- a/cookbook/miles_disagg/serving.py
+++ b/cookbook/miles_disagg/serving.py
@@ -1,26 +1,15 @@
-"""Dedicated B200 NVFP4 SGLang serving image for the rollout pool.
+"""Dedicated B200 NVFP4 SGLang serving image for the miles rollout pool.
 
-The trainer half of this example runs on the miles/Megatron image
-(``modal_train.image``). The rollout half that serves the NVFP4 checkpoint needs
-a different stack: a Blackwell SGLang build that loads the model's NVFP4 weights
-and runs MLA attention with the tuned hierarchical KV cache. This module builds
-that image — the miles twin of cookbook/slime_disagg/serving.py.
+A thin wrapper over :func:`cookbook.serving.build_b200_serving_image` — the miles
+twin of cookbook/slime_disagg/serving.py. The image itself is trainer-agnostic
+(see that module): NVFP4 vs INT4 is driven by the served checkpoint's own quant
+config, not by this builder. This wrapper pins miles as the ``--no-deps`` decoder
+package, does a full clone, and clears the SGLang kernel cache as the final
+filesystem step (modal_train mounts a kernel-cache volume at /root/.cache/sglang,
+which can't mount over a non-empty path).
 
-Two deliberate choices keep it lean:
-
-  * **SGLang comes from the modal-projects/sglang fork** (Blackwell fa4 /
-    cutlass-dsl prerelease kernels + the tokenspeed MLA attention backend) — the
-    same build the slime example uses, proven for NVFP4. No ``--quantization``
-    flag is baked in; the served checkpoint's own NVFP4 quant config drives
-    weight loading (see the config module's ``SGLANG_SERVER_ARGS``).
-  * **miles is cloned ``--no-deps`` for one module.** The sidecar only imports
-    ``miles.utils.disk_delta`` (stdlib + numpy + zstandard; xxhash/blake3 lazy),
-    so Megatron is intentionally absent from the rollout pool. NOTE: this assumes
-    ``miles.utils.disk_delta`` is import-light (no heavy package __init__ chain);
-    verify on a warm container during bring-up.
-
-Pin the SAME miles ref the trainer image uses so the host-side delta decoder
-matches the trainer's delta encoder.
+NOTE: this assumes ``miles.utils.disk_delta`` is import-light (no heavy package
+__init__ chain); verify on a warm container during bring-up.
 """
 
 from __future__ import annotations
@@ -29,26 +18,7 @@ from pathlib import Path
 
 import modal
 
-# Pinned Blackwell SGLang fork — matches the slime 4xB200 Kimi serve recipe,
-# proven for NVFP4. Only the python sources are checked out over the prebuilt
-# base image's kernels.
-SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.12"
-SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
-SGLANG_FORK_BRANCH = "timmy/dflash-fa4-fp8"
-SGLANG_FORK_COMMIT = "dafb2b325b40298c5097564811463c585b7e9814"
-
-# SGLang runtime tunables carried over from the B200 deployment.
-SERVING_IMAGE_ENV = {
-    "HF_XET_HIGH_PERFORMANCE": "1",
-    "HF_HUB_ENABLE_HF_TRANSFER": "1",
-    "SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN": "1",
-    "SGLANG_DISABLE_CUDNN_CHECK": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
-    "SGLANG_TIMEOUT_KEEP_ALIVE": "300",
-}
-# NOTE: kernel-cache persistence is handled by mounting SGLang's cache dir
-# (/root/.cache/sglang, which nests flashinfer/DeepGemm) as a volume in
-# modal_train — no env override here, so SGLang's default placement is kept.
+from cookbook.serving import build_b200_serving_image
 
 
 def build_nvfp4_b200_serving_image(
@@ -59,72 +29,13 @@ def build_nvfp4_b200_serving_image(
     hf_cache_path: str,
     experiment: str,
 ) -> modal.Image:
-    """Build the rollout-pool serving image (see module docstring).
-
-    The miles fork ref / root and the HF cache path are passed in by
-    ``modal_train`` so the pool and the trainer pin the identical miles commit
-    (the sidecar's ``disk_delta`` must match the trainer's delta encoder).
-    """
-    # serving.py lives in cookbook/miles_disagg, mounted to /root/cookbook/miles_disagg
-    # exactly as the trainer image mounts it, so `cookbook.miles_disagg.sidecar`
-    # imports identically in either container.
-    miles_disagg_dir = Path(__file__).parent
-    return (
-        modal.Image.from_registry(SGLANG_IMAGE_TAG)
-        .run_commands(
-            f"cd /sgl-workspace/sglang && git remote add modal-fork {SGLANG_FORK_REPO}"
-            f" && git fetch modal-fork {SGLANG_FORK_BRANCH}"
-            f" && git checkout {SGLANG_FORK_COMMIT} -- python/",
-        )
-        # Pre-release CUDA wheels (cutlass-dsl / sglang-kernel / flash-attn-4) —
-        # keep the deployment's known-good pip resolution.
-        .run_commands(
-            "pip install nvidia-cutlass-dsl==4.5.1 sglang-kernel==0.4.3 'flash-attn-4>=4.0.0b10'"
-        )
-        # flash-attn-4 checks for the deprecated MmaFP8Op but cutlass-dsl 4.5.1 now
-        # generates MmaF8F6F4Op instead. Patch the isinstance check to handle both.
-        .run_commands(
-            "sed -i 's/isinstance(op, tcgen05.mma.MmaFP8Op)/isinstance(op, (tcgen05.mma.MmaFP8Op, tcgen05.mma.MmaF8F6F4Op))/' "
-            "/usr/local/lib/python3.12/dist-packages/flash_attn/cute/blackwell_helpers.py"
-        )
-        # The base image bakes in an HF cache; remove it so it cannot shadow the
-        # cache volume mounted at the same path.
-        .run_commands(f"rm -rf {hf_cache_path}")
-        # miles --no-deps gives the sidecar `miles.utils.disk_delta` (host-side
-        # delta apply). Megatron is NOT installed — the pool never trains. Pin the
-        # SAME ref the trainer image uses so the delta encoder/decoder match.
-        .run_commands(
-            f"git clone {miles_repo_url} {miles_root}"
-            f" && cd {miles_root}"
-            f" && git fetch origin {miles_repo_ref}"
-            f" && git checkout FETCH_HEAD"
-            f" && python3 -m pip install --no-deps -e {miles_root}"
-        )
-        .pip_install(
-            "autoinference-utils==0.2.0",  # SGLang server lifecycle for the rollout pool
-            "fastapi",  # stitch sidecar
-            "httpx",  # stitch sidecar
-            "uvicorn",  # stitch sidecar
-            # disk_delta host-side apply: zstd decompress + xxhash (xxh3-128
-            # default) / blake3 checksums. miles is installed --no-deps.
-            "zstandard",
-            "xxhash",
-            "blake3",
-        )
-        # MUST be the last filesystem step: modal_train mounts the
-        # miles-sglang-cache volume at /root/.cache/sglang, and a volume can't
-        # mount over a non-empty path. The sglang-kernel/flashinfer and miles
-        # installs above populate this dir, so clear it AFTER them (the volume
-        # repopulates the JIT/autotuner cache on first boot).
-        .run_commands("rm -rf /root/.cache/sglang")
-        .env({"EXPERIMENT_CONFIG": experiment, **SERVING_IMAGE_ENV})
-        # Mounted at container start (not copied into the image) so code edits to
-        # stitch / the sidecar never rebuild the image. Modal puts /root on
-        # PYTHONPATH for subprocesses (the sidecar).
-        .add_local_python_source("stitch")
-        .add_local_dir(
-            miles_disagg_dir,
-            remote_path="/root/cookbook/miles_disagg",
-            ignore=["**/__pycache__"],
-        )
+    return build_b200_serving_image(
+        trainer_repo_url=miles_repo_url,
+        trainer_repo_ref=miles_repo_ref,
+        trainer_root=miles_root,
+        cookbook_dir=Path(__file__).parent,
+        hf_cache_path=hf_cache_path,
+        experiment=experiment,
+        shallow_clone=False,
+        clear_sglang_cache_at_end=True,
     )

--- a/cookbook/miles_disagg/sidecar.py
+++ b/cookbook/miles_disagg/sidecar.py
@@ -1,223 +1,26 @@
-"""SGLang weight-sync sidecar launcher for the miles_disagg example.
+"""SGLang weight-sync sidecar entry point for the miles_disagg example.
 
-The reusable versioned-proxy library lives in ``stitch.servers.sglang``; this
-module wires the concrete bulletin-board + Modal Volume + SGLang-disk-delta
-realization and runs it as a process (``helpers.start_sglang_sidecar`` launches
-``python3 -m cookbook.miles_disagg.sidecar``).
+A thin adapter over :mod:`cookbook.sidecar`: the shared spine owns every knob;
+this only names miles' host-side delta decoder and asks for it to be injected.
+``helpers.start_sglang_sidecar`` launches it via
+``python3 -m cookbook.miles_disagg.sidecar``.
 
-The ONLY functional difference from cookbook/slime_disagg/sidecar.py is the
-host-side delta decoder: this injects ``miles.utils.disk_delta`` into the
-adapter instead of letting it default to ``slime.utils.disk_delta``. The two are
-byte-identical (same XOR/overwrite + zstd + xxh3/blake3/adler32 wire format), but
-the rollout pool image ships miles (``--no-deps``), not slime, so the miles
-functions must be injected explicitly.
+miles' ``disk_delta`` is byte-identical to slime's (same XOR/overwrite + zstd +
+xxh3/blake3/adler32 wire format), but the rollout pool image ships miles
+``--no-deps``, not slime, so the decoder must be injected explicitly rather than
+relying on the engine's slime default.
 """
 
 from __future__ import annotations
 
-import argparse
-import logging
-import os
-
-from stitch.bulletin import FilesystemBulletinBoard
-from stitch.engines.sglang import SGLangDiskDeltaAdapter
-from stitch.servers.sglang import create_app
-from stitch.sync import CommitMode, WeightSyncManager
-
-logger = logging.getLogger(__name__)
+from cookbook.sidecar import run_sidecar
 
 
-def _parallel_init_local_checkpoint(workers: int = 32):
-    """Return an ``init_local_checkpoint(local, base)`` that copies the base
-    shards concurrently. miles' default copies them one at a time with
-    ``shutil.copy2`` — fine for a 16 B Moonlight base, far too slow for K2.6's
-    ~591 GB. We reuse miles' apply-lock + applied-version bookkeeping so
-    ``apply_deltas`` stays compatible, and fall back to the miles default if those
-    internals move under us."""
-    import concurrent.futures
-    import hashlib
-    import shutil
-
-    from miles.utils import disk_delta as dd
-
-    def _base_fingerprint(base_dir: str) -> str:
-        """Identity of the base's bytes: (filename, size, mtime_ns) over every shard. Re-prep
-        rewrites the shards (new mtime/size), so this changes even when the tensor index/shapes
-        don't — which is exactly the case that bit us (NVFP4 values changed, names didn't)."""
-        h = hashlib.sha256()
-        for e in sorted(os.scandir(base_dir), key=lambda e: e.name):
-            if e.is_file():
-                st = e.stat()
-                h.update(f"{e.name}:{st.st_size}:{st.st_mtime_ns}\n".encode())
-        return h.hexdigest()
-
-    def _init(local_ckpt_dir: str, base_dir: str) -> None:
-        try:
-            apply_lock = dd._apply_lock
-            read_version = dd._read_applied_version
-            write_version = dd._write_applied_version
-            drop_page_cache = dd.drop_page_cache
-        except AttributeError:  # miles internals changed — use its own copier
-            dd.init_local_checkpoint(local_ckpt_dir, base_dir)
-            return
-
-        fp_path = os.path.join(local_ckpt_dir, ".base_fingerprint")
-        base_fp = _base_fingerprint(base_dir)
-        with apply_lock(local_ckpt_dir):
-            if read_version(local_ckpt_dir) is not None:
-                try:
-                    cur = open(fp_path).read().strip()
-                except FileNotFoundError:
-                    cur = None
-                if cur == base_fp:
-                    return  # current base already materialized
-                # STALE: /local-checkpoint holds a different (older) base — e.g. after a re-prep.
-                # Reusing it makes the host-side delta (diffed against the NEW base) XOR onto the
-                # WRONG bytes -> base_local XOR delta != export -> checksum mismatch on every tensor.
-                logger.warning(
-                    "stale /local-checkpoint (base changed: %s != %s) — wiping + re-materializing",
-                    cur, base_fp,
-                )
-                shutil.rmtree(local_ckpt_dir, ignore_errors=True)
-            logger.info("Materializing base %s -> %s (%d copy workers)", base_dir, local_ckpt_dir, workers)
-            os.makedirs(local_ckpt_dir, exist_ok=True)
-            files = [e for e in os.scandir(base_dir) if e.is_file()]
-
-            def _copy(entry: os.DirEntry) -> None:
-                import shutil
-
-                shutil.copy2(entry.path, os.path.join(local_ckpt_dir, entry.name))
-                drop_page_cache(entry.path)  # don't evict the local copy we keep resident
-
-            with concurrent.futures.ThreadPoolExecutor(max_workers=min(workers, max(1, len(files)))) as ex:
-                for _ in ex.map(_copy, files):  # re-raises the first copy failure
-                    pass
-            write_version(local_ckpt_dir, "000000")
-            with open(fp_path, "w") as f:
-                f.write(base_fp)
-
-    return _init
-
-
-def build_manager(
-    *,
-    upstream_url: str,
-    bulletin_root: str,
-    local_checkpoint_dir: str,
-    base_checkpoint_dir: str,
-    volume_name: str = "",
-    run_id: str | None = None,
-    commit_mode: CommitMode = "in_place",
-    debug_requests: bool = False,
-) -> WeightSyncManager:
-    # The miles host-side delta decoder. miles is installed --no-deps in the
-    # serving image for exactly this module (Megatron is absent — the pool never
-    # trains). Pinned to the same miles ref as the trainer so encoder == decoder.
-    from miles.utils.disk_delta import apply_deltas
-
-    refresh = None
-    if volume_name:
-        from stitch.providers.modal import volume_reloader
-
-        refresh = volume_reloader(volume_name)
-    # miles publish-only writes the flat layout (weight_v{N}/ +
-    # model.safetensors.index.json + a raw `latest` pointer) to the Volume — the
-    # same layout slime uses, so layout="slime" reads it unchanged.
-    board = FilesystemBulletinBoard(bulletin_root, refresh=refresh, layout="slime")
-    engine = SGLangDiskDeltaAdapter(
-        upstream_url=upstream_url,
-        local_checkpoint_dir=local_checkpoint_dir,
-        base_checkpoint_dir=base_checkpoint_dir,
-        apply_deltas=apply_deltas,
-        init_local_checkpoint=_parallel_init_local_checkpoint(),
-    )
-    return WeightSyncManager(
-        board=board,
-        engine=engine,
-        run_id=run_id,
-        commit_mode=commit_mode,
-        debug_requests=debug_requests,
-    )
+DISK_DELTA_MODULE = "miles.utils.disk_delta"
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--host", default="0.0.0.0")
-    parser.add_argument("--port", type=int, default=8000)
-    parser.add_argument("--upstream-url", required=True)
-    parser.add_argument(
-        "--bulletin-root",
-        default=os.environ.get("DELTA_BULLETIN_ROOT", "/delta-bulletin"),
-    )
-    parser.add_argument("--volume-name", default=os.environ.get("DELTA_VOLUME_NAME", ""))
-    parser.add_argument(
-        "--local-checkpoint-dir",
-        default=os.environ.get("STITCH_LOCAL_CHECKPOINT_DIR", "/local-checkpoint"),
-        help="Writable host-local full HF checkpoint patched in place by each delta.",
-    )
-    parser.add_argument(
-        "--base-checkpoint-dir",
-        default=os.environ.get("STITCH_BASE_CHECKPOINT_DIR"),
-        help="Base HF checkpoint the local copy is seeded from (deltas build on it).",
-    )
-    parser.add_argument("--run-id", default=os.environ.get("DISAGG_RUN_ID"))
-    parser.add_argument(
-        "--commit-mode",
-        choices=("quiesce", "in_place"),
-        default=os.environ.get("SIDECAR_COMMIT_MODE", "in_place"),
-        help=(
-            "in_place (default): pause/apply/continue without flushing; in-flight "
-            "requests keep decoding on stale KV and version isolation comes from "
-            "extra_key stamping. quiesce: wait out active requests and flush "
-            "before applying (safe on any build)."
-        ),
-    )
-    parser.add_argument(
-        "--debug-requests",
-        action="store_true",
-        default=os.environ.get("SIDECAR_DEBUG_REQUESTS", "").lower() in {"1", "true", "yes"},
-        help="Log every versioned sidecar proxy request at INFO level.",
-    )
-    parser.add_argument(
-        "--upstream-timeout",
-        type=float,
-        default=float(os.environ.get("SIDECAR_UPSTREAM_TIMEOUT", "3600")),
-        help=(
-            "Seconds to wait for an upstream SGLang response before failing the "
-            "request (5xx) instead of holding it open forever. Must exceed the "
-            "slowest legitimate generation."
-        ),
-    )
-    args = parser.parse_args()
-    if not args.base_checkpoint_dir:
-        raise SystemExit(
-            "--base-checkpoint-dir/STITCH_BASE_CHECKPOINT_DIR is required: deltas are"
-            " applied host-side on top of a copy of this base HF checkpoint."
-        )
-
-    logging.basicConfig(level=logging.INFO)
-    import uvicorn
-
-    manager = build_manager(
-        upstream_url=args.upstream_url,
-        bulletin_root=args.bulletin_root,
-        local_checkpoint_dir=args.local_checkpoint_dir,
-        base_checkpoint_dir=args.base_checkpoint_dir,
-        volume_name=args.volume_name,
-        run_id=args.run_id,
-        commit_mode=args.commit_mode,
-        debug_requests=args.debug_requests,
-    )
-    uvicorn.run(
-        create_app(
-            manager,
-            upstream_url=args.upstream_url,
-            upstream_timeout=args.upstream_timeout,
-        ),
-        host=args.host,
-        port=args.port,
-        log_level="info",
-    )
+    run_sidecar(disk_delta_module=DISK_DELTA_MODULE, inject_apply_deltas=True)
 
 
 if __name__ == "__main__":

--- a/cookbook/rollout_control.py
+++ b/cookbook/rollout_control.py
@@ -1,0 +1,80 @@
+"""Trainer-side primitives shared by both rollout-control planes.
+
+The cookbook has two *intended* control planes for advancing the rollout pool's
+``latest`` pointer:
+
+- **trainer-as-writer** (slime_disagg / miles_disagg): the trainer's rank-0
+  publish hook writes the Modal-Volume bulletin board directly
+  (:mod:`cookbook.bulletin_hooks`).
+- **frontdoor-as-writer** (standalone_rollouts): the trainer POSTs a hot-load
+  signal to an external front door that owns the pointer
+  (:mod:`cookbook.standalone_rollouts.slime.hooks`).
+
+Those two planes are the real "disagg vs standalone" axis and stay distinct. But
+the trainer-side *plumbing* around them was copy-forked: an identical torch rank
+probe, an identical args-or-env settings reader, and identical session-affinity
+header stamping. This module owns that plumbing once so the two hook stacks only
+encode their genuine difference (who writes the pointer), not boilerplate.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def distributed_rank() -> int | None:
+    """Return this process's torch-distributed rank, or ``None`` if torch
+    distributed isn't initialized (single-process / pre-init).
+
+    Used to gate rank-0-only side effects (pointer writes, transport copies,
+    pool wakes) so only one writer acts per publish.
+    """
+    try:
+        import torch.distributed as dist
+
+        if dist.is_available() and dist.is_initialized():
+            return int(dist.get_rank())
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def read_setting(
+    args: Any | None,
+    attr: str,
+    env: str,
+    *,
+    default: str | None = None,
+    required: bool = False,
+) -> str:
+    """Read a string setting from the trainer ``args`` namespace, falling back to
+    an environment variable, then a default.
+
+    The trainer's ``--custom-config-path`` setattr's every config key onto
+    ``args``; an env var is the deploy-time fallback for values that can't ride a
+    per-launch arg. Returns ``""`` for an absent, non-required setting.
+    """
+    value = getattr(args, attr, None) if args is not None else None
+    if value is None:
+        value = os.environ.get(env)
+    if value is None:
+        value = default
+    if value is None and required:
+        raise RuntimeError(
+            f"Missing required setting {attr!r} or environment variable {env}"
+        )
+    return str(value) if value is not None else ""
+
+
+def apply_session_affinity(request: dict[str, Any], session_id: Any, header: str) -> None:
+    """Stamp ``header: session_id`` onto a rollout request's headers (idempotent).
+
+    Sticky-session routing: a sample carrying a ``session_id`` should land on the
+    same replica across turns. ``setdefault`` so an explicit caller header wins.
+    """
+    if not session_id:
+        return
+    headers = dict(request.get("headers") or {})
+    headers.setdefault(header, str(session_id))
+    request["headers"] = headers

--- a/cookbook/rollout_control_test.py
+++ b/cookbook/rollout_control_test.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import unittest
+from argparse import Namespace
+from unittest import mock
+
+from cookbook import rollout_control
+
+
+class DistributedRankTest(unittest.TestCase):
+    def test_none_when_torch_distributed_unavailable(self) -> None:
+        # No torch dist initialized in tests (torch may be absent entirely): the
+        # probe must degrade to None, which the hooks treat as "single writer".
+        self.assertIsNone(rollout_control.distributed_rank())
+
+
+class ReadSettingTest(unittest.TestCase):
+    def test_args_beats_env_beats_default(self) -> None:
+        args = Namespace(api_key="from-args")
+        with mock.patch.dict("os.environ", {"API_KEY": "from-env"}, clear=True):
+            self.assertEqual(
+                rollout_control.read_setting(args, "api_key", "API_KEY", default="d"), "from-args"
+            )
+        with mock.patch.dict("os.environ", {"API_KEY": "from-env"}, clear=True):
+            self.assertEqual(
+                rollout_control.read_setting(Namespace(), "api_key", "API_KEY", default="d"),
+                "from-env",
+            )
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertEqual(
+                rollout_control.read_setting(Namespace(), "api_key", "API_KEY", default="d"), "d"
+            )
+
+    def test_empty_string_for_absent_optional_and_raises_when_required(self) -> None:
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertEqual(rollout_control.read_setting(None, "x", "X"), "")
+            with self.assertRaises(RuntimeError):
+                rollout_control.read_setting(None, "x", "X", required=True)
+
+
+class SessionAffinityTest(unittest.TestCase):
+    def test_stamps_header_without_overriding_explicit_value(self) -> None:
+        request: dict = {"headers": {"x-aff": "explicit"}}
+        rollout_control.apply_session_affinity(request, "sess-1", "x-aff")
+        self.assertEqual(request["headers"]["x-aff"], "explicit")  # setdefault, not override
+
+        request = {}
+        rollout_control.apply_session_affinity(request, "sess-1", "x-aff")
+        self.assertEqual(request["headers"]["x-aff"], "sess-1")
+
+    def test_noop_for_falsy_session_id(self) -> None:
+        request: dict = {"headers": {"a": "b"}}
+        rollout_control.apply_session_affinity(request, None, "x-aff")
+        self.assertEqual(request["headers"], {"a": "b"})
+        self.assertNotIn("x-aff", request["headers"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cookbook/serving.py
+++ b/cookbook/serving.py
@@ -60,8 +60,12 @@ def build_b200_serving_image(
     ``trainer_repo_url`` / ``trainer_repo_ref`` / ``trainer_root`` pin the
     ``--no-deps`` trainer checkout (so the pool's ``disk_delta`` matches the
     trainer's encoder). ``cookbook_dir`` is the per-trainer cookbook package dir;
-    it is mounted at ``/root/cookbook/<name>`` exactly as the trainer image mounts
-    it, so ``cookbook.<name>.sidecar`` imports identically in either container.
+    its parent (the whole ``cookbook`` package) is mounted at ``/root/cookbook``,
+    so the sidecar subprocess can import both ``cookbook.<name>.sidecar`` and the
+    shared ``cookbook.sidecar`` spine it delegates to. Mounting the package (not
+    just the subdir) is required because the sidecar is launched as
+    ``python3 -m cookbook.<name>.sidecar`` and is never imported at deploy time,
+    so Modal's import-time automounting never sees the shared module.
 
     ``shallow_clone`` does a ``--depth 1`` clone+fetch (fine when the ref is a
     branch tip or recent commit). ``clear_sglang_cache_at_end`` removes
@@ -125,11 +129,13 @@ def build_b200_serving_image(
         image.env({"EXPERIMENT_CONFIG": experiment, **SERVING_IMAGE_ENV})
         # Mounted at container start (not copied into the image) so code edits to
         # stitch / the sidecar never rebuild the image. Modal puts /root on
-        # PYTHONPATH for subprocesses (the sidecar).
+        # PYTHONPATH for subprocesses (the sidecar). The whole cookbook package is
+        # mounted (not just the per-trainer subdir) so the sidecar can import the
+        # shared cookbook.sidecar spine it is a thin adapter over.
         .add_local_python_source("stitch")
         .add_local_dir(
-            cookbook_dir,
-            remote_path=f"/root/cookbook/{cookbook_dir.name}",
+            cookbook_dir.parent,
+            remote_path="/root/cookbook",
             ignore=["**/__pycache__"],
         )
     )

--- a/cookbook/serving.py
+++ b/cookbook/serving.py
@@ -1,0 +1,135 @@
+"""Shared B200 SGLang serving-image builder for the disagg rollout pool.
+
+The trainer half of each disagg example runs on its own slime/miles Megatron
+image. The rollout half serves the model on a Blackwell SGLang build (fa4 /
+cutlass-dsl prerelease kernels + the tokenspeed MLA attention backend) that
+loads the served checkpoint's *own* quant config — there is no ``--quantization``
+flag baked in, so INT4 (slime/Kimi K2.6) vs NVFP4 (miles) is a property of the
+served checkpoint, not of this image. The per-trainer ``serving.py`` modules are
+thin wrappers that pass their trainer package + repo pin here.
+
+Two deliberate choices keep the image lean (identical for every trainer):
+
+  * **SGLang comes from the modal-projects/sglang fork** pinned below — the same
+    build the standalone 4xB200 Kimi deployment uses (proven for NVFP4; the INT4
+    MLA-MoE path is the one un-de-risked axis — verify on a warm container).
+  * **The trainer package is cloned ``--no-deps`` for one module.** The sidecar
+    only imports ``<trainer>.utils.disk_delta`` (stdlib + numpy + zstandard;
+    xxhash/blake3 lazy), so Megatron is intentionally absent — the pool never
+    trains. Pin the SAME ref the trainer image uses so the host-side delta
+    decoder matches the trainer's delta encoder.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import modal
+
+# Pinned Blackwell SGLang fork. Only the python sources are checked out over the
+# prebuilt base image's kernels.
+SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.12"
+SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
+SGLANG_FORK_BRANCH = "timmy/dflash-fa4-fp8"
+SGLANG_FORK_COMMIT = "dafb2b325b40298c5097564811463c585b7e9814"
+
+# SGLang runtime tunables carried over from the standalone B200 deployment.
+SERVING_IMAGE_ENV = {
+    "HF_XET_HIGH_PERFORMANCE": "1",
+    "HF_HUB_ENABLE_HF_TRANSFER": "1",
+    "SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN": "1",
+    "SGLANG_DISABLE_CUDNN_CHECK": "1",
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
+    "SGLANG_TIMEOUT_KEEP_ALIVE": "300",
+}
+
+
+def build_b200_serving_image(
+    *,
+    trainer_repo_url: str,
+    trainer_repo_ref: str,
+    trainer_root: str,
+    cookbook_dir: Path,
+    hf_cache_path: str,
+    experiment: str,
+    shallow_clone: bool = True,
+    clear_sglang_cache_at_end: bool = False,
+) -> modal.Image:
+    """Build the rollout-pool serving image (see module docstring).
+
+    ``trainer_repo_url`` / ``trainer_repo_ref`` / ``trainer_root`` pin the
+    ``--no-deps`` trainer checkout (so the pool's ``disk_delta`` matches the
+    trainer's encoder). ``cookbook_dir`` is the per-trainer cookbook package dir;
+    it is mounted at ``/root/cookbook/<name>`` exactly as the trainer image mounts
+    it, so ``cookbook.<name>.sidecar`` imports identically in either container.
+
+    ``shallow_clone`` does a ``--depth 1`` clone+fetch (fine when the ref is a
+    branch tip or recent commit). ``clear_sglang_cache_at_end`` removes
+    ``/root/.cache/sglang`` as the final filesystem step, required when
+    ``modal_train`` mounts a kernel-cache volume there (a volume can't mount over
+    a non-empty path).
+    """
+    depth = "--depth 1 " if shallow_clone else ""
+    fetch_depth = "--depth 1 " if shallow_clone else ""
+    image = (
+        modal.Image.from_registry(SGLANG_IMAGE_TAG)
+        .run_commands(
+            f"cd /sgl-workspace/sglang && git remote add modal-fork {SGLANG_FORK_REPO}"
+            f" && git fetch modal-fork {SGLANG_FORK_BRANCH}"
+            f" && git checkout {SGLANG_FORK_COMMIT} -- python/",
+        )
+        # Pre-release CUDA wheels (cutlass-dsl / sglang-kernel / flash-attn-4) —
+        # keep the deployment's known-good pip resolution.
+        .run_commands(
+            "pip install nvidia-cutlass-dsl==4.5.1 sglang-kernel==0.4.3 'flash-attn-4>=4.0.0b10'"
+        )
+        # flash-attn-4 checks for the deprecated MmaFP8Op but cutlass-dsl 4.5.1 now
+        # generates MmaF8F6F4Op instead. Patch the isinstance check to handle both.
+        .run_commands(
+            "sed -i 's/isinstance(op, tcgen05.mma.MmaFP8Op)/isinstance(op, (tcgen05.mma.MmaFP8Op, tcgen05.mma.MmaF8F6F4Op))/' "
+            "/usr/local/lib/python3.12/dist-packages/flash_attn/cute/blackwell_helpers.py"
+        )
+        # The base image bakes in an HF cache; remove it so it cannot shadow the
+        # cache volume mounted at the same path.
+        .run_commands(f"rm -rf {hf_cache_path}")
+        # trainer pkg --no-deps gives the sidecar `<trainer>.utils.disk_delta`
+        # (host-side delta apply). Megatron is NOT installed — the pool never
+        # trains. Pin the SAME ref the trainer image uses so encoder == decoder.
+        .run_commands(
+            f"git clone {depth}{trainer_repo_url} {trainer_root}"
+            f" && cd {trainer_root}"
+            f" && git fetch {fetch_depth}origin {trainer_repo_ref}"
+            f" && git checkout FETCH_HEAD"
+            f" && python3 -m pip install --no-deps -e {trainer_root}"
+        )
+        .pip_install(
+            "autoinference-utils==0.2.0",  # SGLang server lifecycle for the rollout pool
+            "fastapi",  # stitch sidecar
+            "httpx",  # stitch sidecar
+            "uvicorn",  # stitch sidecar
+            # disk_delta host-side apply: zstd decompress + xxhash (xxh3-128
+            # default) / blake3 checksums. trainer pkg is installed --no-deps.
+            "zstandard",
+            "xxhash",
+            "blake3",
+        )
+    )
+    if clear_sglang_cache_at_end:
+        # MUST be the last filesystem step: modal_train mounts a kernel-cache
+        # volume at /root/.cache/sglang, and a volume can't mount over a non-empty
+        # path. The sglang-kernel/flashinfer and trainer installs above populate
+        # this dir, so clear it AFTER them (the volume repopulates the JIT/
+        # autotuner cache on first boot).
+        image = image.run_commands("rm -rf /root/.cache/sglang")
+    return (
+        image.env({"EXPERIMENT_CONFIG": experiment, **SERVING_IMAGE_ENV})
+        # Mounted at container start (not copied into the image) so code edits to
+        # stitch / the sidecar never rebuild the image. Modal puts /root on
+        # PYTHONPATH for subprocesses (the sidecar).
+        .add_local_python_source("stitch")
+        .add_local_dir(
+            cookbook_dir,
+            remote_path=f"/root/cookbook/{cookbook_dir.name}",
+            ignore=["**/__pycache__"],
+        )
+    )

--- a/cookbook/sidecar.py
+++ b/cookbook/sidecar.py
@@ -1,0 +1,252 @@
+"""Shared SGLang weight-sync sidecar spine for the disagg cookbook trainers.
+
+The reusable versioned-proxy library lives in ``stitch.servers.sglang``; this
+module wires the concrete bulletin-board + Modal Volume + SGLang-disk-delta
+realization once, and the per-trainer ``cookbook/<trainer>/sidecar.py`` modules
+are thin adapters that select the host-side delta decoder.
+
+The ONLY axis that varies between trainers is the host-side ``disk_delta``
+module the rollout pool ships ``--no-deps`` (``slime.utils.disk_delta`` vs
+``miles.utils.disk_delta``). Their XOR/overwrite + zstd + xxh3/blake3 wire
+formats are byte-identical, but the pool image installs exactly one of them, so
+the adapter names which to import. Everything else — arg parsing, the bulletin
+board + Volume reloader, the base-materialization strategy — lives here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import hashlib
+import logging
+import os
+import shutil
+from typing import Callable
+
+from stitch.bulletin import FilesystemBulletinBoard
+from stitch.engines.sglang import SGLangDiskDeltaAdapter
+from stitch.servers.sglang import create_app
+from stitch.sync import CommitMode, WeightSyncManager
+
+
+logger = logging.getLogger(__name__)
+
+
+def parallel_init_local_checkpoint(disk_delta_module: str, workers: int = 32) -> Callable[[str, str], None]:
+    """Return an ``init_local_checkpoint(local, base)`` that copies the base
+    shards concurrently and skips the copy when the materialized base is current.
+
+    ``disk_delta``'s default seeds the local checkpoint one shard at a time with
+    ``shutil.copy2`` — fine for a 16 B Moonlight base, far too slow for K2.6's
+    ~591 GB. We reuse the decoder's apply-lock + applied-version bookkeeping so
+    ``apply_deltas`` stays compatible, and fall back to the decoder's own copier
+    if those internals move under us. ``disk_delta_module`` is the trainer's
+    decoder (``slime.utils.disk_delta`` / ``miles.utils.disk_delta``); both expose
+    the same internals (miles is forked from slime), so one implementation serves
+    both. Imported lazily so the module imports without slime/miles installed."""
+    import importlib
+
+    def _base_fingerprint(base_dir: str) -> str:
+        """Identity of the base's bytes: (filename, size, mtime_ns) over every shard. Re-prep
+        rewrites the shards (new mtime/size), so this changes even when the tensor index/shapes
+        don't — which is exactly the case that bit K2.6 (NVFP4 values changed, names didn't)."""
+        h = hashlib.sha256()
+        for e in sorted(os.scandir(base_dir), key=lambda e: e.name):
+            if e.is_file():
+                st = e.stat()
+                h.update(f"{e.name}:{st.st_size}:{st.st_mtime_ns}\n".encode())
+        return h.hexdigest()
+
+    def _init(local_ckpt_dir: str, base_dir: str) -> None:
+        dd = importlib.import_module(disk_delta_module)
+        try:
+            apply_lock = dd._apply_lock
+            read_version = dd._read_applied_version
+            write_version = dd._write_applied_version
+            drop_page_cache = dd.drop_page_cache
+        except AttributeError:  # decoder internals changed — use its own copier
+            dd.init_local_checkpoint(local_ckpt_dir, base_dir)
+            return
+
+        fp_path = os.path.join(local_ckpt_dir, ".base_fingerprint")
+        base_fp = _base_fingerprint(base_dir)
+        with apply_lock(local_ckpt_dir):
+            if read_version(local_ckpt_dir) is not None:
+                try:
+                    cur = open(fp_path).read().strip()
+                except FileNotFoundError:
+                    cur = None
+                if cur == base_fp:
+                    return  # current base already materialized
+                # STALE: /local-checkpoint holds a different (older) base — e.g. after a re-prep.
+                # Reusing it makes the host-side delta (diffed against the NEW base) XOR onto the
+                # WRONG bytes -> base_local XOR delta != export -> checksum mismatch on every tensor.
+                logger.warning(
+                    "stale /local-checkpoint (base changed: %s != %s) — wiping + re-materializing",
+                    cur, base_fp,
+                )
+                shutil.rmtree(local_ckpt_dir, ignore_errors=True)
+            logger.info("Materializing base %s -> %s (%d copy workers)", base_dir, local_ckpt_dir, workers)
+            os.makedirs(local_ckpt_dir, exist_ok=True)
+            files = [e for e in os.scandir(base_dir) if e.is_file()]
+
+            def _copy(entry: os.DirEntry) -> None:
+                shutil.copy2(entry.path, os.path.join(local_ckpt_dir, entry.name))
+                drop_page_cache(entry.path)  # don't evict the local copy we keep resident
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=min(workers, max(1, len(files)))) as ex:
+                for _ in ex.map(_copy, files):  # re-raises the first copy failure
+                    pass
+            write_version(local_ckpt_dir, "000000")
+            with open(fp_path, "w") as f:
+                f.write(base_fp)
+
+    return _init
+
+
+def build_manager(
+    *,
+    upstream_url: str,
+    bulletin_root: str,
+    local_checkpoint_dir: str,
+    base_checkpoint_dir: str,
+    disk_delta_module: str,
+    inject_apply_deltas: bool,
+    base_copy_workers: int = 32,
+    volume_name: str = "",
+    run_id: str | None = None,
+    commit_mode: CommitMode = "in_place",
+    debug_requests: bool = False,
+) -> WeightSyncManager:
+    """Build the reconciling :class:`WeightSyncManager` for one rollout replica.
+
+    ``disk_delta_module`` is the trainer's host-side decoder. ``inject_apply_deltas``
+    passes that module's ``apply_deltas`` to the engine explicitly — needed when the
+    decoder is not slime's default (miles), and harmless when it is. The base copy is
+    always the shared concurrent/stale-aware materializer.
+    """
+    import importlib
+
+    refresh = None
+    if volume_name:
+        from stitch.providers.modal import volume_reloader
+
+        refresh = volume_reloader(volume_name)
+    # Publish-only writes the flat slime-native layout (weight_v{N}/ +
+    # model.safetensors.index.json + a raw `latest` pointer) to the transport;
+    # miles writes the same layout, so layout="slime" reads either unchanged.
+    board = FilesystemBulletinBoard(bulletin_root, refresh=refresh, layout="slime")
+    apply_deltas = None
+    if inject_apply_deltas:
+        # The decoder is installed --no-deps in the serving image for exactly this
+        # module (Megatron is absent — the pool never trains). Pinned to the same
+        # trainer ref as the encoder so encoder == decoder.
+        apply_deltas = importlib.import_module(disk_delta_module).apply_deltas
+    engine = SGLangDiskDeltaAdapter(
+        upstream_url=upstream_url,
+        local_checkpoint_dir=local_checkpoint_dir,
+        base_checkpoint_dir=base_checkpoint_dir,
+        apply_deltas=apply_deltas,
+        init_local_checkpoint=parallel_init_local_checkpoint(disk_delta_module, base_copy_workers),
+    )
+    return WeightSyncManager(
+        board=board,
+        engine=engine,
+        run_id=run_id,
+        commit_mode=commit_mode,
+        debug_requests=debug_requests,
+    )
+
+
+def run_sidecar(*, disk_delta_module: str, inject_apply_deltas: bool) -> None:
+    """Parse args and run the sidecar uvicorn server.
+
+    The per-trainer adapter calls this with its decoder module; ``run_sidecar``
+    owns every other knob (host/port/transport/commit-mode/timeout/...).
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--upstream-url", required=True)
+    parser.add_argument(
+        "--bulletin-root",
+        default=os.environ.get("DELTA_BULLETIN_ROOT", "/delta-bulletin"),
+    )
+    parser.add_argument("--volume-name", default=os.environ.get("DELTA_VOLUME_NAME", ""))
+    parser.add_argument(
+        "--local-checkpoint-dir",
+        default=os.environ.get("STITCH_LOCAL_CHECKPOINT_DIR", "/local-checkpoint"),
+        help="Writable host-local full HF checkpoint patched in place by each delta.",
+    )
+    parser.add_argument(
+        "--base-checkpoint-dir",
+        default=os.environ.get("STITCH_BASE_CHECKPOINT_DIR"),
+        help="Base HF checkpoint the local copy is seeded from (deltas build on it).",
+    )
+    parser.add_argument("--run-id", default=os.environ.get("DISAGG_RUN_ID"))
+    parser.add_argument(
+        "--base-copy-workers",
+        type=int,
+        default=int(os.environ.get("SIDECAR_BASE_COPY_WORKERS", "32")),
+        help="Threads used to materialize the base checkpoint (concurrent shard copy).",
+    )
+    parser.add_argument(
+        "--commit-mode",
+        choices=("quiesce", "in_place"),
+        default=os.environ.get("SIDECAR_COMMIT_MODE", "in_place"),
+        help=(
+            "in_place (default): pause/apply/continue without flushing; in-flight "
+            "requests keep decoding on stale KV and version isolation comes from "
+            "extra_key stamping. quiesce: wait out active requests and flush "
+            "before applying (safe on any build)."
+        ),
+    )
+    parser.add_argument(
+        "--debug-requests",
+        action="store_true",
+        default=os.environ.get("SIDECAR_DEBUG_REQUESTS", "").lower() in {"1", "true", "yes"},
+        help="Log every versioned sidecar proxy request at INFO level.",
+    )
+    parser.add_argument(
+        "--upstream-timeout",
+        type=float,
+        default=float(os.environ.get("SIDECAR_UPSTREAM_TIMEOUT", "3600")),
+        help=(
+            "Seconds to wait for an upstream SGLang response before failing the "
+            "request (5xx) instead of holding it open forever. Must exceed the "
+            "slowest legitimate generation."
+        ),
+    )
+    args = parser.parse_args()
+    if not args.base_checkpoint_dir:
+        raise SystemExit(
+            "--base-checkpoint-dir/STITCH_BASE_CHECKPOINT_DIR is required: deltas are"
+            " applied host-side on top of a copy of this base HF checkpoint."
+        )
+
+    logging.basicConfig(level=logging.INFO)
+    import uvicorn
+
+    manager = build_manager(
+        upstream_url=args.upstream_url,
+        bulletin_root=args.bulletin_root,
+        local_checkpoint_dir=args.local_checkpoint_dir,
+        base_checkpoint_dir=args.base_checkpoint_dir,
+        disk_delta_module=disk_delta_module,
+        inject_apply_deltas=inject_apply_deltas,
+        base_copy_workers=args.base_copy_workers,
+        volume_name=args.volume_name,
+        run_id=args.run_id,
+        commit_mode=args.commit_mode,
+        debug_requests=args.debug_requests,
+    )
+    uvicorn.run(
+        create_app(
+            manager,
+            upstream_url=args.upstream_url,
+            upstream_timeout=args.upstream_timeout,
+        ),
+        host=args.host,
+        port=args.port,
+        log_level="info",
+    )

--- a/cookbook/sidecar_test.py
+++ b/cookbook/sidecar_test.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+from cookbook import sidecar
+
+
+def _install_fake_decoder(name: str, *, with_internals: bool) -> types.ModuleType:
+    """Register a fake ``disk_delta`` module in sys.modules.
+
+    ``with_internals=True`` exposes the apply-lock + applied-version bookkeeping
+    the concurrent copier reuses; False omits them so the copier falls back to the
+    decoder's own ``init_local_checkpoint``.
+    """
+    mod = types.ModuleType(name)
+
+    def init_local_checkpoint(local: str, base: str) -> None:
+        os.makedirs(local, exist_ok=True)
+        Path(local, ".fallback_used").write_text("1")
+
+    mod.init_local_checkpoint = init_local_checkpoint  # type: ignore[attr-defined]
+
+    if with_internals:
+        @contextlib.contextmanager
+        def _apply_lock(local: str):
+            yield
+
+        def _read_applied_version(local: str) -> str | None:
+            p = Path(local, ".applied_version")
+            return p.read_text().strip() if p.exists() else None
+
+        def _write_applied_version(local: str, version: str) -> None:
+            Path(local).mkdir(parents=True, exist_ok=True)
+            Path(local, ".applied_version").write_text(version)
+
+        mod._apply_lock = _apply_lock  # type: ignore[attr-defined]
+        mod._read_applied_version = _read_applied_version  # type: ignore[attr-defined]
+        mod._write_applied_version = _write_applied_version  # type: ignore[attr-defined]
+        mod.drop_page_cache = lambda path: None  # type: ignore[attr-defined]
+
+    sys.modules[name] = mod
+    return mod
+
+
+class ParallelInitLocalCheckpointTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.base = self.root / "base"
+        self.local = self.root / "local"
+        self.base.mkdir()
+        (self.base / "shard-0.safetensors").write_bytes(b"AAAA")
+        (self.base / "shard-1.safetensors").write_bytes(b"BBBB")
+        self._names: list[str] = []
+
+    def tearDown(self) -> None:
+        for n in self._names:
+            sys.modules.pop(n, None)
+        self._tmp.cleanup()
+
+    def _decoder(self, name: str, *, with_internals: bool = True) -> str:
+        self._names.append(name)
+        _install_fake_decoder(name, with_internals=with_internals)
+        return name
+
+    def test_copies_all_base_shards_and_records_fingerprint(self) -> None:
+        init = sidecar.parallel_init_local_checkpoint(self._decoder("fake_dd_copy"))
+        init(str(self.local), str(self.base))
+        self.assertEqual((self.local / "shard-0.safetensors").read_bytes(), b"AAAA")
+        self.assertEqual((self.local / "shard-1.safetensors").read_bytes(), b"BBBB")
+        self.assertTrue((self.local / ".base_fingerprint").exists())
+        self.assertEqual((self.local / ".applied_version").read_text(), "000000")
+
+    def test_skips_recopy_when_base_unchanged(self) -> None:
+        init = sidecar.parallel_init_local_checkpoint(self._decoder("fake_dd_skip"))
+        init(str(self.local), str(self.base))
+        # A delta would have patched the local copy in place; an unnecessary
+        # re-materialize would clobber it, so prove the second call is a no-op.
+        (self.local / "shard-0.safetensors").write_bytes(b"PATCHED")
+        init(str(self.local), str(self.base))
+        self.assertEqual((self.local / "shard-0.safetensors").read_bytes(), b"PATCHED")
+
+    def test_wipes_and_rematerializes_when_base_changed(self) -> None:
+        init = sidecar.parallel_init_local_checkpoint(self._decoder("fake_dd_stale"))
+        init(str(self.local), str(self.base))
+        (self.local / "stale-marker").write_text("x")
+        # Re-prep rewrites a base shard (new size/mtime) — fingerprint changes,
+        # so the stale local copy must be wiped and rebuilt against the new base.
+        (self.base / "shard-0.safetensors").write_bytes(b"CCCCCCCC")
+        init(str(self.local), str(self.base))
+        self.assertEqual((self.local / "shard-0.safetensors").read_bytes(), b"CCCCCCCC")
+        self.assertFalse((self.local / "stale-marker").exists())
+
+    def test_falls_back_to_decoder_copier_when_internals_missing(self) -> None:
+        init = sidecar.parallel_init_local_checkpoint(
+            self._decoder("fake_dd_fallback", with_internals=False)
+        )
+        init(str(self.local), str(self.base))
+        self.assertTrue((self.local / ".fallback_used").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cookbook/slime_disagg/helpers.py
+++ b/cookbook/slime_disagg/helpers.py
@@ -1,23 +1,19 @@
 """Trainer-specific helpers for the slime_disagg example.
 
-Ray cluster, sidecar, and process helpers are shared across trainers via
-:mod:`cookbook.ray_cluster` and :mod:`cookbook.sidecar_process`. This module
-provides slime-specific config preparation, train command building, and the
-Flash pool smoke check.
+Thin wrappers over the shared launch spine: Ray-cluster/sidecar/process helpers
+come from :mod:`cookbook.ray_cluster` / :mod:`cookbook.sidecar_process`, and
+config-prep / train-command / smoke-check come from :mod:`cookbook.trainer_helpers`.
+This module only supplies the slime-specific axes: the sidecar module path, the
+config-field tuple to materialize, the model-script attribute, and that the
+rollout pool runs with a warm floor (not scale-from-zero).
 """
 
 from __future__ import annotations
 
-import json
-import os
-import shlex
 import subprocess
-import time
-import urllib.error
-import urllib.request
 from typing import Any
 
-from stitch.providers.modal import discover_flash_targets, resolve_flash_gateway_url
+from cookbook.slime_disagg.configs.base import YAML_CONFIG_FIELDS
 
 # Re-export shared helpers so existing callers (modal_train.py) don't break.
 from cookbook.ray_cluster import (  # noqa: F401
@@ -31,6 +27,12 @@ from cookbook.ray_cluster import (  # noqa: F401
 from cookbook.sidecar_process import (  # noqa: F401
     terminate_process,
     wait_http,
+)
+from cookbook.trainer_helpers import (  # noqa: F401
+    VersionAheadError,
+    build_train_cmd as _build_train_cmd,
+    prepare_config,
+    smoke_flash_pool as _smoke_flash_pool,
 )
 
 
@@ -63,45 +65,14 @@ def start_sglang_sidecar(
     )
 
 
-# ── SLIME launch ──────────────────────────────────────────────────────────────
-
-
 def prepare_slime_config(slime_cfg: Any, tmpdir: str) -> None:
     """Resolve HF repo IDs to local paths and materialize inline YAML configs."""
-    from huggingface_hub import snapshot_download
-    import yaml
-
-    from cookbook.slime_disagg.configs.base import YAML_CONFIG_FIELDS
-
-    for attr in ("hf_checkpoint", "load", "ref_load", "critic_load"):
-        if (val := getattr(slime_cfg, attr, None)) and not str(val).startswith("/"):
-            setattr(slime_cfg, attr, snapshot_download(val, local_files_only=True))
-
-    for field in YAML_CONFIG_FIELDS:
-        if isinstance(val := getattr(slime_cfg, field, None), dict):
-            path = os.path.join(tmpdir, f"{field}.yaml")
-            with open(path, "w") as f:
-                yaml.dump(val, f)
-            setattr(slime_cfg, field, path)
+    prepare_config(slime_cfg, tmpdir, YAML_CONFIG_FIELDS)
 
 
 def build_train_cmd(slime_cfg: Any, slime_root: str) -> str:
-    """Build the training command, sourcing model arch args if needed."""
-    train_script = f"{slime_root}/{'train_async.py' if slime_cfg.async_mode else 'train.py'}"
-    if slime_cfg.slime_model_script:
-        inner = (
-            f"source {slime_root}/{slime_cfg.slime_model_script} && "
-            f"python3 {train_script} ${{MODEL_ARGS[@]}} {shlex.join(slime_cfg.cli_args())}"
-        )
-        return f"bash -c {shlex.quote(inner)}"
-    return f"python3 {train_script} {shlex.join(slime_cfg.cli_args())}"
-
-
-# ── Flash pool smoke check ────────────────────────────────────────────────────
-
-
-class VersionAheadError(RuntimeError):
-    """Raised when a monotonic rollout pool has already advanced past a smoke version."""
+    """Build the training command, sourcing slime's model arch args if needed."""
+    return _build_train_cmd(slime_cfg, slime_root, model_script_attr="slime_model_script")
 
 
 def smoke_flash_pool(
@@ -113,68 +84,13 @@ def smoke_flash_pool(
     expect_min_containers: int,
     timeout_seconds: int,
 ) -> None:
-    """Poll the Flash gateway and direct container URLs until the pool serves
-    completions at the expected weight version."""
-    deadline = time.time() + timeout_seconds
-    last_error: str | None = None
-    while True:
-        gateway = resolve_flash_gateway_url(app_name, cls_name)
-        targets = discover_flash_targets(app_name, cls_name)
-        if len(targets) < expect_min_containers:
-            last_error = f"expected at least {expect_min_containers} containers, found {len(targets)}: {targets}"
-        else:
-            try:
-                _check_flash_pool_once(gateway, targets, model_name, weight_version)
-                return
-            except VersionAheadError:
-                raise
-            except Exception as exc:  # noqa: BLE001
-                last_error = f"{type(exc).__name__}: {exc}"
-        if time.time() >= deadline:
-            raise TimeoutError(f"Flash pool smoke did not pass before timeout: {last_error}")
-        print(f"Waiting for Flash pool readiness: {last_error}")
-        time.sleep(10)
-
-
-def _check_flash_pool_once(gateway: str, targets: list[str], model_name: str, expected: int) -> None:
-    print(f"Gateway URL: {gateway}")
-    print(f"Direct container URLs ({len(targets)}):")
-    for target in targets:
-        print(f"  {target}")
-
-    for target in [gateway, *targets]:
-        info = _get_json(f"{target}/server_info", timeout=30)
-        print(f"{target} server_info={info}")
-        current = int(info["current_version"])
-        if current > expected:
-            raise VersionAheadError(f"{target} current_version={current} already passed expected {expected}")
-        if current != expected:
-            raise RuntimeError(f"{target} current_version={current} expected {expected}")
-
-    payload = {
-        "model": model_name,
-        "messages": [{"role": "user", "content": "Reply with exactly OK."}],
-        "max_tokens": 8,
-        "temperature": 0,
-        "weight_version": {"exact_version": expected},
-        "chat_template_kwargs": {"enable_thinking": False},
-    }
-    data = _post_json(f"{gateway}/v1/chat/completions", payload, timeout=180)
-    print(f"Gateway completion: {data}")
-    if int(data.get("weight_version_start", -1)) != expected or int(data.get("weight_version_end", -1)) != expected:
-        raise RuntimeError(f"unexpected gateway weight metadata: {data}")
-
-
-def _get_json(url: str, *, timeout: float) -> dict:
-    with urllib.request.urlopen(url, timeout=timeout) as resp:
-        return json.load(resp)
-
-
-def _post_json(url: str, payload: dict, *, timeout: float) -> dict:
-    request = urllib.request.Request(
-        url,
-        data=json.dumps(payload).encode(),
-        headers={"Content-Type": "application/json"},
+    """Smoke the warm-floor slime rollout pool (min_containers > 0)."""
+    _smoke_flash_pool(
+        app_name=app_name,
+        cls_name=cls_name,
+        model_name=model_name,
+        weight_version=weight_version,
+        expect_min_containers=expect_min_containers,
+        timeout_seconds=timeout_seconds,
+        wake_on_demand=False,
     )
-    with urllib.request.urlopen(request, timeout=timeout) as resp:
-        return json.load(resp)

--- a/cookbook/slime_disagg/modal_train.py
+++ b/cookbook/slime_disagg/modal_train.py
@@ -113,11 +113,14 @@ image = (
     # Local source is mounted when containers start rather than copied into the
     # image, so code changes never trigger an image rebuild. Modal puts /root
     # on PYTHONPATH, which also makes both packages importable from
-    # subprocesses (the sidecar, Ray workers).
+    # subprocesses (the sidecar, Ray workers). The whole cookbook package is
+    # mounted (not just the per-trainer subdir) so the trainer and the
+    # `python3 -m cookbook.slime_disagg.sidecar` subprocess can import the shared
+    # cookbook spine (helpers/hooks/sidecar) the thin adapters delegate to.
     .add_local_python_source("stitch")
     .add_local_dir(
-        Path(__file__).parent,
-        remote_path="/root/cookbook/slime_disagg",
+        Path(__file__).parent.parent,
+        remote_path="/root/cookbook",
         ignore=["**/__pycache__"],
     )
 )

--- a/cookbook/slime_disagg/serving.py
+++ b/cookbook/slime_disagg/serving.py
@@ -1,26 +1,10 @@
-"""Dedicated B200 native-INT4 SGLang serving image for the rollout pool.
+"""Dedicated B200 native-INT4 SGLang serving image for the slime rollout pool.
 
-The trainer half of this example runs on the slime/Megatron image
-(``modal_train.image``). The rollout half that serves Kimi K2.6 needs a
-different stack: a Blackwell SGLang build that loads the model's native
-compressed-tensors INT4 (W4A16) checkpoint and runs MLA attention with the
-tuned hierarchical KV cache. This module builds that image.
-
-Two deliberate choices keep it lean:
-
-  * **SGLang comes from the modal-projects/sglang fork** (Blackwell fa4 /
-    cutlass-dsl prerelease kernels + the tokenspeed MLA attention backend) — the
-    same build the standalone 4xB200 Kimi deployment uses. The FP4-specific
-    ``--quantization modelopt_fp4`` is *not* baked in here; the served
-    checkpoint's own ``compressed-tensors`` config drives INT4 weight loading
-    (see the config module's ``SGLANG_SERVER_ARGS``).
-  * **slime is cloned ``--no-deps`` for one module.** The sidecar only imports
-    ``slime.utils.disk_delta`` (stdlib + numpy + zstandard; xxhash/blake3 lazy),
-    so Megatron is intentionally absent from the rollout pool.
-
-The single un-de-risked axis is whether this fork serves native-INT4 MLA MoE on
-Blackwell as cleanly as it serves NVFP4 (it is proven for NVFP4). Verify on a
-warm container before a long run; the FP4 path is the known-good fallback.
+A thin wrapper over :func:`cookbook.serving.build_b200_serving_image`. The image
+itself is trainer-agnostic (see that module): INT4 vs NVFP4 is driven by the
+served checkpoint's own ``compressed-tensors`` config, not by this builder. This
+wrapper only pins slime as the ``--no-deps`` decoder package and does a shallow
+clone (the slime ref is a branch-tip commit).
 """
 
 from __future__ import annotations
@@ -29,22 +13,7 @@ from pathlib import Path
 
 import modal
 
-# Pinned Blackwell SGLang fork — matches the standalone 4xB200 Kimi serve recipe.
-# Only the python sources are checked out over the prebuilt base image's kernels.
-SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.12"
-SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
-SGLANG_FORK_BRANCH = "timmy/dflash-fa4-fp8"
-SGLANG_FORK_COMMIT = "dafb2b325b40298c5097564811463c585b7e9814"
-
-# SGLang runtime tunables carried over from the standalone B200 deployment.
-SERVING_IMAGE_ENV = {
-    "HF_XET_HIGH_PERFORMANCE": "1",
-    "HF_HUB_ENABLE_HF_TRANSFER": "1",
-    "SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN": "1",
-    "SGLANG_DISABLE_CUDNN_CHECK": "1",
-    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
-    "SGLANG_TIMEOUT_KEEP_ALIVE": "300",
-}
+from cookbook.serving import build_b200_serving_image
 
 
 def build_int4_b200_serving_image(
@@ -55,66 +24,12 @@ def build_int4_b200_serving_image(
     hf_cache_path: str,
     experiment: str,
 ) -> modal.Image:
-    """Build the rollout-pool serving image (see module docstring).
-
-    The slime fork ref / root and the HF cache path are passed in by
-    ``modal_train`` so the pool and the trainer pin the identical slime commit
-    (the sidecar's ``disk_delta`` must match the trainer's delta encoder).
-    """
-    # serving.py lives in cookbook/slime_disagg, mounted to /root/cookbook/slime_disagg
-    # exactly as the trainer image mounts it, so `cookbook.slime_disagg.sidecar`
-    # imports identically in either container.
-    slime_disagg_dir = Path(__file__).parent
-    return (
-        modal.Image.from_registry(SGLANG_IMAGE_TAG)
-        .run_commands(
-            f"cd /sgl-workspace/sglang && git remote add modal-fork {SGLANG_FORK_REPO}"
-            f" && git fetch modal-fork {SGLANG_FORK_BRANCH}"
-            f" && git checkout {SGLANG_FORK_COMMIT} -- python/",
-        )
-        # Pre-release CUDA wheels (cutlass-dsl / sglang-kernel / flash-attn-4) —
-        # keep the deployment's known-good pip resolution.
-        .run_commands(
-            "pip install nvidia-cutlass-dsl==4.5.1 sglang-kernel==0.4.3 'flash-attn-4>=4.0.0b10'"
-        )
-        # flash-attn-4 checks for the deprecated MmaFP8Op but cutlass-dsl 4.5.1 now
-        # generates MmaF8F6F4Op instead. Patch the isinstance check to handle both.
-        .run_commands(
-            "sed -i 's/isinstance(op, tcgen05.mma.MmaFP8Op)/isinstance(op, (tcgen05.mma.MmaFP8Op, tcgen05.mma.MmaF8F6F4Op))/' "
-            "/usr/local/lib/python3.12/dist-packages/flash_attn/cute/blackwell_helpers.py"
-        )
-        # The base image bakes in an HF cache; remove it so it cannot shadow the
-        # cache volume mounted at the same path.
-        .run_commands(f"rm -rf {hf_cache_path}")
-        # slime --no-deps gives the sidecar `slime.utils.disk_delta` (host-side
-        # delta apply). Megatron is NOT installed — the pool never trains. Pin the
-        # SAME ref the trainer image uses so the delta encoder/decoder match.
-        .run_commands(
-            f"git clone --depth 1 {slime_repo_url} {slime_root}"
-            f" && cd {slime_root}"
-            f" && git fetch --depth 1 origin {slime_repo_ref}"
-            f" && git checkout FETCH_HEAD"
-            f" && python3 -m pip install --no-deps -e {slime_root}"
-        )
-        .pip_install(
-            "autoinference-utils==0.2.0",  # SGLang server lifecycle for the rollout pool
-            "fastapi",  # stitch sidecar
-            "httpx",  # stitch sidecar
-            "uvicorn",  # stitch sidecar
-            # disk_delta host-side apply: zstd decompress + xxhash (xxh3-128
-            # default) / blake3 checksums. slime is installed --no-deps.
-            "zstandard",
-            "xxhash",
-            "blake3",
-        )
-        .env({"EXPERIMENT_CONFIG": experiment, **SERVING_IMAGE_ENV})
-        # Mounted at container start (not copied into the image) so code edits to
-        # stitch / the sidecar never rebuild the image. Modal puts /root on
-        # PYTHONPATH for subprocesses (the sidecar).
-        .add_local_python_source("stitch")
-        .add_local_dir(
-            slime_disagg_dir,
-            remote_path="/root/cookbook/slime_disagg",
-            ignore=["**/__pycache__"],
-        )
+    return build_b200_serving_image(
+        trainer_repo_url=slime_repo_url,
+        trainer_repo_ref=slime_repo_ref,
+        trainer_root=slime_root,
+        cookbook_dir=Path(__file__).parent,
+        hf_cache_path=hf_cache_path,
+        experiment=experiment,
+        shallow_clone=True,
     )

--- a/cookbook/slime_disagg/sidecar.py
+++ b/cookbook/slime_disagg/sidecar.py
@@ -1,137 +1,21 @@
-"""SGLang weight-sync sidecar launcher for the slime_disagg example.
+"""SGLang weight-sync sidecar entry point for the slime_disagg example.
 
-The reusable versioned-proxy library lives in ``stitch.servers.sglang``; this
-module wires the concrete bulletin-board + Modal Volume + SGLang-disk-delta
-realization and runs it as a process (``helpers.start_sglang_sidecar`` launches
-``python3 -m cookbook.slime_disagg.sidecar``).
+A thin adapter over :mod:`cookbook.sidecar`: the shared spine owns every knob;
+this only names slime's host-side delta decoder. ``helpers.start_sglang_sidecar``
+launches it via ``python3 -m cookbook.slime_disagg.sidecar``.
 """
 
 from __future__ import annotations
 
-import argparse
-import logging
-import os
-
-from stitch.bulletin import FilesystemBulletinBoard
-from stitch.engines.sglang import SGLangDiskDeltaAdapter
-from stitch.servers.sglang import create_app
-from stitch.sync import CommitMode, WeightSyncManager
+from cookbook.sidecar import run_sidecar
 
 
-def build_manager(
-    *,
-    upstream_url: str,
-    bulletin_root: str,
-    local_checkpoint_dir: str,
-    base_checkpoint_dir: str,
-    volume_name: str = "",
-    run_id: str | None = None,
-    commit_mode: CommitMode = "in_place",
-    debug_requests: bool = False,
-) -> WeightSyncManager:
-    refresh = None
-    if volume_name:
-        from stitch.providers.modal import volume_reloader
-
-        refresh = volume_reloader(volume_name)
-    # slime publish-only writes the flat slime-native layout (weight_v{N}/ +
-    # model.safetensors.index.json + a raw `latest` pointer) to the Volume.
-    board = FilesystemBulletinBoard(bulletin_root, refresh=refresh, layout="slime")
-    engine = SGLangDiskDeltaAdapter(
-        upstream_url=upstream_url,
-        local_checkpoint_dir=local_checkpoint_dir,
-        base_checkpoint_dir=base_checkpoint_dir,
-    )
-    return WeightSyncManager(
-        board=board,
-        engine=engine,
-        run_id=run_id,
-        commit_mode=commit_mode,
-        debug_requests=debug_requests,
-    )
+# slime's decoder is the engine's lazy default, so it need not be injected.
+DISK_DELTA_MODULE = "slime.utils.disk_delta"
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--host", default="0.0.0.0")
-    parser.add_argument("--port", type=int, default=8000)
-    parser.add_argument("--upstream-url", required=True)
-    parser.add_argument(
-        "--bulletin-root",
-        default=os.environ.get("DELTA_BULLETIN_ROOT", "/delta-bulletin"),
-    )
-    parser.add_argument(
-        "--volume-name", default=os.environ.get("DELTA_VOLUME_NAME", "")
-    )
-    parser.add_argument(
-        "--local-checkpoint-dir",
-        default=os.environ.get("STITCH_LOCAL_CHECKPOINT_DIR", "/local-checkpoint"),
-        help="Writable host-local full HF checkpoint patched in place by each delta.",
-    )
-    parser.add_argument(
-        "--base-checkpoint-dir",
-        default=os.environ.get("STITCH_BASE_CHECKPOINT_DIR"),
-        help="Base HF checkpoint the local copy is seeded from (deltas build on it).",
-    )
-    parser.add_argument("--run-id", default=os.environ.get("DISAGG_RUN_ID"))
-    parser.add_argument(
-        "--commit-mode",
-        choices=("quiesce", "in_place"),
-        default=os.environ.get("SIDECAR_COMMIT_MODE", "in_place"),
-        help=(
-            "in_place (default): pause/apply/continue without flushing; "
-            "in-flight requests keep decoding on stale KV and version isolation "
-            "comes from extra_key stamping. quiesce: wait out active requests "
-            "and flush before applying."
-        ),
-    )
-    parser.add_argument(
-        "--debug-requests",
-        action="store_true",
-        default=os.environ.get("SIDECAR_DEBUG_REQUESTS", "").lower()
-        in {"1", "true", "yes"},
-        help="Log every versioned sidecar proxy request at INFO level.",
-    )
-    parser.add_argument(
-        "--upstream-timeout",
-        type=float,
-        default=float(os.environ.get("SIDECAR_UPSTREAM_TIMEOUT", "3600")),
-        help=(
-            "Seconds to wait for an upstream SGLang response before failing the "
-            "request (5xx) instead of holding it open forever. Must exceed the "
-            "slowest legitimate generation."
-        ),
-    )
-    args = parser.parse_args()
-    if not args.base_checkpoint_dir:
-        raise SystemExit(
-            "--base-checkpoint-dir/STITCH_BASE_CHECKPOINT_DIR is required: deltas are"
-            " applied host-side on top of a copy of this base HF checkpoint."
-        )
-
-    logging.basicConfig(level=logging.INFO)
-    import uvicorn
-
-    manager = build_manager(
-        upstream_url=args.upstream_url,
-        bulletin_root=args.bulletin_root,
-        local_checkpoint_dir=args.local_checkpoint_dir,
-        base_checkpoint_dir=args.base_checkpoint_dir,
-        volume_name=args.volume_name,
-        run_id=args.run_id,
-        commit_mode=args.commit_mode,
-        debug_requests=args.debug_requests,
-    )
-    uvicorn.run(
-        create_app(
-            manager,
-            upstream_url=args.upstream_url,
-            upstream_timeout=args.upstream_timeout,
-        ),
-        host=args.host,
-        port=args.port,
-        log_level="info",
-    )
+    run_sidecar(disk_delta_module=DISK_DELTA_MODULE, inject_apply_deltas=False)
 
 
 if __name__ == "__main__":

--- a/cookbook/standalone_rollouts/slime/hooks.py
+++ b/cookbook/standalone_rollouts/slime/hooks.py
@@ -24,6 +24,9 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
+from cookbook.rollout_control import apply_session_affinity
+from cookbook.rollout_control import distributed_rank as _distributed_rank
+from cookbook.rollout_control import read_setting as _setting
 from stitch.protocol import RolloutPoolState, parse_weight_identity, weight_identity
 
 
@@ -198,6 +201,37 @@ def announce_and_wait(args: Any, version_dir: str, rollout_engines: list[Any]) -
     )
 
 
+def announce_claim(args: Any, *, run_id: str) -> None:
+    """Trainer launch hook (rank 0): claim the rollout pool for this run via the
+    front door, the standalone counterpart to :func:`cookbook.bulletin_hooks.claim_pool`.
+
+    POST the empty pointer (``weight_v000000``) under a fresh ``run_id`` so the
+    front door's cross-run :func:`decide_pointer_move` resets ``latest`` to base
+    *before* the first delta — every replica (cold, or warm on a finished run)
+    reconciles to base up front instead of inferring the reset from the first
+    publish's run mismatch. Best-effort and non-blocking: the pool may be scaled
+    to zero at launch, and the first :func:`announce_and_wait` already blocks on
+    readiness, so a transient claim failure costs only the early reset, not
+    correctness. ``run_id`` must be fresh per launch (the epoch/fence token).
+    """
+    if _distributed_rank() not in (None, 0):
+        return
+    cfg = replace(ShimConfig.from_env(args), run_id=run_id)
+    try:
+        _post_hot_load(
+            cfg,
+            identity=weight_identity(0),
+            previous_identity=cfg.base_snapshot_identity,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Best-effort pool claim failed for run %r; the first publish's "
+            "cross-run reset will still establish base",
+            run_id,
+            exc_info=True,
+        )
+
+
 def rollout_request_weight_version_hook(
     args: Any, sample: Any, request: dict[str, Any]
 ) -> None:
@@ -270,17 +304,16 @@ def rollout_request_weight_version_hook(
         headers["Provider-Model"] = cfg.provider_model
     if cfg.provider_deployment:
         headers["Provider-Deployment"] = cfg.provider_deployment
-    if getattr(sample, "session_id", None):
-        # Neutral by default. The front-door relabel proxy maps this to
-        # Modal-Session-ID before the gateway.
-        affinity_header = _setting(
-            args,
-            "api_shim_session_affinity_header",
-            "STITCH_SHIM_SESSION_AFFINITY_HEADER",
-            default="x-session-affinity",
-        )
-        headers.setdefault(affinity_header, sample.session_id)
     request["headers"] = headers
+    # Neutral by default. The front-door relabel proxy maps this to
+    # Modal-Session-ID before the gateway.
+    affinity_header = _setting(
+        args,
+        "api_shim_session_affinity_header",
+        "STITCH_SHIM_SESSION_AFFINITY_HEADER",
+        default="x-session-affinity",
+    )
+    apply_session_affinity(request, getattr(sample, "session_id", None), affinity_header)
 
 
 def _rollout_request_target_version(args: Any, rollout_id: int, evaluation: bool) -> int:
@@ -413,32 +446,4 @@ def _copy_version_to_transport(version_dir: Path, destination: Path) -> None:
             shutil.copyfileobj(src, dst)
 
 
-def _distributed_rank() -> int | None:
-    try:
-        import torch.distributed as dist
 
-        if dist.is_available() and dist.is_initialized():
-            return int(dist.get_rank())
-    except Exception:  # noqa: BLE001
-        return None
-    return None
-
-
-def _setting(
-    args: Any | None,
-    attr: str,
-    env: str,
-    *,
-    default: str | None = None,
-    required: bool = False,
-) -> str:
-    value = getattr(args, attr, None) if args is not None else None
-    if value is None:
-        value = os.environ.get(env)
-    if value is None:
-        value = default
-    if value is None and required:
-        raise RuntimeError(
-            f"Missing required setting {attr!r} or environment variable {env}"
-        )
-    return str(value) if value is not None else ""

--- a/cookbook/standalone_rollouts/slime/hooks_test.py
+++ b/cookbook/standalone_rollouts/slime/hooks_test.py
@@ -89,6 +89,46 @@ class AnnounceAndWaitTest(unittest.TestCase):
         self.assertEqual(posted, [])
 
 
+class AnnounceClaimTest(unittest.TestCase):
+    def test_posts_base_pointer_under_fresh_run_on_rank_zero(self) -> None:
+        # Claim-at-launch parity with bulletin_hooks.claim_pool: POST the empty
+        # pointer (weight_v000000) under the fresh run id so the front door resets
+        # latest to base before the first delta.
+        posted: list[tuple[str | None, str, str]] = []
+
+        def fake_post(cfg, *, identity, previous_identity) -> None:
+            posted.append((cfg.run_id, identity, previous_identity))
+
+        args = Namespace(api_shim_base_url="http://provider")
+        with mock.patch.object(hooks, "_distributed_rank", return_value=0), mock.patch.object(
+            hooks, "_post_hot_load", fake_post
+        ):
+            hooks.announce_claim(args, run_id="run-a")
+        self.assertEqual(posted, [("run-a", "weight_v000000", "base")])
+
+    def test_is_noop_off_rank_zero(self) -> None:
+        posted: list[int] = []
+        args = Namespace(api_shim_base_url="http://provider")
+        with mock.patch.object(hooks, "_distributed_rank", return_value=1), mock.patch.object(
+            hooks, "_post_hot_load", lambda *a, **k: posted.append(1)
+        ):
+            hooks.announce_claim(args, run_id="run-a")
+        self.assertEqual(posted, [])
+
+    def test_swallows_claim_failure(self) -> None:
+        # Best-effort: a transient claim POST failure must not kill the launch
+        # (the first publish's cross-run reset still establishes base).
+        args = Namespace(api_shim_base_url="http://provider")
+
+        def boom(*a, **k) -> None:
+            raise RuntimeError("front door down")
+
+        with mock.patch.object(hooks, "_distributed_rank", return_value=0), mock.patch.object(
+            hooks, "_post_hot_load", boom
+        ):
+            hooks.announce_claim(args, run_id="run-a")  # must not raise
+
+
 class RolloutRequestHookTest(unittest.TestCase):
     def test_skips_pin_without_rollout_id_but_sets_affinity(self) -> None:
         # PR #5's request carries no rollout_id: the hook must not crash, must

--- a/cookbook/standalone_rollouts/slime/modal_train.py
+++ b/cookbook/standalone_rollouts/slime/modal_train.py
@@ -18,6 +18,7 @@ import modal
 import modal.experimental
 
 from cookbook.standalone_rollouts import modal_serve as provider_app
+from cookbook.standalone_rollouts.slime import hooks
 from cookbook.slime_disagg import helpers
 from cookbook.slime_disagg.configs.base import (
     CHECKPOINTS_PATH,
@@ -199,6 +200,11 @@ class Trainer:
         cfg.custom_config_path = _custom_config(
             cfg, rollout_num_engines=getattr(run, "ROLLOUT_NUM_ENGINES", 1)
         )
+        # Claim the pool for this fresh run before any delta: reset `latest` to
+        # base via the front door so replicas reconcile to base up front instead
+        # of inferring the reset from the first publish (the explicit-claim model
+        # PR #5 established for the bulletin path, now mirrored here).
+        hooks.announce_claim(cfg, run_id=run_id)
         helpers.prepare_slime_config(cfg, tempfile.mkdtemp())
         cmd = helpers.build_train_cmd(cfg, SLIME_ROOT)
 

--- a/cookbook/trainer_helpers.py
+++ b/cookbook/trainer_helpers.py
@@ -1,0 +1,271 @@
+"""Shared trainer-side launch helpers for the disagg cookbook trainers.
+
+slime and miles drive the same launch spine: resolve HF repo ids + materialize
+inline YAML configs, build the ``train.py`` command (optionally sourcing a model
+arch script), monitor host RAM, and smoke the deployed Flash rollout pool. The
+per-trainer ``helpers.py`` modules are thin wrappers that supply the only axes
+that actually differ: which config-field tuple to materialize, the model-script
+attribute name, and whether the rollout pool has a warm floor or scales from zero.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import socket
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Iterable
+
+from stitch.providers.modal import discover_flash_targets, resolve_flash_gateway_url
+
+
+# ── Config preparation ────────────────────────────────────────────────────────
+
+
+def prepare_config(cfg: Any, tmpdir: str, yaml_config_fields: Iterable[str]) -> None:
+    """Resolve HF repo IDs to local paths and materialize inline YAML configs.
+
+    Repo-id-shaped checkpoint fields are snapshot-downloaded from the HF cache;
+    absolute paths (already-prepared checkpoints) are left untouched. Inline dict
+    configs in ``yaml_config_fields`` are written to ``tmpdir`` and the field is
+    repointed at the file the trainer reads.
+    """
+    from huggingface_hub import snapshot_download
+    import yaml
+
+    for attr in ("hf_checkpoint", "load", "ref_load", "critic_load"):
+        if (val := getattr(cfg, attr, None)) and not str(val).startswith("/"):
+            setattr(cfg, attr, snapshot_download(val, local_files_only=True))
+
+    for field in yaml_config_fields:
+        if isinstance(val := getattr(cfg, field, None), dict):
+            path = os.path.join(tmpdir, f"{field}.yaml")
+            with open(path, "w") as f:
+                yaml.dump(val, f)
+            setattr(cfg, field, path)
+
+
+def materialize_node_local_yaml(cfg: Any, field: str, dest_dir: str = "/root/.miles_node_yaml") -> None:
+    """Materialize a per-actor-read YAML config to a deterministic node-local path.
+
+    Some config files (notably miles' ``te_precision_config_file``, which
+    ``load_quantization_recipe`` re-reads on every Ray actor during model build)
+    are read independently on each trainer node — not just parsed once on the head.
+    ``prepare_config`` writes them under ``tempfile.mkdtemp()`` on the head only,
+    so on a multi-node cluster the other containers can't see that path.
+
+    Call this on EVERY node (SPMD train()), before the rank-0 gate: each node
+    writes identical content (from the shared payload) to the same fixed path, so
+    the path the head embeds in the args resolves locally on all actors. No volume
+    commit/reload race — Ray actors are long-lived and wouldn't see post-start
+    volume writes anyway.
+    """
+    import yaml
+
+    if isinstance(val := getattr(cfg, field, None), dict):
+        os.makedirs(dest_dir, exist_ok=True)
+        path = os.path.join(dest_dir, f"{field}.yaml")
+        with open(path, "w") as f:
+            yaml.dump(val, f)
+        setattr(cfg, field, path)
+
+
+def build_train_cmd(cfg: Any, trainer_root: str, *, model_script_attr: str) -> str:
+    """Build the training command, sourcing model arch args if needed.
+
+    slime/miles ``train.py`` / ``train_async.py`` live at the repo root and consume
+    the ``MODEL_ARGS`` bash array defined by the sourced model script.
+    ``model_script_attr`` is the config attribute naming that script
+    (``slime_model_script`` / ``miles_model_script``).
+    """
+    train_script = f"{trainer_root}/{'train_async.py' if cfg.async_mode else 'train.py'}"
+    model_script = getattr(cfg, model_script_attr)
+    if model_script:
+        inner = (
+            f"source {trainer_root}/{model_script} && "
+            f"python3 {train_script} ${{MODEL_ARGS[@]}} {shlex.join(cfg.cli_args())}"
+        )
+        return f"bash -c {shlex.quote(inner)}"
+    return f"python3 {train_script} {shlex.join(cfg.cli_args())}"
+
+
+# ── Flash pool smoke check ────────────────────────────────────────────────────
+
+
+class VersionAheadError(RuntimeError):
+    """Raised when a monotonic rollout pool has already advanced past a smoke version."""
+
+
+def smoke_flash_pool(
+    *,
+    app_name: str,
+    cls_name: str,
+    model_name: str,
+    weight_version: int,
+    expect_min_containers: int,
+    timeout_seconds: int,
+    wake_on_demand: bool,
+) -> None:
+    """Poll the Flash gateway until the pool serves completions at the expected
+    weight version, via the gateway and each container directly.
+
+    ``wake_on_demand`` chooses the readiness model. False (warm floor): require
+    ``expect_min_containers`` live containers, then check each, then complete via
+    the gateway. True (scale-from-zero): a completion sent to the gateway is what
+    scales the pool 0->1 (Flash holds the request through the cold start, so the
+    timeout must be generous); ``expect_min_containers`` is advisory and the
+    direct-container check confirms the warmed pool afterward.
+    """
+    deadline = time.time() + timeout_seconds
+    last_error: str | None = None
+    while True:
+        try:
+            if wake_on_demand:
+                _smoke_wake_on_demand(app_name, cls_name, model_name, weight_version)
+            else:
+                _smoke_warm_floor(app_name, cls_name, model_name, weight_version, expect_min_containers)
+            return
+        except VersionAheadError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            last_error = f"{type(exc).__name__}: {exc}"
+        if time.time() >= deadline:
+            raise TimeoutError(f"Flash pool smoke did not pass before timeout: {last_error}")
+        print(f"Waiting for Flash pool readiness: {last_error}")
+        time.sleep(10)
+
+
+def _smoke_warm_floor(
+    app_name: str, cls_name: str, model_name: str, expected: int, expect_min_containers: int
+) -> None:
+    gateway = resolve_flash_gateway_url(app_name, cls_name)
+    targets = discover_flash_targets(app_name, cls_name)
+    if len(targets) < expect_min_containers:
+        raise RuntimeError(
+            f"expected at least {expect_min_containers} containers, found {len(targets)}: {targets}"
+        )
+    print(f"Gateway URL: {gateway}")
+    print(f"Direct container URLs ({len(targets)}):")
+    for target in targets:
+        print(f"  {target}")
+    _assert_containers_at_version([gateway, *targets], expected)
+    _assert_gateway_completion_exact(gateway, model_name, expected)
+
+
+def _smoke_wake_on_demand(app_name: str, cls_name: str, model_name: str, expected: int) -> None:
+    gateway = resolve_flash_gateway_url(app_name, cls_name)
+    print(f"Gateway URL: {gateway}")
+    # Wake the (scaled-to-zero) pool and wait for a container to serve. Flash
+    # holds the request through the cold start, so the timeout must exceed it.
+    data = _post_json(f"{gateway}/v1/chat/completions", _completion_payload(model_name, expected), timeout=900)
+    print(f"Gateway completion: {data}")
+    start, end = int(data.get("weight_version_start", -1)), int(data.get("weight_version_end", -1))
+    if start > expected or end > expected:
+        raise VersionAheadError(f"gateway served version {start}->{end}, already past expected {expected}")
+    if start != expected or end != expected:
+        raise RuntimeError(f"unexpected gateway weight metadata: {data}")
+    # The pool is warm now; confirm each live container reports the version.
+    targets = discover_flash_targets(app_name, cls_name)
+    print(f"Direct container URLs ({len(targets)}):")
+    _assert_containers_at_version([gateway, *targets], expected)
+
+
+def _assert_containers_at_version(targets: list[str], expected: int) -> None:
+    for target in targets:
+        info = _get_json(f"{target}/server_info", timeout=30)
+        print(f"{target} server_info={info}")
+        current = int(info["current_version"])
+        if current > expected:
+            raise VersionAheadError(f"{target} current_version={current} already passed expected {expected}")
+        if current != expected:
+            raise RuntimeError(f"{target} current_version={current} expected {expected}")
+
+
+def _assert_gateway_completion_exact(gateway: str, model_name: str, expected: int) -> None:
+    data = _post_json(f"{gateway}/v1/chat/completions", _completion_payload(model_name, expected), timeout=180)
+    print(f"Gateway completion: {data}")
+    if int(data.get("weight_version_start", -1)) != expected or int(data.get("weight_version_end", -1)) != expected:
+        raise RuntimeError(f"unexpected gateway weight metadata: {data}")
+
+
+def _completion_payload(model_name: str, expected: int) -> dict:
+    return {
+        "model": model_name,
+        "messages": [{"role": "user", "content": "Reply with exactly OK."}],
+        "max_tokens": 8,
+        "temperature": 0,
+        "weight_version": {"exact_version": expected},
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+
+def _get_json(url: str, *, timeout: float) -> dict:
+    with urllib.request.urlopen(url, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def _post_json(url: str, payload: dict, *, timeout: float) -> dict:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+# ── Host-RAM monitor ──────────────────────────────────────────────────────────
+
+
+def start_host_mem_monitor(interval_s: int = 20) -> None:
+    """Log this node's host-RAM trajectory to stdout from a daemon thread.
+
+    The trainer can OOM-kill on host-RAM exhaustion (the publish/update_weights
+    full-model gather is the peak consumer), but Megatron only reports GPU memory
+    and the kill leaves no durable peak behind. This logs MemTotal/MemAvailable +
+    the container cgroup usage every ``interval_s`` so a live ``modal app logs -f``
+    shows exactly which phase blows a big node and how high it peaks. Runs on EVERY
+    node (called from the SPMD enter()), so whichever rank OOMs has its own trace.
+    Best-effort: never raises."""
+    host = socket.gethostname()
+
+    def _meminfo() -> tuple[float, float]:
+        total = avail = 0.0
+        try:
+            with open("/proc/meminfo") as f:
+                for line in f:
+                    if line.startswith("MemTotal:"):
+                        total = int(line.split()[1]) / 1024 / 1024  # GiB
+                    elif line.startswith("MemAvailable:"):
+                        avail = int(line.split()[1]) / 1024 / 1024
+        except Exception:  # noqa: BLE001
+            pass
+        return total, avail
+
+    def _cgroup_used_gib() -> float:
+        for path in ("/sys/fs/cgroup/memory.current",  # cgroup v2
+                     "/sys/fs/cgroup/memory/memory.usage_in_bytes"):  # v1
+            try:
+                with open(path) as f:
+                    return int(f.read().strip()) / 1024**3
+            except Exception:  # noqa: BLE001
+                continue
+        return -1.0
+
+    def _loop() -> None:
+        while True:
+            total, avail = _meminfo()
+            used = total - avail
+            cg = _cgroup_used_gib()
+            print(
+                f"[hostmem] {host} used={used:.0f}GiB avail={avail:.0f}GiB "
+                f"total={total:.0f}GiB cgroup_used={cg:.0f}GiB",
+                flush=True,
+            )
+            time.sleep(interval_s)
+
+    threading.Thread(target=_loop, daemon=True, name="host-mem-monitor").start()

--- a/cookbook/trainer_helpers_test.py
+++ b/cookbook/trainer_helpers_test.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import unittest
+from argparse import Namespace
+from unittest import mock
+
+from cookbook import trainer_helpers
+
+
+def _cfg(*, async_mode: bool, model_script: str | None) -> Namespace:
+    cfg = Namespace(async_mode=async_mode, trainer_model_script=model_script)
+    cfg.cli_args = lambda: ["--foo", "bar baz"]  # a value with a space to prove quoting
+    return cfg
+
+
+class BuildTrainCmdTest(unittest.TestCase):
+    def test_plain_python_invocation_without_model_script(self) -> None:
+        cmd = trainer_helpers.build_train_cmd(
+            _cfg(async_mode=False, model_script=None), "/root/slime", model_script_attr="trainer_model_script"
+        )
+        self.assertEqual(cmd, "python3 /root/slime/train.py --foo 'bar baz'")
+
+    def test_async_mode_selects_train_async(self) -> None:
+        cmd = trainer_helpers.build_train_cmd(
+            _cfg(async_mode=True, model_script=None), "/root/slime", model_script_attr="trainer_model_script"
+        )
+        self.assertTrue(cmd.startswith("python3 /root/slime/train_async.py "))
+
+    def test_sources_model_script_and_passes_model_args(self) -> None:
+        cmd = trainer_helpers.build_train_cmd(
+            _cfg(async_mode=False, model_script="scripts/qwen.sh"),
+            "/root/slime",
+            model_script_attr="trainer_model_script",
+        )
+        # bash -c wrapping a `source <script> && python3 ... ${MODEL_ARGS[@]} ...`.
+        self.assertTrue(cmd.startswith("bash -c "))
+        self.assertIn("source /root/slime/scripts/qwen.sh", cmd)
+        self.assertIn("${MODEL_ARGS[@]}", cmd)
+
+
+class SmokeFlashPoolTest(unittest.TestCase):
+    def test_warm_floor_checks_containers_then_gateway(self) -> None:
+        server_info = {"current_version": 3}
+        completion = {"weight_version_start": 3, "weight_version_end": 3}
+        with mock.patch.object(trainer_helpers, "resolve_flash_gateway_url", return_value="http://gw"), \
+            mock.patch.object(trainer_helpers, "discover_flash_targets", return_value=["http://c1"]), \
+            mock.patch.object(trainer_helpers, "_get_json", return_value=server_info), \
+            mock.patch.object(trainer_helpers, "_post_json", return_value=completion):
+            trainer_helpers.smoke_flash_pool(
+                app_name="a", cls_name="Server", model_name="m", weight_version=3,
+                expect_min_containers=1, timeout_seconds=5, wake_on_demand=False,
+            )
+
+    def test_warm_floor_version_ahead_raises_immediately(self) -> None:
+        with mock.patch.object(trainer_helpers, "resolve_flash_gateway_url", return_value="http://gw"), \
+            mock.patch.object(trainer_helpers, "discover_flash_targets", return_value=["http://c1"]), \
+            mock.patch.object(trainer_helpers, "_get_json", return_value={"current_version": 9}):
+            with self.assertRaises(trainer_helpers.VersionAheadError):
+                trainer_helpers.smoke_flash_pool(
+                    app_name="a", cls_name="Server", model_name="m", weight_version=3,
+                    expect_min_containers=1, timeout_seconds=5, wake_on_demand=False,
+                )
+
+    def test_wake_on_demand_completes_then_confirms_containers(self) -> None:
+        completion = {"weight_version_start": 2, "weight_version_end": 2}
+        with mock.patch.object(trainer_helpers, "resolve_flash_gateway_url", return_value="http://gw"), \
+            mock.patch.object(trainer_helpers, "discover_flash_targets", return_value=["http://c1"]), \
+            mock.patch.object(trainer_helpers, "_post_json", return_value=completion), \
+            mock.patch.object(trainer_helpers, "_get_json", return_value={"current_version": 2}):
+            trainer_helpers.smoke_flash_pool(
+                app_name="a", cls_name="Server", model_name="m", weight_version=2,
+                expect_min_containers=0, timeout_seconds=5, wake_on_demand=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #5 (stacked on its branch). #5 unified *who advances `latest`*; this PR unifies the **cookbook scaffolding around it**, which had drifted into near-duplicate forks. The audit found the two intended axes (slime-vs-miles quant; disagg-trainer-writer-vs-standalone-frontdoor-writer) tangled with accidental copy-forks. This collapses each example onto one trainer-agnostic spine + thin adapters, so each example encodes only its genuine difference.

Net: the per-trainer `sidecar.py` / `serving.py` / `helpers.py` shrink to thin adapters, the 444-line standalone slime hook fork loses its duplicated plumbing, and the standalone path gains the explicit claim-at-launch that #5 established for the bulletin path.

**What moved where**

- **`cookbook/sidecar.py`** — one sidecar spine (arg parsing, bulletin board + Volume reloader, and the concurrent/stale-aware base materializer that previously lived only in miles). The only per-trainer axis is the host-side delta decoder module:
  ```
  slime_disagg/sidecar.py  = run_sidecar("slime.utils.disk_delta", inject_apply_deltas=False)
  miles_disagg/sidecar.py  = run_sidecar("miles.utils.disk_delta", inject_apply_deltas=True)
  ```
  `parallel_init_local_checkpoint` reuses the decoder's apply-lock/applied-version bookkeeping, skips the copy when the base fingerprint `(name,size,mtime_ns)` is unchanged, and wipes+rebuilds when a re-prep changed the base (the K2.6 NVFP4 case).

- **`cookbook/serving.py`** — one B200 SGLang image builder parameterized on trainer repo/ref/root + clone-depth + optional cache-clear. `build_int4_b200_serving_image` / `build_nvfp4_b200_serving_image` keep their public names as thin wrappers.

- **`cookbook/trainer_helpers.py`** — shared `prepare_config`, `build_train_cmd(..., model_script_attr=)`, `materialize_node_local_yaml`, `start_host_mem_monitor`, and `smoke_flash_pool(..., wake_on_demand=)` (warm-floor vs scale-from-zero are now one function with two internal paths). slime/miles `helpers.py` re-export these with their per-trainer params. Incidentally fixes a latent `NameError` in the miles host-mem monitor (`socket` was used but never imported).

- **`cookbook/rollout_control.py`** — trainer-side primitives shared by **both** control planes: `distributed_rank`, `read_setting` (args→env→default), `apply_session_affinity`. `bulletin_hooks` and the standalone slime `hooks` now import these instead of each carrying their own copy. The two *request hooks* stay distinct on purpose — they encode the two real control models (trainer-owned cached-latest gating vs frontdoor `rollout_id` pinning), which is the intended axis, not drift.

- **standalone `announce_claim`** — claim-at-launch parity with `bulletin_hooks.claim_pool`: POST `weight_v000000` under the fresh `run_id` so the front door resets `latest` to base *before* the first delta (the front door already documents+supports the v0 claim via `decide_pointer_move`). Best-effort/non-blocking; wired into the standalone trainer launch right after the fresh `run_id` is minted. This closes the "third writer #5 didn't touch" gap.

**Compatibility:** every public name imported by the Modal entrypoints/configs is preserved (the adapters re-export), so trainer configs that pass hook/sidecar paths as import strings are unchanged.

## Testing

- Full suite: **116 passed** (98 from #5 + 18 new).
- New tests: `rollout_control_test.py`, `trainer_helpers_test.py` (`build_train_cmd` variants + `smoke_flash_pool` both modes incl. `VersionAheadError`), `sidecar_test.py` (copy / skip-when-current / stale-wipe / decoder-fallback via a fake `disk_delta`), and `announce_claim` cases added to the standalone `hooks_test.py`.
- `py_compile` over all Modal-only files (`modal_*.py`, `serving.py`, `sidecar.py`, `helpers.py`) — these can't run under pytest (need Modal/slime/miles installed), so compile is the gate.
- No `.github/workflows` or lint config in the repo; pytest is the only automated gate. Backend-only, no UI.


Link to Devin session: https://modal.devinenterprise.com/sessions/b0d6110c71924c24943bcb5cea1eb5f4
Requested by: @jvmncs
<!-- devin-review-badge-begin -->

---

<a href="https://modal.devinenterprise.com/review/modal-projects/stitch/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->