### PR TITLE
[codex] add GLM-Air FP8 disagg training

### DIFF
--- a/cookbook/miles_disagg/README.md
+++ b/cookbook/miles_disagg/README.md
@@ -1,8 +1,9 @@
 # Disaggregated miles on Modal
 
 Train Kimi K2.6 or Moonlight with GRPO under **native NVFP4 QAT**, or run
-GLM-4.5-Air as a BF16 H200 experiment, while rollouts run on a separate,
-elastic pool of SGLang servers. The miles twin of
+GLM-4.5-Air as a BF16-trainer H200 experiment with BF16 or native HF FP8
+rollout weights, while rollouts run on a separate, elastic pool of SGLang
+servers. The miles twin of
 [`../slime_disagg`](../slime_disagg): same two-half architecture and the same
 `stitch` bulletin-board / sidecar machinery, but the trainer is **miles**.
 
@@ -13,7 +14,7 @@ The app has two halves.
   exports BF16. After each step it writes a sparse XOR weight delta to a Modal
   Volume (the "bulletin board") and publishes a new weight version.
 - **`Server`** is a Modal Flash pool of SGLang servers on the configured GPU
-  type: B200 for NVFP4 configs, H200 for GLM-4.5-Air BF16. A sidecar in each
+  type: B200 for NVFP4 configs, H200 for GLM-4.5-Air. A sidecar in each
   container watches the bulletin board, applies deltas in order, and serves
   rollouts pinned to an exact weight version. Requests for a version a container
   hasn't reached get `409` and miles retries.
@@ -28,8 +29,10 @@ NVFP4 QAT is native Megatron FP4 training (`NVFP4BlockScaling`, TransformerEngin
 rollout pool run on B200 — unlike the INT4 recipe, which fake-quantizes on H200.
 There is no simulated/non-Blackwell NVFP4 weight-QAT path.
 
-`glm45_air_bf16_disagg` is the exception: a BF16 experiment on H200 with no
-NVFP4 anywhere (see the variant note below).
+`glm45_air_bf16_disagg` and `glm45_air_fp8_disagg` are the exceptions: they are
+BF16 trainer experiments on H200. They do not use NVFP4 QAT or run
+`convert_hf_to_nvfp4.py`; the rollout base is either the prepared BF16 Hugging
+Face checkpoint or the native `zai-org/GLM-4.5-Air-FP8` checkpoint.
 
 ## Checkpoint lifecycle (three roles)
 
@@ -101,16 +104,42 @@ between the prep and deploy steps. Keep `POOL_MIN_CONTAINERS=0` during prep so
 warm containers don't crash-loop on the missing model path, and let each prep
 job finish before starting the next.
 
+### GLM-4.5-Air FP8 rollout variant
+
+`glm45_air_fp8_disagg` trains from the same BF16 Megatron `torch_dist` checkpoint
+as the BF16 variant, but serves the native Hugging Face FP8 checkpoint
+`zai-org/GLM-4.5-Air-FP8` in SGLang. The prepared paths are:
+
+- `/prep/glm45-air-bf16/bf16`: BF16 Hugging Face masters used to build
+  `torch_dist`.
+- `/prep/glm45-air-bf16/fp8`: native FP8 rollout base; this is miles
+  `--hf-checkpoint`, the SGLang served base, and the disk-delta baseline/export
+  quant config source.
+- `/prep/glm45-air-bf16/torch_dist`: Megatron raw-mode checkpoint loaded by the
+  trainer via `--ref-load`.
+
+Run the same GLM flow with `EXPERIMENT_CONFIG=glm45_air_fp8_disagg`. Keep
+`POOL_MIN_CONTAINERS=0` for `prepare_checkpoints`, `prepare_torch_dist`, and
+`prepare_dataset`; deploy afterward, smoke version 0, then launch training. The
+rollout pool is capped at two H200 containers, each using four GPUs. Each
+rollout container applies `patches/sglang-fp8-reload-attrs.patch` to the SGLang
+checkout at startup so online FP8 reload preserves SGLang's sharded parameter
+loaders.
+
 ### Fork dependencies
 
-The image pins a miles fork commit (`MILES_REPO_REF` in `modal_train.py`) that
-carries the disaggregated-rollout features plus the NVFP4/publish-only fixes
-this cookbook needs; push the ref to `modal-projects/miles` before deploying.
+The image pins `modal-projects/miles` branch `nvfp4-disagg-v2` by commit
+(`MILES_REPO_REF`). That branch carries the disaggregated-rollout features, the
+publish-only / NVFP4 fixes, and the GLM-Air native FP8 disk-delta export support
+needed by `glm45_air_fp8_disagg`.
+
 The megatron routing-replay (R3) fix is baked into the trainer image at build
 time (idempotent — a no-op once the fork ships it).
 
 Dev iteration: overlay a local miles checkout at deploy time (no rebuild, no
-push). This only overlays miles; the megatron R3 fix still comes from the bake.
+push). This is optional; the committed GLM-Air FP8 path does not require a local
+overlay. This only overlays miles; the megatron R3 fix still comes from the
+bake.
 
 ```bash
 MILES_LOCAL_DIR=/path/to/miles EXPERIMENT_CONFIG=moonlight_nvfp4_disagg \

--- a/cookbook/miles_disagg/configs/base.py
+++ b/cookbook/miles_disagg/configs/base.py
@@ -55,6 +55,7 @@ class ModalConfig:
     cloud: str | None = None  # e.g. "aws", "gcp"
     region: str | None = None  # e.g. "us-east-2"
     rollout_min_containers: int = 2  # warm Flash rollout containers
+    rollout_max_containers: int | None = None  # cap Flash rollout containers; None = no explicit cap
     # Flash autoscaler target: concurrent inputs (requests) per container before it
     # scales OUT. None = use sglang_server_concurrency (legacy). Set it well below the
     # SGLang engine concurrency so Flash adds containers instead of packing requests

--- a/cookbook/miles_disagg/configs/glm45_air_fp8_disagg.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8_disagg.py
@@ -1,24 +1,28 @@
-"""GLM-4.5-Air BF16 disaggregated Miles rollout on Modal."""
+"""GLM-4.5-Air BF16 training with native HF FP8 SGLang rollout on Modal."""
 
 from __future__ import annotations
 
 from cookbook.miles_disagg.configs.base import DATA_PATH, PREP_PATH, ModalConfig, MilesConfig
 
 
-APP_NAME = "miles-glm45-air-bf16-disagg"
-DELTA_VOLUME_NAME = "miles-delta-bulletin-glm45-air-bf16"
+APP_NAME = "miles-glm45-air-fp8-disagg"
+DELTA_VOLUME_NAME = "miles-delta-bulletin-glm45-air-fp8"
 DELTA_BULLETIN_ROOT = "/delta-bulletin"
 
 SOURCE_MODEL = "zai-org/GLM-4.5-Air"
+ROLLOUT_SOURCE_MODEL = "zai-org/GLM-4.5-Air-FP8"
 MODEL_TAG = "glm45-air-bf16"
-SERVED_CHECKPOINT_FORMAT = "bf16"
+SERVED_CHECKPOINT_FORMAT = "fp8"
 USE_MODAL_TORCH_DIST_WRAPPER = True
 # The standard HF downloader was the path that finished reliably for this model.
 DISABLE_HF_XET = True
 DISABLE_HF_TRANSFER = True
 
-SIDECAR_COMMIT_MODE = "in_place"
+SIDECAR_COMMIT_MODE = "quiesce"
 SIDECAR_DEBUG_REQUESTS = True
+SGLANG_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/sglang-fp8-reload-attrs.patch",
+]
 
 
 def build_serving_image(**kwargs):
@@ -28,12 +32,17 @@ def build_serving_image(**kwargs):
 
 
 SGLANG_SERVER_ARGS = {
+    "--dtype": "auto",
     "--reasoning-parser": "glm45",
     "--tool-call-parser": "glm45",
     "--dist-timeout": "3600",
     "--context-length": "32768",
-    "--mem-fraction-static": "0.8",
-    "--chunked-prefill-size": "16384",
+    "--mem-fraction-static": "0.7",
+    "--chunked-prefill-size": "8192",
+    "--max-prefill-tokens": "16384",
+    # Keep CUDA graph enabled, but avoid H200 cold-start hangs while compiling
+    # the largest FP8 piecewise graph shape.
+    "--piecewise-cuda-graph-max-tokens": "2048",
     "--model-loader-extra-config": '{"enable_multithread_load":true,"num_threads":8}',
     "--skip-server-warmup": "",
 }
@@ -42,7 +51,8 @@ modal = ModalConfig(
     gpu="H200",
     region="us",
     memory=1_048_576,
-    rollout_min_containers=1,
+    rollout_min_containers=2,
+    rollout_max_containers=2,
     rollout_target_inputs=32,
     proxy_regions=["us-west"],
     rollout_ephemeral_disk_mib=819_200,
@@ -62,7 +72,9 @@ modal = ModalConfig(
 class _Miles(MilesConfig):
     miles_model_script = "scripts/models/glm4.5-106B-A12B.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/bf16"
+    # hf_checkpoint is the native FP8 rollout checkpoint. The trainer weights
+    # come from ref_load below.
+    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/fp8"
     ref_load = f"{PREP_PATH}/{MODEL_TAG}/torch_dist"
     megatron_to_hf_mode = "raw"
     model_name = "glm4moe"
@@ -72,7 +84,7 @@ class _Miles(MilesConfig):
     num_gpus_per_node = 8
     colocate = False
     rollout_num_gpus = 0
-    rollout_num_gpus_per_engine = 8
+    rollout_num_gpus_per_engine = 4
     rollout_endpoint_url = None
     use_miles_router = True
 
@@ -105,8 +117,10 @@ class _Miles(MilesConfig):
     rm_type = "deepscaler"
     eval_interval = None
 
-    num_rollout = 3
-    save_interval = 20
+    num_rollout = 10
+    # Leave checkpoint saving disabled. Miles forces a final save whenever
+    # --save-interval is set, regardless of how large the interval is.
+    save_interval = None
     rollout_batch_size = 16
     rollout_max_response_len = 4096
     rollout_temperature = 0.8

--- a/cookbook/miles_disagg/helpers.py
+++ b/cookbook/miles_disagg/helpers.py
@@ -70,6 +70,38 @@ def smoke_flash_pool(**kwargs: Any) -> None:
     _smoke_flash_pool(wake_on_demand=WAKE_ON_DEMAND, **kwargs)
 
 
+def apply_sglang_runtime_patches(patch_paths: list[str], repo_dir: str = "/sgl-workspace/sglang") -> None:
+    """Apply git patches to the runtime SGLang checkout before server start."""
+    for patch_path in patch_paths:
+        if not os.path.exists(patch_path):
+            raise FileNotFoundError(f"SGLang runtime patch not found: {patch_path}")
+
+        check = subprocess.run(
+            ["git", "-C", repo_dir, "apply", "--check", patch_path],
+            capture_output=True,
+            text=True,
+        )
+        if check.returncode == 0:
+            subprocess.run(["git", "-C", repo_dir, "apply", patch_path], check=True)
+            print(f"[SGLang patch] applied {patch_path}", flush=True)
+            continue
+
+        reverse = subprocess.run(
+            ["git", "-C", repo_dir, "apply", "--reverse", "--check", patch_path],
+            capture_output=True,
+            text=True,
+        )
+        if reverse.returncode == 0:
+            print(f"[SGLang patch] already applied {patch_path}", flush=True)
+            continue
+
+        raise RuntimeError(
+            f"Cannot apply SGLang runtime patch {patch_path}\n"
+            f"apply --check stderr:\n{check.stderr}\n"
+            f"reverse --check stderr:\n{reverse.stderr}"
+        )
+
+
 def materialize_node_local_yaml(cfg: Any, field: str, dest_dir: str = "/root/.miles_node_yaml") -> None:
     """Materialize a per-actor-read YAML config to a deterministic node-local path.
 

--- a/cookbook/miles_disagg/modal_train.py
+++ b/cookbook/miles_disagg/modal_train.py
@@ -45,13 +45,13 @@ miles_cfg = exp.miles
 
 # The rollout Server pool warm-boots `min_containers` replicas the moment this app
 # is materialized — by a deploy OR by `modal run` of ANY function in it. Those
-# replicas serve the prepared NVFP4 base (miles_cfg.hf_checkpoint), so before that
+# replicas serve the prepared rollout base (miles_cfg.hf_checkpoint), so before that
 # base exists they crash-loop on a missing --model-path. prepare_checkpoints builds
 # the base, so it must run with the pool down: POOL_MIN_CONTAINERS=0.
 POOL_MIN_CONTAINERS = int(os.environ.get("POOL_MIN_CONTAINERS", modal_cfg.rollout_min_containers))
 
 APP_NAME = exp.APP_NAME
-MODEL_NAME = miles_cfg.hf_checkpoint  # the served NVFP4 base (a prepared local path)
+MODEL_NAME = miles_cfg.hf_checkpoint
 ROLLOUT_CONCURRENCY = modal_cfg.rollout_target_inputs or miles_cfg.sglang_server_concurrency
 N_TRAIN_NODES = helpers.training_nodes(miles_cfg)
 
@@ -72,11 +72,11 @@ MILES_ROOT = "/root/miles"
 # must we (we run train_async.py directly rather than via execute_train).
 MEGATRON_PATH = "/root/Megatron-LM"
 # Fork commit with the disaggregated-rollout features (opaque HTTP endpoint,
-# publish-only disk-delta, request hook) plus the NVFP4 fixes this cookbook
-# needs. Pin to an exact commit, not the branch tip (cached image layer); push
-# the ref to modal-projects/miles before deploying.
+# publish-only disk-delta, request hook) plus the NVFP4 and GLM-Air FP8 fixes
+# this cookbook needs. Pin to an exact commit, not the branch tip (cached image
+# layer); push the ref to modal-projects/miles before deploying.
 MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
-MILES_REPO_REF = "e9ad52dbbe09b6113b4fa4dccfb5ace35341540e"
+MILES_REPO_REF = "852fb9a5cfb3c4630691b643ed354a9703ff3722"
 
 # Build-time bake of the megatron R3 dispatch fix (see the .run_commands call
 # below). Kept as a string so the build step has no host-file dependency; the
@@ -94,26 +94,6 @@ _R3_DISPATCH_BAKE_PY = (
     f"n=s.count({_R3_DISPATCH_OLD!r});"
     f"p.write_text(s.replace({_R3_DISPATCH_OLD!r}, {_R3_DISPATCH_NEW!r}));"
     "print(f'[R3 bake] patched {n} dispatch site(s) in token_dispatcher.py')"
-)
-
-# Keep GLM4Moe expert-bias exports fp32 for BF16 disk-delta byte-shape parity.
-_GLM4MOE_EXPERT_BIAS_TARGET = f"{MILES_ROOT}/miles/backends/megatron_utils/megatron_to_hf/glm4moe.py"
-_GLM4MOE_EXPERT_BIAS_OLD = (
-    '        elif rest == "mlp.router.expert_bias":\n'
-    '            return [(f"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias", to_model_dtype(args, param))]'
-)
-_GLM4MOE_EXPERT_BIAS_NEW = (
-    '        elif rest == "mlp.router.expert_bias":\n'
-    "            return [(f\"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias\", param)]"
-)
-_GLM4MOE_EXPERT_BIAS_BAKE_PY = (
-    "import pathlib;"
-    f"p=pathlib.Path({_GLM4MOE_EXPERT_BIAS_TARGET!r});"
-    "s=p.read_text();"
-    f"n=s.count({_GLM4MOE_EXPERT_BIAS_OLD!r});"
-    "assert n == 1, f'expected exactly one GLM4Moe expert-bias export site, found {n}';"
-    f"p.write_text(s.replace({_GLM4MOE_EXPERT_BIAS_OLD!r}, {_GLM4MOE_EXPERT_BIAS_NEW!r}));"
-    "print(f'[GLM4Moe bake] patched {n} expert-bias dtype export site(s) in glm4moe.py')"
 )
 
 TORCH_DIST_CONVERT_WRAPPER = "/root/convert_hf_to_torch_dist_modal.py"
@@ -177,9 +157,6 @@ if getattr(exp, "USE_MODAL_TORCH_DIST_WRAPPER", False):
         TORCH_DIST_CONVERT_WRAPPER,
         copy=True,
     )
-
-if getattr(exp, "PATCH_GLM4MOE_EXPERT_BIAS_FP32", False):
-    image = image.run_commands(f"python3 -c {shlex.quote(_GLM4MOE_EXPERT_BIAS_BAKE_PY)}")
 
 # Local source mounted at container start (no rebuild on code edits). Modal puts
 # /root on PYTHONPATH, so both packages import from subprocesses (the sidecar, Ray
@@ -290,6 +267,7 @@ WARMUP_PAYLOAD = {
         exp.DELTA_BULLETIN_ROOT: delta_volume,
     },
     min_containers=POOL_MIN_CONTAINERS,
+    max_containers=getattr(modal_cfg, "rollout_max_containers", None),
     timeout=40 * MINUTES,
     scaledown_window=15 * MINUTES,
     # The sidecar copies the full served base (~591 GB for K2.6) to
@@ -314,6 +292,7 @@ class Server:
 
     @modal.enter()
     def startup(self) -> None:
+        helpers.apply_sglang_runtime_patches(list(getattr(exp, "SGLANG_RUNTIME_PATCHES", [])))
         self.endpoint = SGLangEndpoint(
             model_path=MODEL_NAME,
             worker_port=SGLANG_PORT,
@@ -330,9 +309,8 @@ class Server:
             request_timeout=120.0,
             max_attempts_per_request=3,
         )
-        # The served NVFP4 base is a prepared directory on the prep Volume
-        # (MODEL_NAME is its absolute path); deltas are applied host-side onto a
-        # copy of it.
+        # The served base is a prepared directory (MODEL_NAME is its absolute
+        # path); deltas are applied host-side onto a copy of it.
         self.sidecar = helpers.start_sglang_sidecar(
             sidecar_port=SIDECAR_PORT,
             sglang_port=SGLANG_PORT,
@@ -448,19 +426,25 @@ class Trainer:
         # run is a forward pointer move, never a colliding rewind.
         run_id = uuid.uuid4().hex[:12]
         cfg.update_weight_disk_dir = f"{exp.DELTA_BULLETIN_ROOT}/{run_id}"
-        cfg.load = f"{CHECKPOINTS_PATH}/{run_id}/checkpoints"
-        cfg.save = f"{CHECKPOINTS_PATH}/{run_id}/checkpoints"
+        if getattr(cfg, "save_interval", None) is None:
+            cfg.load = None
+            cfg.save = None
+            cfg.save_hf = None
+        else:
+            cfg.load = f"{CHECKPOINTS_PATH}/{run_id}/checkpoints"
+            cfg.save = f"{CHECKPOINTS_PATH}/{run_id}/checkpoints"
         # Merge the dynamic bulletin identity into custom_config_path (which already
         # carries the request-gating knobs). miles setattr's every key onto args,
         # so the publish + request hooks read them via getattr(args, ...).
         existing = dict(getattr(cfg, "custom_config_path", {}) or {})
-        cfg.custom_config_path = {
+        custom_config = {
             **existing,
             "update_weight_delta_volume_name": exp.DELTA_VOLUME_NAME,
             "rollout_modal_flash_app_name": APP_NAME,
             "rollout_modal_flash_server_cls_name": Server.__name__,
             "run_id": run_id,
         }
+        cfg.custom_config_path = custom_config
         helpers.prepare_miles_config(cfg, tempfile.mkdtemp())
         cmd = helpers.build_train_cmd(cfg, MILES_ROOT)
 
@@ -470,9 +454,7 @@ class Trainer:
         # reconcile to a finished run's stale high-water version.
         from cookbook.miles_disagg import hooks
 
-        hooks.claim_pool(
-            SimpleNamespace(update_weight_disk_dir=cfg.update_weight_disk_dir, **cfg.custom_config_path)
-        )
+        hooks.claim_pool(SimpleNamespace(update_weight_disk_dir=cfg.update_weight_disk_dir, **custom_config))
 
         print(f"Training {experiment}: nodes={N_TRAIN_NODES}, rollout_endpoint={cfg.rollout_endpoint_url}")
         print(f"Command: {cmd}")
@@ -527,9 +509,10 @@ def prepare_checkpoints() -> None:
     prep_volume.reload()
     tag = exp.MODEL_TAG
     bf16_dir = f"{PREP_PATH}/{tag}/bf16"
+    fp8_dir = f"{PREP_PATH}/{tag}/fp8"
     nvfp4_dir = f"{PREP_PATH}/{tag}/nvfp4"
     served_checkpoint_format = getattr(exp, "SERVED_CHECKPOINT_FORMAT", "nvfp4")
-    if served_checkpoint_format not in {"bf16", "nvfp4"}:
+    if served_checkpoint_format not in {"bf16", "fp8", "nvfp4"}:
         raise SystemExit(f"Unsupported SERVED_CHECKPOINT_FORMAT={served_checkpoint_format!r}")
     tools = f"{MILES_ROOT}/tools"
 
@@ -575,6 +558,20 @@ def prepare_checkpoints() -> None:
     if served_checkpoint_format == "bf16":
         prep_volume.commit()
         print(f"Prepared masters={bf16_dir} served_base={bf16_dir}")
+        return
+
+    if served_checkpoint_format == "fp8":
+        fp8_source_model = getattr(exp, "ROLLOUT_SOURCE_MODEL", None)
+        if not fp8_source_model:
+            raise SystemExit("SERVED_CHECKPOINT_FORMAT='fp8' requires ROLLOUT_SOURCE_MODEL")
+
+        def _build_fp8(out: str) -> None:
+            fp8_src = snapshot_download(fp8_source_model)
+            subprocess.run(f"cp -aL {fp8_src}/. {out}/", shell=True, check=True)
+
+        _staged(fp8_dir, _build_fp8)
+        prep_volume.commit()
+        print(f"Prepared masters={bf16_dir} served_base={fp8_dir}")
         return
 
     # 2. served NVFP4 base (miles' TE-direct quantizer). bf16

--- a/cookbook/miles_disagg/patches/sglang-fp8-reload-attrs.patch
+++ b/cookbook/miles_disagg/patches/sglang-fp8-reload-attrs.patch
@@ -1,0 +1,393 @@
+diff --git a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+index d4dafa224b..d62c1f480f 100644
+--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
++++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+@@ -36,6 +36,123 @@ if _use_aiter:
+     from aiter.ops.shuffle import shuffle_weight
+
+
++
++import types
++
++
++_RELOAD_METHOD_NAMES = (
++    "load_column_parallel_weight",
++    "load_row_parallel_weight",
++    "load_merged_column_weight",
++    "load_qkv_weight",
++    "_assert_and_load",
++    "_load_into_shard_id",
++    "_shard_id_as_int",
++    "adjust_shard_indexes_for_packing",
++)
++
++
++def _copy_reload_methods(src, dst):
++    # Fallback for Parameter wrappers that cannot preserve the original subclass.
++    # The saved weight_loader still calls the subclass sharding helpers.
++    for name in _RELOAD_METHOD_NAMES:
++        method = getattr(src, name, None)
++        func = getattr(method, "__func__", None)
++        if func is None:
++            func = getattr(type(src), name, None)
++        if callable(func):
++            setattr(dst, name, types.MethodType(func, dst))
++    return dst
++
++
++def _reload_attrs(src, *, transpose_2d: bool = False):
++    # Keep sharding-aware loader attrs after FP8 postprocess wraps Parameters.
++    out = dict(getattr(src, "__dict__", {}))
++    out.pop("_sglang_fp8_reload_ready", None)
++    out.pop("_sglang_fp8_reload_transposed", None)
++
++    attrs = (
++        "weight_padded",
++        "is_transposed",
++        "is_metadata",
++        "needs_scalar_to_array",
++        "ignore_warning",
++        "quant_method",
++        "_sglang_require_global_experts",
++    )
++    for attr in attrs:
++        if not hasattr(src, attr):
++            continue
++        out[attr] = getattr(src, attr)
++    if transpose_2d:
++        for attr in ("_input_dim", "_output_dim"):
++            value = out.get(attr)
++            if isinstance(value, int):
++                out[attr] = 1 - value
++    return out
++
++
++def _apply_reload_attrs(dst, attrs):
++    for attr, value in attrs.items():
++        try:
++            setattr(dst, attr, value)
++        except AttributeError:
++            # Read-only properties on SGLang parameter subclasses are backed by
++            # private attrs that are already copied from __dict__.
++            pass
++    return dst
++
++
++def _parameter_like(src, data, attrs):
++    cls = type(src)
++    try:
++        dst = cls.__new__(cls, data)
++        dst.requires_grad_(False)
++    except Exception:
++        dst = Parameter(data, requires_grad=False)
++    _apply_reload_attrs(dst, attrs)
++    _copy_reload_methods(src, dst)
++    return dst
++
++
++def _mark_reload_ready(dst, *, transposed: bool = False):
++    dst._sglang_fp8_reload_ready = True
++    dst._sglang_fp8_reload_transposed = transposed
++    return dst
++
++
++def _preserve_reload_attrs(src, dst):
++    dst = _parameter_like(src, dst.data, _reload_attrs(src))
++    return _mark_reload_ready(dst)
++
++
++def _preserve_transposed_reload_attrs(src, dst):
++    original_attrs = _reload_attrs(src)
++    transposed_attrs = _reload_attrs(src, transpose_2d=True)
++    dst = _parameter_like(src, dst.data, transposed_attrs)
++    original_loader = original_attrs.get("_weight_loader") or getattr(src, "weight_loader", None)
++    if original_loader is None:
++        return _mark_reload_ready(dst, transposed=True)
++    load_shape = tuple(src.data.shape)
++    load_stride = tuple(src.data.stride())
++    load_dtype = src.data.dtype
++
++    def transposed_weight_loader(param, loaded_weight, *args, **kwargs):
++        tmp = _parameter_like(
++            src,
++            torch.empty_strided(load_shape, load_stride, dtype=load_dtype, device=param.data.device),
++            original_attrs,
++        )
++        original_loader(tmp, loaded_weight, *args, **kwargs)
++        param.data.copy_(tmp.data.t())
++
++    try:
++        dst._weight_loader = transposed_weight_loader
++    except Exception:
++        dst.weight_loader = transposed_weight_loader
++    return _mark_reload_ready(dst, transposed=True)
++
++
+ strategy_to_parameter_type = {
+     QuantizationStrategy.BLOCK: BlockQuantScaleParameter,
+     QuantizationStrategy.CHANNEL: ChannelQuantScaleParameter,
+@@ -141,6 +258,9 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
+             layer.register_parameter("input_scale", input_scale)
+
+     def process_weights_after_loading(self, layer) -> None:
++        if getattr(layer.weight, "_sglang_fp8_reload_ready", False):
++            return
++
+         if self.strategy == QuantizationStrategy.TENSOR:
+             max_w_scale, weight = requantize_with_max_scale(
+                 weight=layer.weight,
+@@ -156,8 +276,14 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
+                 )
+                 if input_scale is not None:
+                     layer.input_scale = Parameter(input_scale, requires_grad=False)
+-            layer.weight = Parameter(weight.t(), requires_grad=False)
+-            layer.weight_scale = Parameter(max_w_scale, requires_grad=False)
++            old_weight = layer.weight
++            old_weight_scale = layer.weight_scale
++            layer.weight = _preserve_transposed_reload_attrs(
++                old_weight, Parameter(weight.t(), requires_grad=False)
++            )
++            layer.weight_scale = _preserve_reload_attrs(
++                old_weight_scale, Parameter(max_w_scale, requires_grad=False)
++            )
+
+         elif self.strategy == QuantizationStrategy.CHANNEL:
+             weight = layer.weight
+@@ -175,16 +301,23 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
+             else:
+                 weight_scale = layer.weight_scale.data
+
++            old_weight = layer.weight
++            old_weight_scale = layer.weight_scale
+             if _use_aiter:
+                 # keep the weight as (N, K)
+-                layer.weight = Parameter(
+-                    shuffle_weight(weight, (16, 16)), requires_grad=False
++                layer.weight = _preserve_reload_attrs(
++                    old_weight,
++                    Parameter(shuffle_weight(weight, (16, 16)), requires_grad=False),
+                 )
+             else:
+-                layer.weight = Parameter(weight.t(), requires_grad=False)
++                layer.weight = _preserve_transposed_reload_attrs(
++                    old_weight, Parameter(weight.t(), requires_grad=False)
++                )
+
+             # required by torch.compile to be torch.nn.Parameter
+-            layer.weight_scale = Parameter(weight_scale, requires_grad=False)
++            layer.weight_scale = _preserve_reload_attrs(
++                old_weight_scale, Parameter(weight_scale, requires_grad=False)
++            )
+
+         elif self.strategy == QuantizationStrategy.BLOCK:
+             assert self.is_static_input_scheme is False
+@@ -203,7 +336,10 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
+
+         # INPUT SCALE
+         if self.is_static_input_scheme and hasattr(layer, "input_scale"):
+-            layer.input_scale = Parameter(layer.input_scale.max(), requires_grad=False)
++            old_input_scale = layer.input_scale
++            layer.input_scale = _preserve_reload_attrs(
++                old_input_scale, Parameter(old_input_scale.max(), requires_grad=False)
++            )
+         else:
+             layer.input_scale = None
+
+diff --git a/python/sglang/srt/layers/quantization/w8a8_fp8.py b/python/sglang/srt/layers/quantization/w8a8_fp8.py
+index aeea826cd5..f4f4fd1d0d 100644
+--- a/python/sglang/srt/layers/quantization/w8a8_fp8.py
++++ b/python/sglang/srt/layers/quantization/w8a8_fp8.py
+@@ -36,6 +36,122 @@ if TYPE_CHECKING:
+ _is_fp8_fnuz = is_fp8_fnuz()
+
+
++import types
++
++
++_RELOAD_METHOD_NAMES = (
++    "load_column_parallel_weight",
++    "load_row_parallel_weight",
++    "load_merged_column_weight",
++    "load_qkv_weight",
++    "_assert_and_load",
++    "_load_into_shard_id",
++    "_shard_id_as_int",
++    "adjust_shard_indexes_for_packing",
++)
++
++
++def _copy_reload_methods(src, dst):
++    # Fallback for Parameter wrappers that cannot preserve the original subclass.
++    # The saved weight_loader still calls the subclass sharding helpers.
++    for name in _RELOAD_METHOD_NAMES:
++        method = getattr(src, name, None)
++        func = getattr(method, "__func__", None)
++        if func is None:
++            func = getattr(type(src), name, None)
++        if callable(func):
++            setattr(dst, name, types.MethodType(func, dst))
++    return dst
++
++
++def _reload_attrs(src, *, transpose_2d: bool = False):
++    # Keep sharding-aware loader attrs after FP8 postprocess wraps Parameters.
++    out = dict(getattr(src, "__dict__", {}))
++    out.pop("_sglang_fp8_reload_ready", None)
++    out.pop("_sglang_fp8_reload_transposed", None)
++
++    attrs = (
++        "weight_padded",
++        "is_transposed",
++        "is_metadata",
++        "needs_scalar_to_array",
++        "ignore_warning",
++        "quant_method",
++        "_sglang_require_global_experts",
++    )
++    for attr in attrs:
++        if not hasattr(src, attr):
++            continue
++        out[attr] = getattr(src, attr)
++    if transpose_2d:
++        for attr in ("_input_dim", "_output_dim"):
++            value = out.get(attr)
++            if isinstance(value, int):
++                out[attr] = 1 - value
++    return out
++
++
++def _apply_reload_attrs(dst, attrs):
++    for attr, value in attrs.items():
++        try:
++            setattr(dst, attr, value)
++        except AttributeError:
++            # Read-only properties on SGLang parameter subclasses are backed by
++            # private attrs that are already copied from __dict__.
++            pass
++    return dst
++
++
++def _parameter_like(src, data, attrs):
++    cls = type(src)
++    try:
++        dst = cls.__new__(cls, data)
++        dst.requires_grad_(False)
++    except Exception:
++        dst = Parameter(data, requires_grad=False)
++    _apply_reload_attrs(dst, attrs)
++    _copy_reload_methods(src, dst)
++    return dst
++
++
++def _mark_reload_ready(dst, *, transposed: bool = False):
++    dst._sglang_fp8_reload_ready = True
++    dst._sglang_fp8_reload_transposed = transposed
++    return dst
++
++
++def _preserve_reload_attrs(src, dst):
++    dst = _parameter_like(src, dst.data, _reload_attrs(src))
++    return _mark_reload_ready(dst)
++
++
++def _preserve_transposed_reload_attrs(src, dst):
++    original_attrs = _reload_attrs(src)
++    transposed_attrs = _reload_attrs(src, transpose_2d=True)
++    dst = _parameter_like(src, dst.data, transposed_attrs)
++    original_loader = original_attrs.get("_weight_loader") or getattr(src, "weight_loader", None)
++    if original_loader is None:
++        return _mark_reload_ready(dst, transposed=True)
++    load_shape = tuple(src.data.shape)
++    load_stride = tuple(src.data.stride())
++    load_dtype = src.data.dtype
++
++    def transposed_weight_loader(param, loaded_weight, *args, **kwargs):
++        tmp = _parameter_like(
++            src,
++            torch.empty_strided(load_shape, load_stride, dtype=load_dtype, device=param.data.device),
++            original_attrs,
++        )
++        original_loader(tmp, loaded_weight, *args, **kwargs)
++        param.data.copy_(tmp.data.t())
++
++    try:
++        dst._weight_loader = transposed_weight_loader
++    except Exception:
++        dst.weight_loader = transposed_weight_loader
++    return _mark_reload_ready(dst, transposed=True)
++
++
+ class W8A8Fp8Config(QuantizationConfig):
+     """Config class for W8A8 FP8 Quantization.
+
+@@ -107,6 +223,8 @@ class W8A8Fp8LinearMethod(LinearMethodBase):
+         self.quantization_config = quantization_config
+
+     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
++        if getattr(layer.weight, "_sglang_fp8_reload_transposed", False):
++            return
+         weight = layer.weight
+
+         if self.quantization_config.is_checkpoint_fp8_serialized:
+@@ -117,8 +235,14 @@ class W8A8Fp8LinearMethod(LinearMethodBase):
+                     weight=weight, weight_scale=weight_scale
+                 )
+
+-            layer.weight = Parameter(weight.t(), requires_grad=False)
+-            layer.weight_scale = Parameter(weight_scale, requires_grad=False)
++            old_weight = layer.weight
++            old_weight_scale = layer.weight_scale
++            layer.weight = _preserve_transposed_reload_attrs(
++                old_weight, Parameter(weight.t(), requires_grad=False)
++            )
++            layer.weight_scale = _preserve_reload_attrs(
++                old_weight_scale, Parameter(weight_scale, requires_grad=False)
++            )
+         else:
+             # If checkpoint not offline quantized, quantize the weights with per-channel quantization.
+             if self.cutlass_fp8_supported:
+@@ -134,8 +258,14 @@ class W8A8Fp8LinearMethod(LinearMethodBase):
+                 qweight, weight_scale = input_to_float8(layer.weight, dtype=fp8_dtype)
+
+             # Update the layer with the new values.
+-            layer.weight = Parameter(qweight.t(), requires_grad=False)
+-            layer.weight_scale = Parameter(weight_scale, requires_grad=False)
++            old_weight = layer.weight
++            old_weight_scale = layer.weight_scale
++            layer.weight = _preserve_transposed_reload_attrs(
++                old_weight, Parameter(qweight.t(), requires_grad=False)
++            )
++            layer.weight_scale = _preserve_reload_attrs(
++                old_weight_scale, Parameter(weight_scale, requires_grad=False)
++            )
+             layer.input_scale = None
+
+     def create_weights(
+@@ -271,13 +401,21 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
+         layer.register_parameter("w2_input_scale", w2_input_scale)
+
+     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+-        layer.w13_weight = Parameter(layer.w13_weight, requires_grad=False)
+-        layer.w2_weight = Parameter(layer.w2_weight, requires_grad=False)
+-        layer.w13_weight_scale = Parameter(
+-            layer.w13_weight_scale.data, requires_grad=False
++        old_w13_weight = layer.w13_weight
++        old_w2_weight = layer.w2_weight
++        old_w13_weight_scale = layer.w13_weight_scale
++        old_w2_weight_scale = layer.w2_weight_scale
++        layer.w13_weight = _preserve_reload_attrs(
++            old_w13_weight, Parameter(old_w13_weight.data, requires_grad=False)
++        )
++        layer.w2_weight = _preserve_reload_attrs(
++            old_w2_weight, Parameter(old_w2_weight.data, requires_grad=False)
++        )
++        layer.w13_weight_scale = _preserve_reload_attrs(
++            old_w13_weight_scale, Parameter(old_w13_weight_scale.data, requires_grad=False)
+         )
+-        layer.w2_weight_scale = Parameter(
+-            layer.w2_weight_scale.data, requires_grad=False
++        layer.w2_weight_scale = _preserve_reload_attrs(
++            old_w2_weight_scale, Parameter(old_w2_weight_scale.data, requires_grad=False)
+         )
+
+     def create_moe_runner(

--- a/cookbook/miles_disagg/serving.py
+++ b/cookbook/miles_disagg/serving.py
@@ -1,23 +1,25 @@
-"""Dedicated B200 NVFP4 SGLang serving image for the miles rollout pool.
+"""Miles SGLang serving image for the disaggregated rollout pool.
 
-A thin wrapper over :func:`cookbook.serving.build_b200_serving_image` — the miles
-twin of cookbook/slime_disagg/serving.py. The image itself is trainer-agnostic
-(see that module): NVFP4 vs INT4 is driven by the served checkpoint's own quant
-config, not by this builder. This wrapper pins miles as the ``--no-deps`` decoder
-package, does a full clone (the miles ref is not a branch tip), and clears the
-SGLang kernel cache as the final filesystem step (modal_train mounts a
-kernel-cache volume at /root/.cache/sglang, which can't mount over a non-empty
-path).
+The Modal GPU type is selected by each experiment's ``ModalConfig`` in
+``modal_train.py``; this image wrapper does not force B200 vs H200. The shared
+builder still has a historical B200 name because it started with the Blackwell
+rollout path, but the image itself is trainer-agnostic: quantization is driven by
+the served checkpoint's config, not by this builder.
+
+This wrapper pins miles as the ``--no-deps`` decoder package, does a full clone
+(the miles ref is not a branch tip), and clears the SGLang kernel cache as the
+final filesystem step (modal_train mounts a kernel-cache volume at
+/root/.cache/sglang, which can't mount over a non-empty path).
 """
 
 from __future__ import annotations
 
 import modal
 
-from cookbook.serving import build_b200_serving_image
+from cookbook.serving import build_b200_serving_image as _build_shared_serving_image
 
 
-def build_nvfp4_b200_serving_image(
+def build_miles_serving_image(
     *,
     trainer_repo_url: str,
     trainer_repo_ref: str,
@@ -25,7 +27,7 @@ def build_nvfp4_b200_serving_image(
     hf_cache_path: str,
     experiment: str,
 ) -> modal.Image:
-    return build_b200_serving_image(
+    return _build_shared_serving_image(
         trainer_repo_url=trainer_repo_url,
         trainer_repo_ref=trainer_repo_ref,
         trainer_root=trainer_root,
@@ -34,3 +36,8 @@ def build_nvfp4_b200_serving_image(
         shallow_clone=False,
         clear_sglang_cache_at_end=True,
     )
+
+
+def build_nvfp4_b200_serving_image(**kwargs) -> modal.Image:
+    """Backward-compatible name for existing NVFP4/B200 experiment configs."""
+    return build_miles_serving_image(**kwargs)

--- a/src/stitch/engines/sglang.py
+++ b/src/stitch/engines/sglang.py
@@ -16,6 +16,13 @@ logger = logging.getLogger(__name__)
 EXTRA_KEY_DELIMITER = ";"
 
 
+def _transition_files(manifest: VersionManifest) -> list[str]:
+    files = list(manifest.transition_files)
+    if not files:
+        files = [artifact.path for artifact in manifest.artifacts if artifact.kind == "transition"]
+    return files
+
+
 def compose_extra_key(
     version: int, user_extra_key: str | None = None, run_id: str | None = None
 ) -> str:
@@ -132,6 +139,12 @@ class SGLangDiskDeltaAdapter:
         logger.info(
             "[apply timing] v=%s host_delta_apply=%.2fs", manifest.version, time.perf_counter() - _t_apply
         )
+        if not _transition_files(manifest):
+            logger.info(
+                "[apply timing] v=%s engine_reload=skipped empty_delta",
+                manifest.version,
+            )
+            return
 
         _t_reload = time.perf_counter()
         payload = {

--- a/src/stitch/engines/sglang_test.py
+++ b/src/stitch/engines/sglang_test.py
@@ -46,7 +46,11 @@ class SGLangDiskDeltaAdapterTest(unittest.TestCase):
 
             await adapter.prepare()
             manifest = VersionManifest(
-                version=5, base_version=4, backend="disk_delta", load_format="auto"
+                version=5,
+                base_version=4,
+                backend="disk_delta",
+                load_format="auto",
+                transition_files=["model-00000-of-00001.safetensors"],
             )
             with mock.patch("httpx.AsyncClient", _RecordingPost):
                 _RecordingPost.last_json = None
@@ -63,6 +67,34 @@ class SGLangDiskDeltaAdapterTest(unittest.TestCase):
                 _RecordingPost.last_json,
                 {"model_path": "/local", "weight_version": "5", "flush_cache": False},
             )
+
+        asyncio.run(run())
+
+    def test_apply_manifest_skips_engine_reload_for_empty_delta(self) -> None:
+        async def run() -> None:
+            calls: dict[str, list] = {"apply": [], "init": []}
+
+            adapter = SGLangDiskDeltaAdapter(
+                upstream_url="http://up/",
+                local_checkpoint_dir="/local",
+                base_checkpoint_dir="/base",
+                apply_deltas=lambda local, root, version: calls["apply"].append((local, root, version)),
+                init_local_checkpoint=lambda local, base: calls["init"].append((local, base)),
+            )
+
+            manifest = VersionManifest(
+                version=5,
+                base_version=4,
+                backend="disk_delta",
+                load_format="auto",
+                transition_files=[],
+            )
+            with mock.patch("httpx.AsyncClient", _RecordingPost):
+                _RecordingPost.last_json = None
+                await adapter.apply_manifest(manifest, "/bulletin/versions/weight_v000005")
+
+            self.assertEqual(calls["apply"], [("/local", "/bulletin/versions", 5)])
+            self.assertIsNone(_RecordingPost.last_json)
 
         asyncio.run(run())
 

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -285,6 +285,16 @@ class WeightSyncManager(RolloutAdmissionGate):
         while True:
             try:
                 reached = await self._sync_once()
+                if reached:
+                    # A wake/publish can land while _sync_once is already
+                    # committing an older board snapshot. Re-check before going
+                    # idle so the active sync task does not drop that work.
+                    await self.board.refresh()
+                    run_id, latest = self.board.read_latest()
+                    self.latest_seen_version = max(self.latest_seen_version, latest)
+                    queued = self.queued_target_version or 0
+                    if run_id != self.current_run_id or max(latest, queued) > self.current_version:
+                        reached = False
             except Exception as exc:  # noqa: BLE001
                 self.last_sync_error = str(exc)
                 self.sync_state = SyncState.ERROR

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -85,6 +85,32 @@ class SyncManagerTest(unittest.TestCase):
 
         asyncio.run(run())
 
+    def test_sync_keeps_queued_work_that_arrives_during_commit(self) -> None:
+        async def run() -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                board = FilesystemBulletinBoard(tmp)
+                board.publish_manifest(VersionManifest(version=1, base_version=0, backend="fake", load_format="noop"))
+                engine = FakeEngine()
+                engine.apply_gate = asyncio.Event()
+                manager = WeightSyncManager(board=board, engine=engine)
+
+                sync = asyncio.create_task(manager.sync_to())
+                await engine.apply_started.wait()
+
+                board.publish_manifest(VersionManifest(version=2, base_version=1, backend="fake", load_format="noop"))
+                manager.queue_sync(2)
+                self.assertEqual(manager.queued_target_version, 2)
+
+                engine.apply_gate.set()
+                await sync
+
+                self.assertEqual(manager.current_version, 2)
+                self.assertEqual(manager.sync_state, SyncState.IDLE)
+                self.assertIsNone(manager.queued_target_version)
+                self.assertEqual([version for version, _ in engine.applies], [1, 2])
+
+        asyncio.run(run())
+
     def test_run_change_rematerializes_and_resets_under_gate(self) -> None:
         async def run() -> None:
             with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Adds the GLM-4.5-Air FP8 disaggregated Miles experiment and the small Stitch/runtime pieces needed for the train -> XOR disk delta -> sidecar apply -> SGLang reload loop.

Key changes:
- add `glm45_air_fp8_disagg` using BF16 trainer weights from `torch_dist` and native HF FP8 rollout weights from `zai-org/GLM-4.5-Air-FP8`
- teach checkpoint prep to stage/copy a native FP8 rollout base
- apply an SGLang runtime patch that preserves FP8 parameter loader/sharding attrs across online reload
- skip SGLang reload for empty claim deltas and keep queued sync work that arrives during a commit
- document the GLM-Air FP8 workflow and update the miles serving wrapper naming

## Validation

Local checks:
- `git diff --cached --check`
- `python3 -m compileall -q cookbook/miles_disagg src/stitch`
- `PYTHONPATH=src python3 -m unittest src/stitch/sync_test.py src/stitch/engines/sglang_test.py src/stitch/servers/sglang_test.py` (23 tests)
- `git -C /home/ec2-user/sglang apply --check cookbook/miles_disagg/patches/sglang-fp8-reload-attrs.patch`

Modal e2e evidence:
- deployed `miles-glm45-air-fp8-disagg`
- trainer call `fc-01KWR3W3801MG6WKE7C39JDXCX` completed `SUCCESS`
- delta run `2a6f73622a19` published `weight_v000001` through `weight_v000010`; `/latest` points at `weight_v000010`
- exact-version-10 rollout smoke passed; gateway and both live rollout containers reported `current_version=10`, `sync_state=IDLE`, and `last_sync_error=None`

## Notes

The SGLang patch is kept as a runtime patch against the SGLang checkout rather than embedding monkey-patch Python in Stitch. Version 1 is expected to be an empty pool-claim/reset delta; real deltas start at version 2.