### PR TITLE
Drop unnecessary DISABLE_HF_XET/DISABLE_HF_TRANSFER flags

### DIFF
--- a/cookbook/miles_disagg/configs/glm45_air_bf16_disagg.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16_disagg.py
@@ -13,9 +13,6 @@ SOURCE_MODEL = "zai-org/GLM-4.5-Air"
 MODEL_TAG = "glm45-air-bf16"
 SERVED_CHECKPOINT_FORMAT = "bf16"
 USE_MODAL_TORCH_DIST_WRAPPER = True
-# The standard HF downloader was the path that finished reliably for this model.
-DISABLE_HF_XET = True
-DISABLE_HF_TRANSFER = True
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_DEBUG_REQUESTS = True

--- a/cookbook/miles_disagg/configs/glm45_air_fp8_disagg.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8_disagg.py
@@ -14,9 +14,6 @@ ROLLOUT_SOURCE_MODEL = "zai-org/GLM-4.5-Air-FP8"
 MODEL_TAG = "glm45-air-bf16"
 SERVED_CHECKPOINT_FORMAT = "fp8"
 USE_MODAL_TORCH_DIST_WRAPPER = True
-# The standard HF downloader was the path that finished reliably for this model.
-DISABLE_HF_XET = True
-DISABLE_HF_TRANSFER = True
 
 SIDECAR_COMMIT_MODE = "quiesce"
 SIDECAR_DEBUG_REQUESTS = True

--- a/cookbook/miles_disagg/modal_train.py
+++ b/cookbook/miles_disagg/modal_train.py
@@ -498,12 +498,6 @@ def prepare_checkpoints() -> None:
       2. served NVFP4 base: tools/convert_hf_to_nvfp4.py over the masters, so the
          served packing == the trainer's export packing by construction.
     """
-    if getattr(exp, "DISABLE_HF_XET", False):
-        os.environ["HF_HUB_DISABLE_XET"] = "1"
-        os.environ.pop("HF_XET_HIGH_PERFORMANCE", None)
-    if getattr(exp, "DISABLE_HF_TRANSFER", False):
-        os.environ.pop("HF_HUB_ENABLE_HF_TRANSFER", None)
-
     from huggingface_hub import snapshot_download
 
     prep_volume.reload()


### PR DESCRIPTION
## Summary

Addresses the nit from the [PR #12 review](https://github.com/modal-projects/stitch/pull/12#pullrequestreview-4634045816): the `DISABLE_HF_XET` / `DISABLE_HF_TRANSFER` config knobs weren't necessary, so this removes them from all configs that set them and drops the now-dead handling.

- remove `DISABLE_HF_XET = True` / `DISABLE_HF_TRANSFER = True` (and their explanatory comment) from `glm45_air_fp8_disagg.py` and `glm45_air_bf16_disagg.py`
- remove the corresponding `getattr(exp, "DISABLE_HF_*", ...)` branches in `modal_train.py:prepare_checkpoints` that popped/set `HF_HUB_DISABLE_XET` / `HF_HUB_ENABLE_HF_TRANSFER` — with no config setting these attrs, those branches were dead. The image still exports `HF_XET_HIGH_PERFORMANCE=1` and `HF_HUB_ENABLE_HF_TRANSFER=1`.

The remaining review comments (adopting the `SGLANG_RUNTIME_PATCHES` structure elsewhere, the `MILES_REPO_REF` consistency question, enabling `use_rollout_routing_replay`, and pulling the GLM4Moe expert-bias bake into a miles patch) are follow-ups by the reviewer's own framing and are left for a separate PR — see my replies on the thread.

## Validation
- `python3 -m compileall -q` on the three changed files
- `grep -rn DISABLE_HF cookbook/ src/` returns nothing


Link to Devin session: https://modal.devinenterprise.com/sessions/ef865f2b9c9347d9a265abd67d2b7cae
Requested by: @jvmncs