### PR TITLE
Resurrect GLM4Moe expert-bias fp32-export fix as a runtime miles patch

### DIFF
--- a/cookbook/miles_disagg/README.md
+++ b/cookbook/miles_disagg/README.md
@@ -136,6 +136,10 @@ needed by `glm45_air_fp8_disagg`.
 The megatron routing-replay (R3) fix is baked into the trainer image at build
 time (idempotent — a no-op once the fork ships it).
 
+The GLM4Moe expert-bias fp32-export fix is applied at trainer startup as
+`patches/miles-glm4moe-expert-bias-fp32.patch` via `MILES_RUNTIME_PATCHES`
+against the `/root/miles` checkout (idempotent).
+
 Dev iteration: overlay a local miles checkout at deploy time (no rebuild, no
 push). This is optional; the committed GLM-Air FP8 path does not require a local
 overlay. This only overlays miles; the megatron R3 fix still comes from the

--- a/cookbook/miles_disagg/configs/glm45_air_bf16_disagg.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16_disagg.py
@@ -19,6 +19,9 @@ DISABLE_HF_TRANSFER = True
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_DEBUG_REQUESTS = True
+MILES_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/miles-glm4moe-expert-bias-fp32.patch",
+]
 
 
 def build_serving_image(**kwargs):

--- a/cookbook/miles_disagg/configs/glm45_air_fp8_disagg.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8_disagg.py
@@ -23,6 +23,9 @@ SIDECAR_DEBUG_REQUESTS = True
 SGLANG_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/sglang-fp8-reload-attrs.patch",
 ]
+MILES_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/miles-glm4moe-expert-bias-fp32.patch",
+]
 
 
 def build_serving_image(**kwargs):

--- a/cookbook/miles_disagg/helpers.py
+++ b/cookbook/miles_disagg/helpers.py
@@ -70,11 +70,10 @@ def smoke_flash_pool(**kwargs: Any) -> None:
     _smoke_flash_pool(wake_on_demand=WAKE_ON_DEMAND, **kwargs)
 
 
-def apply_sglang_runtime_patches(patch_paths: list[str], repo_dir: str = "/sgl-workspace/sglang") -> None:
-    """Apply git patches to the runtime SGLang checkout before server start."""
+def _apply_git_patches(patch_paths: list[str], repo_dir: str, label: str, runtime_name: str) -> None:
     for patch_path in patch_paths:
         if not os.path.exists(patch_path):
-            raise FileNotFoundError(f"SGLang runtime patch not found: {patch_path}")
+            raise FileNotFoundError(f"{runtime_name} not found: {patch_path}")
 
         check = subprocess.run(
             ["git", "-C", repo_dir, "apply", "--check", patch_path],
@@ -83,7 +82,7 @@ def apply_sglang_runtime_patches(patch_paths: list[str], repo_dir: str = "/sgl-w
         )
         if check.returncode == 0:
             subprocess.run(["git", "-C", repo_dir, "apply", patch_path], check=True)
-            print(f"[SGLang patch] applied {patch_path}", flush=True)
+            print(f"[{label}] applied {patch_path}", flush=True)
             continue
 
         reverse = subprocess.run(
@@ -92,14 +91,24 @@ def apply_sglang_runtime_patches(patch_paths: list[str], repo_dir: str = "/sgl-w
             text=True,
         )
         if reverse.returncode == 0:
-            print(f"[SGLang patch] already applied {patch_path}", flush=True)
+            print(f"[{label}] already applied {patch_path}", flush=True)
             continue
 
         raise RuntimeError(
-            f"Cannot apply SGLang runtime patch {patch_path}\n"
+            f"Cannot apply {runtime_name} {patch_path}\n"
             f"apply --check stderr:\n{check.stderr}\n"
             f"reverse --check stderr:\n{reverse.stderr}"
         )
+
+
+def apply_sglang_runtime_patches(patch_paths: list[str], repo_dir: str = "/sgl-workspace/sglang") -> None:
+    """Apply git patches to the runtime SGLang checkout before server start."""
+    _apply_git_patches(patch_paths, repo_dir, "SGLang patch", "SGLang runtime patch")
+
+
+def apply_miles_runtime_patches(patch_paths: list[str], repo_dir: str = "/root/miles") -> None:
+    """Apply git patches to the runtime miles checkout before trainer start."""
+    _apply_git_patches(patch_paths, repo_dir, "miles patch", "miles runtime patch")
 
 
 def materialize_node_local_yaml(cfg: Any, field: str, dest_dir: str = "/root/.miles_node_yaml") -> None:

--- a/cookbook/miles_disagg/modal_train.py
+++ b/cookbook/miles_disagg/modal_train.py
@@ -365,6 +365,11 @@ class Trainer:
     @modal.enter()
     def start_ray(self) -> None:
         rank, master_addr, my_ip = helpers.get_modal_cluster_context(N_TRAIN_NODES)
+        # /root/miles is editable-installed from the image checkout, so imports
+        # read on-disk source; patch every node here before Ray starts.
+        helpers.apply_miles_runtime_patches(
+            list(getattr(exp, "MILES_RUNTIME_PATCHES", [])), repo_dir=MILES_ROOT
+        )
         self.rank = rank
         # Per-node host-RAM trace: the trainer can OOM-kill at host-RAM exhaustion
         # (the publish/update_weights gather is the peak), and Modal's kill leaves no

--- a/cookbook/miles_disagg/patches/miles-glm4moe-expert-bias-fp32.patch
+++ b/cookbook/miles_disagg/patches/miles-glm4moe-expert-bias-fp32.patch
@@ -1,0 +1,13 @@
+diff --git a/miles/backends/megatron_utils/megatron_to_hf/glm4moe.py b/miles/backends/megatron_utils/megatron_to_hf/glm4moe.py
+index 11819bddc..a0cee1d14 100644
+--- a/miles/backends/megatron_utils/megatron_to_hf/glm4moe.py
++++ b/miles/backends/megatron_utils/megatron_to_hf/glm4moe.py
+@@ -114,7 +114,7 @@ def convert_glm4moe_to_hf(args, name, param):
+             return [(hf_name, to_model_dtype(args, param, hf_name))]
+         elif rest == "mlp.router.expert_bias":
+             hf_name = f"model.layers.{layer_idx}.mlp.gate.e_score_correction_bias"
+-            return [(hf_name, to_model_dtype(args, param, hf_name))]
++            return [(hf_name, param)]
+ 
+         # qk norm
+         elif rest == "self_attention.q_layernorm.weight":


### PR DESCRIPTION
## Summary

PR #12 deleted the build-time bake that kept the GLM4Moe expert-bias HF export fp32 (needed for BF16 disk-delta byte-shape parity, and a prerequisite for rollout routing replay). This resurrects that fix, but through the `patches/` + `git apply` flow #12 introduced for SGLang — addressing [this review comment](https://github.com/modal-projects/stitch/pull/12#discussion_r3527117541).

What changed:
- **New patch** `patches/miles-glm4moe-expert-bias-fp32.patch` — in `miles/backends/megatron_utils/megatron_to_hf/glm4moe.py`, the `mlp.router.expert_bias` export becomes `return [(hf_name, param)]` instead of `to_model_dtype(args, param, hf_name)`, so the exported bias stays fp32.
- **`helpers.py`** — extracted the git check/apply/reverse-check loop from `apply_sglang_runtime_patches` into a shared `_apply_git_patches(paths, repo_dir, label, ...)`, and added `apply_miles_runtime_patches(paths, repo_dir="/root/miles")` on top of it. Same idempotent semantics (skip when reverse-check passes).
- **`modal_train.py`** — `Trainer.start_ray()` (SPMD `@modal.enter`, runs on every node) applies `MILES_RUNTIME_PATCHES` to the `/root/miles` checkout before Ray starts.
- **configs** — `MILES_RUNTIME_PATCHES = [".../miles-glm4moe-expert-bias-fp32.patch"]` on `glm45_air_bf16_disagg` (restores what the deletion dropped) and `glm45_air_fp8_disagg`.

Why this is a valid way to patch the miles source (the "is git-apply legal" question):
- `/root/miles` is a `git clone` in the image build and installed with `pip install --no-deps -e`, so imports read the on-disk source — patching the file before import takes effect.
- The export runs inside Ray actors during training; applying in `start_ray()` on **every** node before `ray start` patches all nodes' checkouts before any actor imports the converter. This matches the old bake's all-nodes, per-image semantics (the old bake was gated by `PATCH_GLM4MOE_EXPERT_BIAS_FP32`, set only by `glm45_air_bf16_disagg`).
- Verified against the pinned fork ref `852fb9a`: exactly one expert-bias export site; `git apply --check` and the reverse-check both pass.

## Validation
- cloned `modal-projects/miles@852fb9a`; `git apply --check` + apply + `--reverse --check` of the new patch all pass
- `python3 -m compileall -q cookbook/miles_disagg src/stitch`
- `PYTHONPATH=src python3 -m unittest src/stitch/sync_test.py src/stitch/engines/sglang_test.py src/stitch/servers/sglang_test.py` → **23 tests OK**

Not covered here: enabling `use_rollout_routing_replay = True` for GLM and the end-to-end Modal validation run — deferred to the routing-replay follow-up.


Link to Devin session: https://modal.devinenterprise.com/sessions/ef865f2b9c9347d9a265abd67d2b7cae
Requested by: @jvmncs