### PR TITLE
Convert R3 Megatron dispatch bake to a runtime git-apply patch

### DIFF
--- a/cookbook/miles_disagg/README.md
+++ b/cookbook/miles_disagg/README.md
@@ -133,13 +133,14 @@ The image pins `modal-projects/miles` branch `nvfp4-disagg-v2` by commit
 publish-only / NVFP4 fixes, and the GLM-Air native FP8 disk-delta export support
 needed by `glm45_air_fp8_disagg`.
 
-The megatron routing-replay (R3) fix is baked into the trainer image at build
-time (idempotent — a no-op once the fork ships it).
+The megatron routing-replay (R3) fix is applied at trainer startup as
+`patches/megatron-r3-dispatch.patch` via `MEGATRON_RUNTIME_PATCHES` against the
+`/root/Megatron-LM` checkout (idempotent).
 
 Dev iteration: overlay a local miles checkout at deploy time (no rebuild, no
-push). This is optional; the committed GLM-Air FP8 path does not require a local
-overlay. This only overlays miles; the megatron R3 fix still comes from the
-bake.
+push). This is optional; the committed GLM-Air FP8 path does not require a
+local overlay. This only overlays miles; the megatron R3 fix still comes from
+the runtime patch.
 
 ```bash
 MILES_LOCAL_DIR=/path/to/miles EXPERIMENT_CONFIG=moonlight_nvfp4_disagg \

--- a/cookbook/miles_disagg/configs/glm45_air_bf16_disagg.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16_disagg.py
@@ -19,6 +19,10 @@ DISABLE_HF_TRANSFER = True
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_DEBUG_REQUESTS = True
+# R3 routing-replay needs the dropless Megatron dispatch fix at startup.
+MEGATRON_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+]
 
 
 def build_serving_image(**kwargs):

--- a/cookbook/miles_disagg/configs/glm45_air_fp8_disagg.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8_disagg.py
@@ -23,6 +23,10 @@ SIDECAR_DEBUG_REQUESTS = True
 SGLANG_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/sglang-fp8-reload-attrs.patch",
 ]
+# R3 routing-replay needs the dropless Megatron dispatch fix at startup.
+MEGATRON_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+]
 
 
 def build_serving_image(**kwargs):

--- a/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4_disagg.py
+++ b/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4_disagg.py
@@ -32,6 +32,10 @@ MODEL_TAG = "kimi-k25-2layer-nvfp4"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_DEBUG_REQUESTS = True
+# R3 routing-replay needs the dropless Megatron dispatch fix at startup.
+MEGATRON_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+]
 
 
 def build_serving_image(**kwargs):

--- a/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4_disagg.py
+++ b/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4_disagg.py
@@ -75,6 +75,10 @@ MODEL_TAG = "kimi-k2-6-nvfp4"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_DEBUG_REQUESTS = True
+# R3 routing-replay needs the dropless Megatron dispatch fix at startup.
+MEGATRON_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+]
 
 
 def build_serving_image(**kwargs):

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4_disagg.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4_disagg.py
@@ -56,6 +56,10 @@ MODEL_TAG = "moonlight-16b-nvfp4"  # names the prepared dirs under PREP_PATH
 # rollouts; stale-version KV is isolated per weight version by the sidecar.
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_DEBUG_REQUESTS = True
+# R3 routing-replay needs the dropless Megatron dispatch fix at startup.
+MEGATRON_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+]
 
 
 def build_serving_image(**kwargs):

--- a/cookbook/miles_disagg/helpers.py
+++ b/cookbook/miles_disagg/helpers.py
@@ -70,11 +70,10 @@ def smoke_flash_pool(**kwargs: Any) -> None:
     _smoke_flash_pool(wake_on_demand=WAKE_ON_DEMAND, **kwargs)
 
 
-def apply_sglang_runtime_patches(patch_paths: list[str], repo_dir: str = "/sgl-workspace/sglang") -> None:
-    """Apply git patches to the runtime SGLang checkout before server start."""
+def _apply_git_patches(patch_paths: list[str], repo_dir: str, label: str, runtime_name: str) -> None:
     for patch_path in patch_paths:
         if not os.path.exists(patch_path):
-            raise FileNotFoundError(f"SGLang runtime patch not found: {patch_path}")
+            raise FileNotFoundError(f"{runtime_name} not found: {patch_path}")
 
         check = subprocess.run(
             ["git", "-C", repo_dir, "apply", "--check", patch_path],
@@ -83,7 +82,7 @@ def apply_sglang_runtime_patches(patch_paths: list[str], repo_dir: str = "/sgl-w
         )
         if check.returncode == 0:
             subprocess.run(["git", "-C", repo_dir, "apply", patch_path], check=True)
-            print(f"[SGLang patch] applied {patch_path}", flush=True)
+            print(f"[{label}] applied {patch_path}", flush=True)
             continue
 
         reverse = subprocess.run(
@@ -92,14 +91,24 @@ def apply_sglang_runtime_patches(patch_paths: list[str], repo_dir: str = "/sgl-w
             text=True,
         )
         if reverse.returncode == 0:
-            print(f"[SGLang patch] already applied {patch_path}", flush=True)
+            print(f"[{label}] already applied {patch_path}", flush=True)
             continue
 
         raise RuntimeError(
-            f"Cannot apply SGLang runtime patch {patch_path}\n"
+            f"Cannot apply {runtime_name} {patch_path}\n"
             f"apply --check stderr:\n{check.stderr}\n"
             f"reverse --check stderr:\n{reverse.stderr}"
         )
+
+
+def apply_sglang_runtime_patches(patch_paths: list[str], repo_dir: str = "/sgl-workspace/sglang") -> None:
+    """Apply git patches to the runtime SGLang checkout before server start."""
+    _apply_git_patches(patch_paths, repo_dir, "SGLang patch", "SGLang runtime patch")
+
+
+def apply_megatron_runtime_patches(patch_paths: list[str], repo_dir: str = "/root/Megatron-LM") -> None:
+    """Apply git patches to the runtime Megatron checkout before trainer start."""
+    _apply_git_patches(patch_paths, repo_dir, "Megatron patch", "Megatron runtime patch")
 
 
 def materialize_node_local_yaml(cfg: Any, field: str, dest_dir: str = "/root/.miles_node_yaml") -> None:

--- a/cookbook/miles_disagg/modal_train.py
+++ b/cookbook/miles_disagg/modal_train.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import importlib
 import os
-import shlex
 import subprocess
 import tempfile
 import uuid
@@ -78,24 +77,6 @@ MEGATRON_PATH = "/root/Megatron-LM"
 MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
 MILES_REPO_REF = "852fb9a5cfb3c4630691b643ed354a9703ff3722"
 
-# Build-time bake of the megatron R3 dispatch fix (see the .run_commands call
-# below). Kept as a string so the build step has no host-file dependency; the
-# replace targets a single, stable line and reports how many sites it hit.
-_R3_DISPATCH_TARGET = "/root/Megatron-LM/megatron/core/transformer/moe/token_dispatcher.py"
-_R3_DISPATCH_OLD = "self.num_out_tokens = routing_map.size(0) * self.config.moe_router_topk"
-_R3_DISPATCH_NEW = (
-    "self.num_out_tokens = num_local_tokens_per_expert.sum()\n"
-    '            self._maybe_update_cuda_sync_point("before_permutation_1")'
-)
-_R3_DISPATCH_BAKE_PY = (
-    "import pathlib;"
-    f"p=pathlib.Path({_R3_DISPATCH_TARGET!r});"
-    "s=p.read_text();"
-    f"n=s.count({_R3_DISPATCH_OLD!r});"
-    f"p.write_text(s.replace({_R3_DISPATCH_OLD!r}, {_R3_DISPATCH_NEW!r}));"
-    "print(f'[R3 bake] patched {n} dispatch site(s) in token_dispatcher.py')"
-)
-
 TORCH_DIST_CONVERT_WRAPPER = "/root/convert_hf_to_torch_dist_modal.py"
 
 image = (
@@ -124,14 +105,6 @@ image = (
         f" && git checkout FETCH_HEAD"
         f" && python3 -m pip install --no-deps -e {MILES_ROOT}"
     )
-    # R3 routing-replay fix for the baked radixark/Megatron-LM. The dropless MoE
-    # token dispatcher computes num_out_tokens = routing_map.size(0) * topk, which
-    # assumes topk distinct experts/token — false under routing replay (duplicate
-    # / -1 experts collapse in the boolean map), causing the EP all-to-all to
-    # crash with "Split sizes doesn't match total dim 0 size". Derive it from the
-    # actual per-expert counts instead (identical to size*topk in the dense
-    # non-replay case). Idempotent: a no-op once the fork itself ships the fix.
-    .run_commands(f"python3 -c {shlex.quote(_R3_DISPATCH_BAKE_PY)}")
     .pip_install(
         "fastapi",  # stitch sidecar (rollout pool reuses this image only if no serving image)
         "httpx",
@@ -365,6 +338,11 @@ class Trainer:
     @modal.enter()
     def start_ray(self) -> None:
         rank, master_addr, my_ip = helpers.get_modal_cluster_context(N_TRAIN_NODES)
+        # /root/Megatron-LM is editable-installed from the image checkout, so
+        # patch the on-disk source here on every node before Ray starts.
+        helpers.apply_megatron_runtime_patches(
+            list(getattr(exp, "MEGATRON_RUNTIME_PATCHES", [])), repo_dir=MEGATRON_PATH
+        )
         self.rank = rank
         # Per-node host-RAM trace: the trainer can OOM-kill at host-RAM exhaustion
         # (the publish/update_weights gather is the peak), and Modal's kill leaves no

--- a/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch
+++ b/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch
@@ -1,0 +1,21 @@
+# R3 routing-replay fix for the baked radixark/Megatron-LM. The dropless MoE
+# token dispatcher computes num_out_tokens = routing_map.size(0) * topk, which
+# assumes topk distinct experts/token -- false under routing replay (duplicate
+# / -1 experts collapse in the boolean map), causing the EP all-to-all to crash
+# with "Split sizes doesn't match total dim 0 size". Derive it from the actual
+# per-expert counts instead (identical to size*topk in the dense non-replay
+# case). Idempotent: a no-op once the fork itself ships the fix.
+diff --git a/megatron/core/transformer/moe/token_dispatcher.py b/megatron/core/transformer/moe/token_dispatcher.py
+index 327dbc8a3..afeca2603 100644
+--- a/megatron/core/transformer/moe/token_dispatcher.py
++++ b/megatron/core/transformer/moe/token_dispatcher.py
+@@ -523,7 +523,8 @@ class MoEAlltoAllTokenDispatcher(MoETokenDispatcher):
+         else:
+             # For dropless training, output size is static (num_tokens * topk)
+             # No explicit sync needed
+-            self.num_out_tokens = routing_map.size(0) * self.config.moe_router_topk
++            self.num_out_tokens = num_local_tokens_per_expert.sum()
++            self._maybe_update_cuda_sync_point("before_permutation_1")
+         if self.ep_size > 1 or self.tp_size > 1:
+             # ===================================================
+             # Calculate input_splits, output_splits for alltoall/allgather in variable size.


### PR DESCRIPTION
## Summary

The routing-replay (R3) fix for the baked `radixark/Megatron-LM` was an inline **build-time** string bake in `modal_train.py`. This moves it to the `patches/` + `git apply` flow that #12 introduced for SGLang, so every source patch (sglang, megatron) now goes through one uniform runtime mechanism. No behavior change — R3 was applied to every config's trainer image before, and still is.

What changed:
- **New patch** `patches/megatron-r3-dispatch.patch` — in `megatron/core/transformer/moe/token_dispatcher.py`, the dropless `else` branch's `num_out_tokens = routing_map.size(0) * topk` becomes the per-expert-count form (`num_local_tokens_per_expert.sum()` + `_maybe_update_cuda_sync_point(...)`, identical to the sync branch just above). The R3 rationale is preserved as a comment header on the patch (git apply ignores pre-diff text).
- **`helpers.py`** — extracted the git check/apply/reverse-check loop into a shared `_apply_git_patches(paths, repo_dir, label, runtime_name)`; `apply_sglang_runtime_patches` now delegates to it, and new `apply_megatron_runtime_patches(paths, repo_dir="/root/Megatron-LM")` sits on top. Same idempotent semantics (reverse-check → "already applied" skip).
- **`modal_train.py`** — deleted the `_R3_DISPATCH_*` constants, the `.run_commands(python3 -c ...)` bake, and the now-unused `import shlex`. `Trainer.start_ray()` (SPMD `@modal.enter`, every node) applies `MEGATRON_RUNTIME_PATCHES` to `/root/Megatron-LM` before Ray starts.
- **configs** — `MEGATRON_RUNTIME_PATCHES = [".../megatron-r3-dispatch.patch"]` added to all five configs (the old bake was unconditional).

Why runtime git-apply is valid here: the miles Dockerfile does `git clone radixark/Megatron-LM -b miles-main && pip install -e .`, so `/root/Megatron-LM` is a git checkout that's editable-installed — imports read on-disk source. The trainer does not re-clone Megatron-LM, so the image's checkout is exactly what gets patched. Applying in `start_ray()` on every node patches all checkouts before any Ray actor imports the dispatcher.

## Validation
- extracted the real `/root/Megatron-LM` from `radixark/miles:latest` (a git checkout); `git apply --check` + apply + `--reverse --check` of the new patch all pass
- `python3 -m compileall -q cookbook/miles_disagg src/stitch`
- `PYTHONPATH=src python3 -m unittest src/stitch/sync_test.py src/stitch/engines/sglang_test.py src/stitch/servers/sglang_test.py` → **23 tests OK**
- `git grep "shlex\|_R3_DISPATCH\|BAKE_PY" cookbook/miles_disagg/modal_train.py` → empty

Deferred: the end-to-end Modal routing-replay validation run.


Link to Devin session: https://modal.devinenterprise.com/sessions/ef865f2b9c9347d9a265abd67d2b7cae
Requested by: @jvmncs