### PR TITLE
Fix FP8 reload weight corruption in sglang-fp8-reload-attrs.patch

### DIFF
--- a/cookbook/miles_disagg/patches/sglang-fp8-reload-attrs.patch
+++ b/cookbook/miles_disagg/patches/sglang-fp8-reload-attrs.patch
@@ -1,393 +1,285 @@
 diff --git a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
-index d4dafa224b..d62c1f480f 100644
+index d4dafa224..4caeb134e 100644
 --- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
 +++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
-@@ -36,6 +36,123 @@ if _use_aiter:
+@@ -36,6 +36,27 @@ if _use_aiter:
      from aiter.ops.shuffle import shuffle_weight
-
-
-+
-+import types
-+
-+
-+_RELOAD_METHOD_NAMES = (
-+    "load_column_parallel_weight",
-+    "load_row_parallel_weight",
-+    "load_merged_column_weight",
-+    "load_qkv_weight",
-+    "_assert_and_load",
-+    "_load_into_shard_id",
-+    "_shard_id_as_int",
-+    "adjust_shard_indexes_for_packing",
-+)
-+
-+
-+def _copy_reload_methods(src, dst):
-+    # Fallback for Parameter wrappers that cannot preserve the original subclass.
-+    # The saved weight_loader still calls the subclass sharding helpers.
-+    for name in _RELOAD_METHOD_NAMES:
-+        method = getattr(src, name, None)
-+        func = getattr(method, "__func__", None)
-+        if func is None:
-+            func = getattr(type(src), name, None)
-+        if callable(func):
-+            setattr(dst, name, types.MethodType(func, dst))
-+    return dst
-+
-+
-+def _reload_attrs(src, *, transpose_2d: bool = False):
-+    # Keep sharding-aware loader attrs after FP8 postprocess wraps Parameters.
-+    out = dict(getattr(src, "__dict__", {}))
-+    out.pop("_sglang_fp8_reload_ready", None)
-+    out.pop("_sglang_fp8_reload_transposed", None)
-+
-+    attrs = (
-+        "weight_padded",
-+        "is_transposed",
-+        "is_metadata",
-+        "needs_scalar_to_array",
-+        "ignore_warning",
-+        "quant_method",
-+        "_sglang_require_global_experts",
-+    )
-+    for attr in attrs:
-+        if not hasattr(src, attr):
-+            continue
-+        out[attr] = getattr(src, attr)
-+    if transpose_2d:
-+        for attr in ("_input_dim", "_output_dim"):
-+            value = out.get(attr)
-+            if isinstance(value, int):
-+                out[attr] = 1 - value
-+    return out
-+
-+
-+def _apply_reload_attrs(dst, attrs):
-+    for attr, value in attrs.items():
-+        try:
-+            setattr(dst, attr, value)
-+        except AttributeError:
-+            # Read-only properties on SGLang parameter subclasses are backed by
-+            # private attrs that are already copied from __dict__.
-+            pass
-+    return dst
-+
-+
-+def _parameter_like(src, data, attrs):
-+    cls = type(src)
-+    try:
-+        dst = cls.__new__(cls, data)
-+        dst.requires_grad_(False)
-+    except Exception:
-+        dst = Parameter(data, requires_grad=False)
-+    _apply_reload_attrs(dst, attrs)
-+    _copy_reload_methods(src, dst)
-+    return dst
-+
-+
-+def _mark_reload_ready(dst, *, transposed: bool = False):
-+    dst._sglang_fp8_reload_ready = True
-+    dst._sglang_fp8_reload_transposed = transposed
-+    return dst
-+
-+
-+def _preserve_reload_attrs(src, dst):
-+    dst = _parameter_like(src, dst.data, _reload_attrs(src))
-+    return _mark_reload_ready(dst)
-+
-+
-+def _preserve_transposed_reload_attrs(src, dst):
-+    original_attrs = _reload_attrs(src)
-+    transposed_attrs = _reload_attrs(src, transpose_2d=True)
-+    dst = _parameter_like(src, dst.data, transposed_attrs)
-+    original_loader = original_attrs.get("_weight_loader") or getattr(src, "weight_loader", None)
-+    if original_loader is None:
-+        return _mark_reload_ready(dst, transposed=True)
-+    load_shape = tuple(src.data.shape)
-+    load_stride = tuple(src.data.stride())
-+    load_dtype = src.data.dtype
-+
-+    def transposed_weight_loader(param, loaded_weight, *args, **kwargs):
-+        tmp = _parameter_like(
-+            src,
-+            torch.empty_strided(load_shape, load_stride, dtype=load_dtype, device=param.data.device),
-+            original_attrs,
-+        )
-+        original_loader(tmp, loaded_weight, *args, **kwargs)
-+        param.data.copy_(tmp.data.t())
-+
-+    try:
-+        dst._weight_loader = transposed_weight_loader
-+    except Exception:
-+        dst.weight_loader = transposed_weight_loader
-+    return _mark_reload_ready(dst, transposed=True)
+ 
+ 
++def _bind_serving_param(layer, name: str, value) -> None:
++    """Bind/refresh a derived serving tensor. When a Parameter of matching
++    shape/dtype is already bound, refresh it IN PLACE so captured CUDA graphs
++    (which hold the serving tensor's storage) stay valid across reloads;
++    same-storage views are left untouched."""
++    existing = getattr(layer, name, None)
++    if (
++        isinstance(existing, Parameter)
++        and existing.shape == value.shape
++        and existing.dtype == value.dtype
++    ):
++        if (
++            existing.data.data_ptr() == value.data_ptr()
++            and existing.data.stride() == value.stride()
++        ):
++            return
++        existing.data.copy_(value)
++        return
++    setattr(layer, name, Parameter(value, requires_grad=False))
 +
 +
  strategy_to_parameter_type = {
      QuantizationStrategy.BLOCK: BlockQuantScaleParameter,
      QuantizationStrategy.CHANNEL: ChannelQuantScaleParameter,
-@@ -141,6 +258,9 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
+@@ -141,6 +162,17 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
              layer.register_parameter("input_scale", input_scale)
-
+ 
      def process_weights_after_loading(self, layer) -> None:
-+        if getattr(layer.weight, "_sglang_fp8_reload_ready", False):
-+            return
-+
++        # Reload-safe postprocess: the registered checkpoint-layout Parameters
++        # (weight / weight_scale / input_scale) are never replaced, so their
++        # stock weight_loaders keep working for update_weights_from_disk and
++        # captured CUDA graphs keep pointing at live storage. Derived serving
++        # forms are written in place (the per-shard -> max-scale requant) or
++        # bound as `*_serving` attributes (transposed views / collapsed
++        # scalars); apply_weights reads only the `*_serving` attributes.
++        # Invariant: this hook runs exactly once after each full (re)load of
++        # the layer -- the in-place transforms consume freshly loaded raw
++        # bytes (running it twice without an intervening load would requant
++        # already-requantized bytes against the raw per-shard scales).
          if self.strategy == QuantizationStrategy.TENSOR:
              max_w_scale, weight = requantize_with_max_scale(
                  weight=layer.weight,
-@@ -156,8 +276,14 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
+@@ -149,63 +181,73 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
+             )
+ 
+             if is_fp8_fnuz():
++                # ROCm: the normalized forms are copies, rebound per load.
+                 input_scale = getattr(layer, "input_scale", None)
+ 
+                 weight, max_w_scale, input_scale = normalize_e4m3fn_to_e4m3fnuz(
+                     weight=weight, weight_scale=max_w_scale, input_scale=input_scale
                  )
                  if input_scale is not None:
-                     layer.input_scale = Parameter(input_scale, requires_grad=False)
+-                    layer.input_scale = Parameter(input_scale, requires_grad=False)
 -            layer.weight = Parameter(weight.t(), requires_grad=False)
 -            layer.weight_scale = Parameter(max_w_scale, requires_grad=False)
-+            old_weight = layer.weight
-+            old_weight_scale = layer.weight_scale
-+            layer.weight = _preserve_transposed_reload_attrs(
-+                old_weight, Parameter(weight.t(), requires_grad=False)
-+            )
-+            layer.weight_scale = _preserve_reload_attrs(
-+                old_weight_scale, Parameter(max_w_scale, requires_grad=False)
-+            )
-
++                    _bind_serving_param(layer, "input_scale_serving", input_scale)
++                _bind_serving_param(layer, "weight_serving", weight.t())
++            else:
++                layer.weight.data.copy_(weight)
++                layer.weight.requires_grad_(False)
++                _bind_serving_param(layer, "weight_serving", layer.weight.data.t())
++            _bind_serving_param(layer, "weight_scale_serving", max_w_scale)
+ 
          elif self.strategy == QuantizationStrategy.CHANNEL:
-             weight = layer.weight
-@@ -175,16 +301,23 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
-             else:
-                 weight_scale = layer.weight_scale.data
-
-+            old_weight = layer.weight
-+            old_weight_scale = layer.weight_scale
+-            weight = layer.weight
++            weight = layer.weight.data
++            weight_scale = layer.weight_scale.data
+ 
+             if is_fp8_fnuz():
++                # ROCm: the normalized forms are copies, rebound per load.
+                 input_scale = getattr(layer, "input_scale", None)
+ 
+                 weight, weight_scale, input_scale = normalize_e4m3fn_to_e4m3fnuz(
+                     weight=weight,
+-                    weight_scale=layer.weight_scale,
++                    weight_scale=weight_scale,
+                     input_scale=input_scale,
+                 )
+                 if input_scale is not None:
+-                    layer.input_scale = Parameter(input_scale, requires_grad=False)
+-            else:
+-                weight_scale = layer.weight_scale.data
++                    _bind_serving_param(layer, "input_scale_serving", input_scale)
+ 
              if _use_aiter:
-                 # keep the weight as (N, K)
+-                # keep the weight as (N, K)
 -                layer.weight = Parameter(
 -                    shuffle_weight(weight, (16, 16)), requires_grad=False
-+                layer.weight = _preserve_reload_attrs(
-+                    old_weight,
-+                    Parameter(shuffle_weight(weight, (16, 16)), requires_grad=False),
-                 )
+-                )
++                # keep the weight as (N, K); the shuffle re-runs on the
++                # freshly loaded raw bytes after every load
++                shuffled = shuffle_weight(weight, (16, 16))
++                if shuffled.dtype == layer.weight.dtype:
++                    layer.weight.data.copy_(shuffled)
++                    layer.weight.requires_grad_(False)
++                    shuffled = layer.weight.data
++                _bind_serving_param(layer, "weight_serving", shuffled)
              else:
 -                layer.weight = Parameter(weight.t(), requires_grad=False)
-+                layer.weight = _preserve_transposed_reload_attrs(
-+                    old_weight, Parameter(weight.t(), requires_grad=False)
-+                )
-
++                _bind_serving_param(layer, "weight_serving", weight.t())
+ 
              # required by torch.compile to be torch.nn.Parameter
 -            layer.weight_scale = Parameter(weight_scale, requires_grad=False)
-+            layer.weight_scale = _preserve_reload_attrs(
-+                old_weight_scale, Parameter(weight_scale, requires_grad=False)
-+            )
-
++            _bind_serving_param(layer, "weight_scale_serving", weight_scale)
+ 
          elif self.strategy == QuantizationStrategy.BLOCK:
              assert self.is_static_input_scheme is False
-@@ -203,7 +336,10 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
-
-         # INPUT SCALE
-         if self.is_static_input_scheme and hasattr(layer, "input_scale"):
--            layer.input_scale = Parameter(layer.input_scale.max(), requires_grad=False)
-+            old_input_scale = layer.input_scale
-+            layer.input_scale = _preserve_reload_attrs(
-+                old_input_scale, Parameter(old_input_scale.max(), requires_grad=False)
-+            )
+-            weight = layer.weight
+-            weight_scale = layer.weight_scale
++            weight = layer.weight.data
++            weight_scale = layer.weight_scale.data
+ 
+             if is_fp8_fnuz():
+                 weight, weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
+                     weight=weight, weight_scale=weight_scale
+                 )
+-            layer.weight = Parameter(weight.data, requires_grad=False)
+-            layer.weight_scale = Parameter(weight_scale.data, requires_grad=False)
++            _bind_serving_param(layer, "weight_serving", weight)
++            _bind_serving_param(layer, "weight_scale_serving", weight_scale)
+ 
          else:
-             layer.input_scale = None
-
+             raise ValueError(f"Unknown quantization strategy {self.strategy}")
+ 
+         # INPUT SCALE
+-        if self.is_static_input_scheme and hasattr(layer, "input_scale"):
+-            layer.input_scale = Parameter(layer.input_scale.max(), requires_grad=False)
++        if self.is_static_input_scheme and getattr(layer, "input_scale", None) is not None:
++            if not is_fp8_fnuz():
++                _bind_serving_param(layer, "input_scale_serving", layer.input_scale.max())
+         else:
+-            layer.input_scale = None
++            layer.input_scale_serving = None
+ 
+     def apply_weights(
+         self,
+@@ -216,19 +258,19 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
+         if self.weight_block_size is not None:
+             return self.w8a8_block_fp8_linear(
+                 input=x,
+-                weight=layer.weight,
++                weight=layer.weight_serving,
+                 block_size=self.weight_block_size,
+-                weight_scale=layer.weight_scale,
+-                input_scale=layer.input_scale,
++                weight_scale=layer.weight_scale_serving,
++                input_scale=layer.input_scale_serving,
+                 bias=bias,
+             )
+ 
+         if _use_aiter and self.strategy == QuantizationStrategy.CHANNEL:
+             return apply_fp8_ptpc_linear(
+                 input=x,
+-                weight=layer.weight,
+-                weight_scale=layer.weight_scale,
+-                input_scale=layer.input_scale,
++                weight=layer.weight_serving,
++                weight_scale=layer.weight_scale_serving,
++                input_scale=layer.input_scale_serving,
+                 bias=bias,
+                 use_per_token_if_dynamic=True,
+                 compressed_tensor_quant=True,
+@@ -236,9 +278,9 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsLinearScheme):
+         else:
+             return apply_fp8_linear(
+                 input=x,
+-                weight=layer.weight,
+-                weight_scale=layer.weight_scale,
+-                input_scale=layer.input_scale,
++                weight=layer.weight_serving,
++                weight_scale=layer.weight_scale_serving,
++                input_scale=layer.input_scale_serving,
+                 bias=bias,
+                 use_per_token_if_dynamic=True,
+                 compressed_tensor_quant=True,
 diff --git a/python/sglang/srt/layers/quantization/w8a8_fp8.py b/python/sglang/srt/layers/quantization/w8a8_fp8.py
-index aeea826cd5..f4f4fd1d0d 100644
+index aeea826cd..83302d892 100644
 --- a/python/sglang/srt/layers/quantization/w8a8_fp8.py
 +++ b/python/sglang/srt/layers/quantization/w8a8_fp8.py
-@@ -36,6 +36,122 @@ if TYPE_CHECKING:
+@@ -36,6 +36,27 @@ if TYPE_CHECKING:
  _is_fp8_fnuz = is_fp8_fnuz()
-
-
-+import types
-+
-+
-+_RELOAD_METHOD_NAMES = (
-+    "load_column_parallel_weight",
-+    "load_row_parallel_weight",
-+    "load_merged_column_weight",
-+    "load_qkv_weight",
-+    "_assert_and_load",
-+    "_load_into_shard_id",
-+    "_shard_id_as_int",
-+    "adjust_shard_indexes_for_packing",
-+)
-+
-+
-+def _copy_reload_methods(src, dst):
-+    # Fallback for Parameter wrappers that cannot preserve the original subclass.
-+    # The saved weight_loader still calls the subclass sharding helpers.
-+    for name in _RELOAD_METHOD_NAMES:
-+        method = getattr(src, name, None)
-+        func = getattr(method, "__func__", None)
-+        if func is None:
-+            func = getattr(type(src), name, None)
-+        if callable(func):
-+            setattr(dst, name, types.MethodType(func, dst))
-+    return dst
-+
-+
-+def _reload_attrs(src, *, transpose_2d: bool = False):
-+    # Keep sharding-aware loader attrs after FP8 postprocess wraps Parameters.
-+    out = dict(getattr(src, "__dict__", {}))
-+    out.pop("_sglang_fp8_reload_ready", None)
-+    out.pop("_sglang_fp8_reload_transposed", None)
-+
-+    attrs = (
-+        "weight_padded",
-+        "is_transposed",
-+        "is_metadata",
-+        "needs_scalar_to_array",
-+        "ignore_warning",
-+        "quant_method",
-+        "_sglang_require_global_experts",
-+    )
-+    for attr in attrs:
-+        if not hasattr(src, attr):
-+            continue
-+        out[attr] = getattr(src, attr)
-+    if transpose_2d:
-+        for attr in ("_input_dim", "_output_dim"):
-+            value = out.get(attr)
-+            if isinstance(value, int):
-+                out[attr] = 1 - value
-+    return out
-+
-+
-+def _apply_reload_attrs(dst, attrs):
-+    for attr, value in attrs.items():
-+        try:
-+            setattr(dst, attr, value)
-+        except AttributeError:
-+            # Read-only properties on SGLang parameter subclasses are backed by
-+            # private attrs that are already copied from __dict__.
-+            pass
-+    return dst
-+
-+
-+def _parameter_like(src, data, attrs):
-+    cls = type(src)
-+    try:
-+        dst = cls.__new__(cls, data)
-+        dst.requires_grad_(False)
-+    except Exception:
-+        dst = Parameter(data, requires_grad=False)
-+    _apply_reload_attrs(dst, attrs)
-+    _copy_reload_methods(src, dst)
-+    return dst
-+
-+
-+def _mark_reload_ready(dst, *, transposed: bool = False):
-+    dst._sglang_fp8_reload_ready = True
-+    dst._sglang_fp8_reload_transposed = transposed
-+    return dst
-+
-+
-+def _preserve_reload_attrs(src, dst):
-+    dst = _parameter_like(src, dst.data, _reload_attrs(src))
-+    return _mark_reload_ready(dst)
-+
-+
-+def _preserve_transposed_reload_attrs(src, dst):
-+    original_attrs = _reload_attrs(src)
-+    transposed_attrs = _reload_attrs(src, transpose_2d=True)
-+    dst = _parameter_like(src, dst.data, transposed_attrs)
-+    original_loader = original_attrs.get("_weight_loader") or getattr(src, "weight_loader", None)
-+    if original_loader is None:
-+        return _mark_reload_ready(dst, transposed=True)
-+    load_shape = tuple(src.data.shape)
-+    load_stride = tuple(src.data.stride())
-+    load_dtype = src.data.dtype
-+
-+    def transposed_weight_loader(param, loaded_weight, *args, **kwargs):
-+        tmp = _parameter_like(
-+            src,
-+            torch.empty_strided(load_shape, load_stride, dtype=load_dtype, device=param.data.device),
-+            original_attrs,
-+        )
-+        original_loader(tmp, loaded_weight, *args, **kwargs)
-+        param.data.copy_(tmp.data.t())
-+
-+    try:
-+        dst._weight_loader = transposed_weight_loader
-+    except Exception:
-+        dst.weight_loader = transposed_weight_loader
-+    return _mark_reload_ready(dst, transposed=True)
+ 
+ 
++def _bind_serving_param(layer, name: str, value) -> None:
++    """Bind/refresh a derived serving tensor. When a Parameter of matching
++    shape/dtype is already bound, refresh it IN PLACE so captured CUDA graphs
++    (which hold the serving tensor's storage) stay valid across reloads;
++    same-storage views are left untouched."""
++    existing = getattr(layer, name, None)
++    if (
++        isinstance(existing, Parameter)
++        and existing.shape == value.shape
++        and existing.dtype == value.dtype
++    ):
++        if (
++            existing.data.data_ptr() == value.data_ptr()
++            and existing.data.stride() == value.stride()
++        ):
++            return
++        existing.data.copy_(value)
++        return
++    setattr(layer, name, Parameter(value, requires_grad=False))
 +
 +
  class W8A8Fp8Config(QuantizationConfig):
      """Config class for W8A8 FP8 Quantization.
-
-@@ -107,6 +223,8 @@ class W8A8Fp8LinearMethod(LinearMethodBase):
+ 
+@@ -107,7 +128,11 @@ class W8A8Fp8LinearMethod(LinearMethodBase):
          self.quantization_config = quantization_config
-
+ 
      def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-+        if getattr(layer.weight, "_sglang_fp8_reload_transposed", False):
-+            return
-         weight = layer.weight
-
+-        weight = layer.weight
++        # Reload-safe: the registered checkpoint-layout Parameters are never
++        # replaced (their weight_loaders keep working on reloads); serving
++        # reads the derived `*_serving` attributes, re-derived after every
++        # load. See CompressedTensorsW8A8Fp8 for the pattern.
++        weight = layer.weight.data
+ 
          if self.quantization_config.is_checkpoint_fp8_serialized:
-@@ -117,8 +235,14 @@ class W8A8Fp8LinearMethod(LinearMethodBase):
+             weight_scale = layer.weight_scale.detach()
+@@ -117,8 +142,8 @@ class W8A8Fp8LinearMethod(LinearMethodBase):
                      weight=weight, weight_scale=weight_scale
                  )
-
+ 
 -            layer.weight = Parameter(weight.t(), requires_grad=False)
 -            layer.weight_scale = Parameter(weight_scale, requires_grad=False)
-+            old_weight = layer.weight
-+            old_weight_scale = layer.weight_scale
-+            layer.weight = _preserve_transposed_reload_attrs(
-+                old_weight, Parameter(weight.t(), requires_grad=False)
-+            )
-+            layer.weight_scale = _preserve_reload_attrs(
-+                old_weight_scale, Parameter(weight_scale, requires_grad=False)
-+            )
++            _bind_serving_param(layer, "weight_serving", weight.t())
++            _bind_serving_param(layer, "weight_scale_serving", weight_scale)
          else:
              # If checkpoint not offline quantized, quantize the weights with per-channel quantization.
              if self.cutlass_fp8_supported:
-@@ -134,8 +258,14 @@ class W8A8Fp8LinearMethod(LinearMethodBase):
+@@ -133,10 +158,10 @@ class W8A8Fp8LinearMethod(LinearMethodBase):
+                 # which requires per tensor quantization on weight
                  qweight, weight_scale = input_to_float8(layer.weight, dtype=fp8_dtype)
-
-             # Update the layer with the new values.
+ 
+-            # Update the layer with the new values.
 -            layer.weight = Parameter(qweight.t(), requires_grad=False)
 -            layer.weight_scale = Parameter(weight_scale, requires_grad=False)
-+            old_weight = layer.weight
-+            old_weight_scale = layer.weight_scale
-+            layer.weight = _preserve_transposed_reload_attrs(
-+                old_weight, Parameter(qweight.t(), requires_grad=False)
-+            )
-+            layer.weight_scale = _preserve_reload_attrs(
-+                old_weight_scale, Parameter(weight_scale, requires_grad=False)
-+            )
-             layer.input_scale = None
-
+-            layer.input_scale = None
++            # The bf16 raw weight stays registered; the quantized serving copy
++            # is re-derived after every load.
++            _bind_serving_param(layer, "weight_serving", qweight.t())
++            _bind_serving_param(layer, "weight_scale_serving", weight_scale)
+ 
      def create_weights(
-@@ -271,13 +401,21 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
+         self,
+@@ -187,8 +212,8 @@ class W8A8Fp8LinearMethod(LinearMethodBase):
+     ):
+         return apply_fp8_linear(
+             x,
+-            layer.weight,
+-            layer.weight_scale,
++            layer.weight_serving,
++            layer.weight_scale_serving,
+             bias=bias,
+             cutlass_fp8_supported=self.cutlass_fp8_supported,
+         )
+@@ -271,14 +296,10 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
          layer.register_parameter("w2_input_scale", w2_input_scale)
-
+ 
      def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
 -        layer.w13_weight = Parameter(layer.w13_weight, requires_grad=False)
 -        layer.w2_weight = Parameter(layer.w2_weight, requires_grad=False)
 -        layer.w13_weight_scale = Parameter(
 -            layer.w13_weight_scale.data, requires_grad=False
-+        old_w13_weight = layer.w13_weight
-+        old_w2_weight = layer.w2_weight
-+        old_w13_weight_scale = layer.w13_weight_scale
-+        old_w2_weight_scale = layer.w2_weight_scale
-+        layer.w13_weight = _preserve_reload_attrs(
-+            old_w13_weight, Parameter(old_w13_weight.data, requires_grad=False)
-+        )
-+        layer.w2_weight = _preserve_reload_attrs(
-+            old_w2_weight, Parameter(old_w2_weight.data, requires_grad=False)
-+        )
-+        layer.w13_weight_scale = _preserve_reload_attrs(
-+            old_w13_weight_scale, Parameter(old_w13_weight_scale.data, requires_grad=False)
-         )
+-        )
 -        layer.w2_weight_scale = Parameter(
 -            layer.w2_weight_scale.data, requires_grad=False
-+        layer.w2_weight_scale = _preserve_reload_attrs(
-+            old_w2_weight_scale, Parameter(old_w2_weight_scale.data, requires_grad=False)
-         )
-
+-        )
++        # Keep the registered Parameters (and their weight_loaders) intact for
++        # reloads; the replaced-Parameter re-wrap only cleared requires_grad.
++        for name in ("w13_weight", "w2_weight", "w13_weight_scale", "w2_weight_scale"):
++            getattr(layer, name).requires_grad_(False)
+ 
      def create_moe_runner(
+         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig


### PR DESCRIPTION
The weight-sync checksum probe caught the runtime patch from #12 corrupting the fused w8a8 weights (`qkv_proj`/`gate_up_proj`) on every `update_weights_from_disk` — this affects every weight sync in the GLM-Air FP8 example.

**Two defects in the current patch:**
1. `transposed_weight_loader` stages each shard in a fresh **uninitialized** `torch.empty_strided` buffer, then copies the *whole* buffer over the fused weight — each of q/k/v clobbers the other two shards with allocator leftovers. Usually the caching allocator hands back the previous call's block and it looks fine; under `num_threads=8` loading it races, so the served bytes are nondeterministic (two identical reloads produce different weights). Single-shard params (o_proj, down_proj) are immune, which is exactly the divergence pattern the per-tensor checksums showed.
2. The `_sglang_fp8_reload_ready` early-return skips `requantize_with_max_scale` on reload, so freshly loaded raw per-shard-scale bytes are served against the boot-collapsed max scale.

**Rewritten architecture** (smaller than the wrapper approach it replaces): registered checkpoint-layout Parameters are never replaced — stock shard-aware loaders keep working, no wrapper machinery; postprocess re-runs after every load doing the shard→max-scale requant **in place**; kernels read derived `*_serving` attributes (transposed views / collapsed scalars) that refresh pointer-stably so captured CUDA graphs stay valid across reloads.

**Verification** (GLM-4.5-Air-FP8, H200:4, real published deltas from run `2a6f73622a19`): record vs replay vs second-replay checksums match per tensor per rank (`plan_checksum_match: True`, `plan_checksum_match_fast: True`), and a partial-request-fallback reload is byte-identical to a plain full reload of the same delta-patched checkpoint (`partial_checksum_match: True`). All three comparisons failed on the current main, on exactly the fused weights. The patch applies cleanly on both the current `dafb2b3` pin and `weight-sync-upstream`.

cc @nanjiangwill — this rewrites your patch from #12; the reload-ability it provides is preserved, verified by consecutive-reload checksum gates.