### PR TITLE
Weight-sync core: staged split, no-op skip, touched-name plumbing, reload metrics

### DIFF
--- a/src/stitch/engines/sglang.py
+++ b/src/stitch/engines/sglang.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from stitch.protocol import VersionManifest
 
@@ -21,6 +23,20 @@ def _transition_files(manifest: VersionManifest) -> list[str]:
     if not files:
         files = [artifact.path for artifact in manifest.artifacts if artifact.kind == "transition"]
     return files
+
+
+def parse_reload_timing(message: str) -> dict[str, float]:
+    """Lift the engine's optional ``[reload timing] iter_wait=1.2s load=3.4s ...``
+    success-message suffix (emitted by the instrumented modal-projects/sglang
+    fork) into ``{"engine_iter_wait_s": 1.2, ...}``. Empty on engines without
+    the instrumentation, so callers can treat the result as best-effort."""
+    match = re.search(r"\[reload timing\]([^\[\]]*)", message)
+    if match is None:
+        return {}
+    return {
+        f"engine_{key}_s": float(value)
+        for key, value in re.findall(r"(\w+)=([0-9.]+)s", match.group(1))
+    }
 
 
 def compose_extra_key(
@@ -58,13 +74,13 @@ class SGLangDiskDeltaAdapter:
     local_checkpoint_dir: str
     base_checkpoint_dir: str
     backend: str = "disk_delta"
-    apply_deltas: Callable[[str, str, int], None] | None = None
+    apply_deltas: Callable[[str, str, int], Any] | None = None
     init_local_checkpoint: Callable[[str, str], None] | None = None
 
     def __post_init__(self) -> None:
         self.upstream_url = self.upstream_url.rstrip("/")
 
-    def _apply_deltas(self) -> Callable[[str, str, int], None]:
+    def _apply_deltas(self) -> Callable[[str, str, int], Any]:
         if self.apply_deltas is not None:
             return self.apply_deltas
         from slime.utils.disk_delta import apply_deltas
@@ -124,30 +140,50 @@ class SGLangDiskDeltaAdapter:
             resp = await client.post(f"{self.upstream_url}/continue_generation", json={})
             resp.raise_for_status()
 
-    async def apply_manifest(self, manifest: VersionManifest, version_path: str) -> None:
-        import httpx
+    async def stage_manifest(self, manifest: VersionManifest, version_path: str) -> dict[str, Any] | None:
+        """Bring the local checkpoint up to this version host-side (apply_deltas
+        chain-replays from whatever is applied, verifying each base_version).
 
-        # Bring the local checkpoint up to this version host-side (apply_deltas
-        # chain-replays from whatever is applied, verifying each base_version),
-        # then reload the full local checkpoint. version_path is the published
-        # version dir; its parent is the root of weight_v* dirs apply_deltas walks.
+        Safe to run while the engine serves: between reloads nothing reads the
+        local checkpoint (weights live on the GPU), so the sync manager calls
+        this BEFORE closing the commit gate. version_path is the published
+        version dir; its parent is the root of weight_v* dirs apply_deltas walks.
+
+        Returns a timing/phase breakdown for server_info metrics; newer decoders
+        return per-version phase stats from ``apply_deltas``, older ones None.
+        """
         delta_root = str(Path(version_path).parent)
         _t_apply = time.perf_counter()
-        await asyncio.to_thread(
+        stats = await asyncio.to_thread(
             self._apply_deltas(), self.local_checkpoint_dir, delta_root, int(manifest.version)
         )
-        logger.info(
-            "[apply timing] v=%s host_delta_apply=%.2fs", manifest.version, time.perf_counter() - _t_apply
-        )
-        if not _transition_files(manifest):
-            logger.info(
-                "[apply timing] v=%s engine_reload=skipped empty_delta",
-                manifest.version,
-            )
-            return
+        elapsed = time.perf_counter() - _t_apply
+        logger.info("[apply timing] v=%s host_delta_apply=%.2fs", manifest.version, elapsed)
+        detail: dict[str, Any] = {"host_delta_apply_s": round(elapsed, 3)}
+        if stats:
+            detail["versions"] = stats
+        return detail
+
+    async def commit_manifest(
+        self,
+        manifest: VersionManifest,
+        version_path: str,
+        weight_names: list[str] | None = None,
+    ) -> dict[str, Any] | None:
+        """Reload the staged local checkpoint into the engine. The sync
+        manager calls this under the commit gate (engine paused in in_place
+        mode), after :meth:`stage_manifest` has materialized the version.
+
+        ``weight_names`` is the tail's union of touched tensor names; an
+        engine with the reload load plan uses it to reload only the touched
+        modules (O(delta)) and silently full-reloads otherwise. Set
+        ``STITCH_PARTIAL_RELOAD=0`` to withhold the names entirely."""
+        import os
+
+        import httpx
 
         _t_reload = time.perf_counter()
-        payload = {
+        payload: dict[str, Any] = {
             "model_path": self.local_checkpoint_dir,
             "weight_version": str(manifest.version),
             # The sync manager flushes via GET /flush_cache while quiesced.
@@ -156,12 +192,28 @@ class SGLangDiskDeltaAdapter:
             # it must stay disabled here.
             "flush_cache": False,
         }
+        if weight_names and os.environ.get("STITCH_PARTIAL_RELOAD", "1") == "1":
+            payload["weight_names"] = list(weight_names)
         async with httpx.AsyncClient(timeout=None, trust_env=False) as client:
             resp = await client.post(f"{self.upstream_url}/update_weights_from_disk", json=payload)
             resp.raise_for_status()
             data = resp.json()
             if data.get("success") is False:
                 raise RuntimeError(f"SGLang rejected weight update: {data}")
-        logger.info(
-            "[apply timing] v=%s engine_reload=%.2fs", manifest.version, time.perf_counter() - _t_reload
-        )
+        elapsed = time.perf_counter() - _t_reload
+        logger.info("[apply timing] v=%s engine_reload=%.2fs", manifest.version, elapsed)
+        detail: dict[str, Any] = {"engine_reload_s": round(elapsed, 3)}
+        detail.update(parse_reload_timing(str(data.get("message") or "")))
+        return detail
+
+    async def apply_manifest(self, manifest: VersionManifest, version_path: str) -> None:
+        """Combined stage + reload, kept for callers that don't use the staged
+        split (the sync manager prefers stage_manifest/commit_manifest)."""
+        await self.stage_manifest(manifest, version_path)
+        if not _transition_files(manifest):
+            logger.info(
+                "[apply timing] v=%s engine_reload=skipped empty_delta",
+                manifest.version,
+            )
+            return
+        await self.commit_manifest(manifest, version_path)

--- a/src/stitch/engines/sglang_test.py
+++ b/src/stitch/engines/sglang_test.py
@@ -4,7 +4,7 @@ import asyncio
 import unittest
 from unittest import mock
 
-from stitch.engines.sglang import SGLangDiskDeltaAdapter, compose_extra_key
+from stitch.engines.sglang import SGLangDiskDeltaAdapter, compose_extra_key, parse_reload_timing
 from stitch.protocol import VersionManifest
 
 
@@ -13,6 +13,7 @@ class _RecordingPost:
 
     last_url: str | None = None
     last_json: dict | None = None
+    response_json: dict = {"success": True}
 
     def __init__(self, *args, **kwargs) -> None:
         pass
@@ -28,7 +29,7 @@ class _RecordingPost:
 
         type(self).last_url = url
         type(self).last_json = json
-        return httpx.Response(200, json={"success": True}, request=httpx.Request("POST", url))
+        return httpx.Response(200, json=type(self).response_json, request=httpx.Request("POST", url))
 
 
 class SGLangDiskDeltaAdapterTest(unittest.TestCase):
@@ -97,6 +98,61 @@ class SGLangDiskDeltaAdapterTest(unittest.TestCase):
             self.assertIsNone(_RecordingPost.last_json)
 
         asyncio.run(run())
+
+    def test_staged_split_reports_metrics(self) -> None:
+        async def run() -> None:
+            apply_stats = [{"version": "000005", "apply_s": 1.2}]
+
+            adapter = SGLangDiskDeltaAdapter(
+                upstream_url="http://up",
+                local_checkpoint_dir="/local",
+                base_checkpoint_dir="/base",
+                apply_deltas=lambda local, root, version: apply_stats,
+                init_local_checkpoint=lambda local, base: None,
+            )
+            manifest = VersionManifest(
+                version=5, base_version=4, backend="disk_delta", load_format="auto"
+            )
+
+            stage_detail = await adapter.stage_manifest(manifest, "/bulletin/versions/weight_v000005")
+            self.assertIn("host_delta_apply_s", stage_detail)
+            # A decoder that returns per-version phase stats gets them surfaced.
+            self.assertEqual(stage_detail["versions"], apply_stats)
+
+            with mock.patch("httpx.AsyncClient", _RecordingPost):
+                _RecordingPost.response_json = {
+                    "success": True,
+                    "message": "Succeeded. [reload timing] iter_wait=1.50s load=4.20s postprocess=0.30s total=6.00s",
+                }
+                commit_detail = await adapter.commit_manifest(manifest, "/bulletin/versions/weight_v000005")
+                _RecordingPost.response_json = {"success": True}
+
+            self.assertIn("engine_reload_s", commit_detail)
+            # The instrumented fork's message suffix is lifted into metrics.
+            self.assertEqual(commit_detail["engine_load_s"], 4.20)
+            self.assertEqual(commit_detail["engine_total_s"], 6.00)
+
+        asyncio.run(run())
+
+
+class ParseReloadTimingTest(unittest.TestCase):
+    def test_parses_instrumented_message(self) -> None:
+        timing = parse_reload_timing(
+            "Succeeded to update model weights. [reload timing] iter_wait=12.30s load=45.60s "
+            "postprocess=7.80s total=70.10s Weight version updated to 5."
+        )
+        self.assertEqual(
+            timing,
+            {
+                "engine_iter_wait_s": 12.30,
+                "engine_load_s": 45.60,
+                "engine_postprocess_s": 7.80,
+                "engine_total_s": 70.10,
+            },
+        )
+
+    def test_uninstrumented_message_yields_nothing(self) -> None:
+        self.assertEqual(parse_reload_timing("Succeeded to update model weights."), {})
 
 
 class ExtraKeyTest(unittest.TestCase):

--- a/src/stitch/protocol.py
+++ b/src/stitch/protocol.py
@@ -242,6 +242,10 @@ class VersionManifest:
     compression_format: str | None = None
     checksum_format: str | None = None
     transition_files: list[str] = field(default_factory=list)
+    # The touched checkpoint tensor names (the delta index's weight_map keys).
+    # Engines that support partial reloads use these to reload only the
+    # modules a version actually changed; empty means unknown -> full reload.
+    transition_weights: list[str] = field(default_factory=list)
     created_at: float = field(default_factory=time.time)
     protocol_version: int = PROTOCOL_VERSION
     artifacts: list[Artifact] = field(default_factory=list)
@@ -264,6 +268,7 @@ class VersionManifest:
         transition_files = [str(x) for x in data.get("transition_files", [])]
         if not transition_files:
             transition_files = [a.path for a in artifacts if a.kind == "transition"]
+        transition_weights = [str(x) for x in data.get("transition_weights", [])]
         return cls(
             version=int(data["version"]),
             base_version=int(data["base_version"]),
@@ -273,6 +278,7 @@ class VersionManifest:
             compression_format=_optional_str(data.get("compression_format")),
             checksum_format=_optional_str(data.get("checksum_format")),
             transition_files=transition_files,
+            transition_weights=transition_weights,
             created_at=float(data.get("created_at", 0.0)),
             protocol_version=protocol_version,
             artifacts=artifacts,
@@ -304,7 +310,8 @@ class VersionManifest:
         with index_path.open("r", encoding="utf-8") as f:
             index = json.load(f)
         meta = index.get("metadata") or {}
-        files = sorted({str(name) for name in (index.get("weight_map") or {}).values()})
+        weight_map = index.get("weight_map") or {}
+        files = sorted({str(name) for name in weight_map.values()})
         return cls(
             version=int(meta["version"]),
             base_version=int(meta["base_version"]),
@@ -314,6 +321,7 @@ class VersionManifest:
             compression_format=_optional_str(meta.get("compression_format")),
             checksum_format=_optional_str(meta.get("checksum_format")),
             transition_files=files,
+            transition_weights=sorted(str(name) for name in weight_map),
             artifacts=[Artifact(kind="transition", path=path) for path in files],
             run_id=run_id,
             base_model=base_model,
@@ -341,6 +349,8 @@ class VersionManifest:
             data["compression_format"] = self.compression_format
         if self.checksum_format is not None:
             data["checksum_format"] = self.checksum_format
+        if self.transition_weights:
+            data["transition_weights"] = list(self.transition_weights)
         if self.run_id is not None:
             data["run_id"] = self.run_id
         if self.base_model is not None:
@@ -591,8 +601,19 @@ class EngineAdapter(Protocol):
 
     An adapter bridges the sync manager to one inference engine instance.
     Required methods are called during every version commit; optional methods
-    (``prepare``, ``reset``) are probed with ``getattr`` at startup and on run
-    switches, so adapters may omit them.
+    (``prepare``, ``reset``, ``stage_manifest``, ``commit_manifest``) are probed
+    with ``getattr``, so adapters may omit them.
+
+    An adapter that implements BOTH ``stage_manifest(manifest, version_path)``
+    and ``commit_manifest(manifest, version_path, weight_names=None)`` gets the
+    staged split: the sync manager runs ``stage_manifest`` (host-side
+    materialization) while the engine still serves, and only
+    ``commit_manifest`` (the engine reload) under the commit gate / pause —
+    instead of one combined ``apply_manifest`` inside the gate.
+    ``weight_names`` is the tail's union of touched tensor names (from
+    ``transition_weights``), or None when any tail version left them unknown;
+    adapters may use it for partial reloads. Either hook may return an
+    optional metrics dict, surfaced under ``server_info()["metrics"]``.
 
     See :class:`stitch.engines.sglang.SGLangDiskDeltaAdapter` for the canonical
     implementation.

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping
 from contextlib import asynccontextmanager
@@ -228,6 +229,12 @@ class WeightSyncManager(RolloutAdmissionGate):
         self.queued_target_version: int | None = None
         self.sync_state = SyncState.IDLE
         self.last_sync_error: str | None = None
+        # Per-stage wall-clock breakdown of the most recent sync pass (seconds),
+        # exposed via server_info()["metrics"] so a scraper can attribute sync
+        # latency to board refresh / host apply / drain / pause / reload without
+        # log access. Written whole (never mutated in place) at the end of each
+        # pass, including failed ones (with an "error" key).
+        self.last_sync_metrics: dict[str, Any] = {}
         self._sync_task: asyncio.Task[None] | None = None
         self._sync_lock = asyncio.Lock()
 
@@ -253,6 +260,7 @@ class WeightSyncManager(RolloutAdmissionGate):
             "sync_task_active": self._sync_task is not None and not self._sync_task.done(),
             "active_requests": self._active_requests,
             "inflight_exact_versions": self.inflight_exact_versions,
+            "metrics": self.last_sync_metrics,
         }
 
     def _on_policy_violation(self, error: dict[str, Any]) -> None:
@@ -343,58 +351,158 @@ class WeightSyncManager(RolloutAdmissionGate):
 
     async def _sync_once(self) -> bool:
         async with self._sync_lock:
-            await self.board.refresh()
-            run_id, latest = self.board.read_latest()
-            if run_id != self.current_run_id:
-                await self._switch_run(run_id)
-            self.latest_seen_version = max(self.latest_seen_version, latest)
-            if latest <= self.current_version:
-                return True
+            metrics: dict[str, Any] = {}
+            try:
+                return await self._sync_once_measured(metrics)
+            except Exception as exc:
+                metrics["error"] = str(exc)
+                raise
+            finally:
+                # A pass that found no work leaves the previous breakdown alone.
+                if len(metrics) > 1 or "error" in metrics:
+                    metrics["recorded_at"] = time.time()
+                    self.last_sync_metrics = metrics
 
-            self.sync_state = SyncState.PREFETCHING
-            self.last_sync_error = None
+    async def _sync_once_measured(self, metrics: dict[str, Any]) -> bool:
+        t0 = time.perf_counter()
+        await self.board.refresh()
+        metrics["board_refresh_s"] = round(time.perf_counter() - t0, 3)
+        run_id, latest = self.board.read_latest()
+        if run_id != self.current_run_id:
+            await self._switch_run(run_id)
+        self.latest_seen_version = max(self.latest_seen_version, latest)
+        if latest <= self.current_version:
+            return True
 
-            # Verify the whole tail is a contiguous chain before touching the
-            # engine, so a broken chain fails before any pause/apply. apply_deltas
-            # re-verifies each step's base_version internally as it replays.
-            expected_base = self.current_version
-            target_manifest: VersionManifest | None = None
-            for version in range(self.current_version + 1, latest + 1):
-                manifest = self.board.read_manifest(self.current_run_id, version)
-                if manifest.base_version != expected_base:
-                    raise RuntimeError(
-                        f"cannot apply version {version}: manifest base "
-                        f"{manifest.base_version} != expected {expected_base}"
-                    )
-                expected_base = version
-                target_manifest = manifest
-            assert target_manifest is not None  # latest > current_version, so the loop ran
-            target_path = str(self.board.version_dir(self.current_run_id, latest))
+        self.sync_state = SyncState.PREFETCHING
+        self.last_sync_error = None
 
-            # Compose the tail and reload once: apply_manifest(target) replays
-            # every delta from the applied version up to `latest` host-side, then
-            # does a single engine reload — not one reload per intermediate version.
-            self.sync_state = SyncState.PREPARING
+        # Verify the whole tail is a contiguous chain before touching the
+        # engine, so a broken chain fails before any pause/apply. apply_deltas
+        # re-verifies each step's base_version internally as it replays.
+        t0 = time.perf_counter()
+        expected_base = self.current_version
+        target_manifest: VersionManifest | None = None
+        tail_transition_files = 0
+        # Union of the tail's touched tensor names, for engines that support
+        # partial reloads. Any manifest without names makes the tail unknown.
+        tail_weights: set[str] | None = set()
+        for version in range(self.current_version + 1, latest + 1):
+            manifest = self.board.read_manifest(self.current_run_id, version)
+            if manifest.base_version != expected_base:
+                raise RuntimeError(
+                    f"cannot apply version {version}: manifest base "
+                    f"{manifest.base_version} != expected {expected_base}"
+                )
+            expected_base = version
+            tail_transition_files += len(manifest.transition_files)
+            if tail_weights is not None and manifest.transition_weights:
+                tail_weights.update(manifest.transition_weights)
+            elif manifest.transition_files:
+                tail_weights = None  # a version with files but unknown names
+            target_manifest = manifest
+        assert target_manifest is not None  # latest > current_version, so the loop ran
+        target_path = str(self.board.version_dir(self.current_run_id, latest))
+        metrics["manifest_verify_s"] = round(time.perf_counter() - t0, 3)
+        metrics["target_version"] = latest
+        metrics["tail_versions"] = latest - self.current_version
+        metrics["tail_transition_files"] = tail_transition_files
+        if tail_weights is not None:
+            metrics["tail_weights"] = len(tail_weights)
+
+        # Compose the tail and reload once: the adapter replays every delta from
+        # the applied version up to `latest` host-side, then does a single engine
+        # reload — not one reload per intermediate version.
+        self.sync_state = SyncState.PREPARING
+
+        # An adapter that offers the staged split gets the host-side patch done
+        # BEFORE the commit gate: between reloads nothing reads the local
+        # checkpoint (weights live on the GPU), so staging can run while the
+        # engine still serves and the pause covers only the engine reload.
+        stage = getattr(self.engine, "stage_manifest", None)
+        commit = getattr(self.engine, "commit_manifest", None)
+        staged = stage is not None and commit is not None
+        if staged:
+            t0 = time.perf_counter()
+            stage_detail = await stage(target_manifest, target_path)
+            metrics["stage_s"] = round(time.perf_counter() - t0, 3)
+            if stage_detail:
+                metrics["stage_detail"] = stage_detail
+
+        def on_applied() -> None:
+            self.current_version = latest
+
+        # A tail that changes zero bytes (an all-empty disk-delta publish, the
+        # common case for low-churn QAT) still must advance the served version,
+        # but reloading identical weights would pause the engine for nothing —
+        # commit the version bump without pause, flush, or reload. Stale KV
+        # stays numerically valid because the weights are byte-identical.
+        if target_manifest.backend == "disk_delta" and tail_transition_files == 0:
+
+            async def apply_nothing() -> None:
+                self.sync_state = SyncState.COMMITTING
+
+            t0 = time.perf_counter()
+            await self.commit_version(apply=apply_nothing, on_applied=on_applied)
+            metrics["gate_s"] = round(time.perf_counter() - t0, 3)
+            metrics["skipped_noop_reload"] = True
+            logger.info(
+                "v=%s: empty delta tail — advanced version without engine reload", latest
+            )
+        else:
 
             async def apply(manifest: VersionManifest = target_manifest, version_path: str = target_path) -> None:
                 # quiesce flushes before applying; in_place skips the flush
                 # (the gate paused the engine and stale KV resumes as-is).
                 if self.commit_mode != "in_place":
+                    t = time.perf_counter()
                     await self.engine.flush_cache()
+                    metrics["flush_s"] = round(time.perf_counter() - t, 3)
                 self.sync_state = SyncState.COMMITTING
-                await self.engine.apply_manifest(manifest, version_path)
+                t = time.perf_counter()
+                if staged:
+                    commit_detail = await commit(
+                        manifest,
+                        version_path,
+                        weight_names=sorted(tail_weights) if tail_weights else None,
+                    )
+                    if commit_detail:
+                        metrics["commit_detail"] = commit_detail
+                else:
+                    await self.engine.apply_manifest(manifest, version_path)
+                metrics["commit_s"] = round(time.perf_counter() - t, 3)
+
+            async def pause() -> None:
+                t = time.perf_counter()
+                await self.engine.pause_generation()
+                metrics["pause_s"] = round(time.perf_counter() - t, 3)
+
+            async def resume() -> None:
+                t = time.perf_counter()
+                await self.engine.continue_generation()
+                metrics["resume_s"] = round(time.perf_counter() - t, 3)
 
             # on_applied bumps current_version under the gate (before
             # continue_generation in in_place mode), so a request can never be
             # admitted observing the stale version on mutated weights.
+            t0 = time.perf_counter()
             await self.commit_version(
                 apply=apply,
-                on_applied=lambda: setattr(self, "current_version", latest),
-                pause=self.engine.pause_generation,
-                resume=self.engine.continue_generation,
+                on_applied=on_applied,
+                pause=pause,
+                resume=resume,
             )
-            self.sync_state = SyncState.PREFETCHING
+            metrics["gate_s"] = round(time.perf_counter() - t0, 3)
+            # The gate time not spent in a measured sub-stage is the wait for
+            # in-flight requests to drain (exact pins in in_place mode; all
+            # proxied requests in quiesce mode).
+            metrics["drain_wait_s"] = round(
+                metrics["gate_s"]
+                - sum(metrics.get(k, 0.0) for k in ("flush_s", "commit_s", "pause_s", "resume_s")),
+                3,
+            )
+        self.sync_state = SyncState.PREFETCHING
 
-            # Reached the board's latest for this run as captured at pass start; a
-            # version published mid-pass is picked up by the next reconcile tick.
-            return self.current_version >= latest
+        # Reached the board's latest for this run as captured at pass start; a
+        # version published mid-pass is picked up by the next reconcile tick.
+        return self.current_version >= latest

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -19,14 +19,18 @@ async def _settle() -> None:
         await asyncio.sleep(0)
 
 
-def _write_slime_version(base: Path, version: int, prev: int) -> None:
+def _write_slime_version(
+    base: Path, version: int, prev: int, *, weight_map: dict[str, str] | None = None
+) -> None:
     vdir = base / f"weight_v{version:06d}"
     vdir.mkdir(parents=True)
+    if weight_map is None:
+        weight_map = {"w": "model-00001-of-00001.safetensors"}
     (vdir / "model.safetensors.index.json").write_text(
         json.dumps(
             {
                 "metadata": {"version": f"{version:06d}", "base_version": f"{prev:06d}"},
-                "weight_map": {"w": "model-00001-of-00001.safetensors"},
+                "weight_map": weight_map,
             }
         ),
         encoding="utf-8",
@@ -62,6 +66,30 @@ class FakeEngine:
 
     async def continue_generation(self) -> None:
         self.events.append("continue")
+
+
+class StagedEngine(FakeEngine):
+    """FakeEngine plus the optional staged split (stage/commit instead of the
+    combined apply)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.commit_weight_names: list[list[str] | None] = []
+
+    async def stage_manifest(self, manifest: VersionManifest, version_path: str) -> dict | None:
+        self.events.append("stage")
+        return {"host_delta_apply_s": 0.0}
+
+    async def commit_manifest(
+        self, manifest: VersionManifest, version_path: str, weight_names: list[str] | None = None
+    ) -> dict | None:
+        self.apply_started.set()
+        if self.apply_gate is not None:
+            await self.apply_gate.wait()
+        self.applies.append((manifest.version, version_path))
+        self.commit_weight_names.append(weight_names)
+        self.events.append("commit")
+        return {"engine_reload_s": 0.0}
 
 
 class SyncManagerTest(unittest.TestCase):
@@ -316,6 +344,101 @@ class SyncManagerTest(unittest.TestCase):
                 await sync
                 self.assertEqual(manager.current_version, 1)
                 self.assertEqual(await gated, "WeightVersionTooOld")
+
+        asyncio.run(run())
+
+    def test_staged_adapter_applies_host_side_before_pause(self) -> None:
+        """An adapter with the stage/commit split gets its host-side apply run
+        BEFORE the engine pause, so the pause covers only the reload."""
+
+        async def run() -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                board = FilesystemBulletinBoard(tmp)
+                board.publish_manifest(VersionManifest(version=1, base_version=0, backend="fake", load_format="noop"))
+                engine = StagedEngine()
+                manager = WeightSyncManager(board=board, engine=engine, commit_mode="in_place")
+                await manager.sync_to(1)
+
+                self.assertEqual(manager.current_version, 1)
+                self.assertEqual(engine.events, ["stage", "pause", "commit", "continue"])
+                self.assertEqual([v for v, _ in engine.applies], [1])
+                # The stage/commit breakdown is surfaced for scraping.
+                info = await manager.server_info()
+                metrics = info["metrics"]
+                self.assertEqual(metrics["target_version"], 1)
+                self.assertEqual(metrics["stage_detail"], {"host_delta_apply_s": 0.0})
+                self.assertEqual(metrics["commit_detail"], {"engine_reload_s": 0.0})
+                for key in ("board_refresh_s", "stage_s", "pause_s", "commit_s", "resume_s", "gate_s", "drain_wait_s"):
+                    self.assertIn(key, metrics)
+
+        asyncio.run(run())
+
+    def test_empty_delta_tail_advances_version_without_reload(self) -> None:
+        """A disk-delta tail that touches zero tensors (all-empty publishes)
+        advances the served version without pausing or reloading the engine."""
+
+        async def run() -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                # Run-less slime layout: no startup run switch to pause through.
+                board = FilesystemBulletinBoard(root, layout="slime")
+                _write_slime_version(root, 1, 0, weight_map={})
+                _write_slime_version(root, 2, 1, weight_map={})
+                board.write_latest(None, 2)
+                engine = StagedEngine()
+                manager = WeightSyncManager(board=board, engine=engine, commit_mode="in_place")
+
+                await manager.startup_sync()
+
+                self.assertEqual(manager.current_version, 2)
+                # Staged (host marker advanced), but never paused or reloaded.
+                self.assertEqual(engine.events, ["stage"])
+                self.assertEqual(engine.applies, [])
+                info = await manager.server_info()
+                self.assertTrue(info["metrics"]["skipped_noop_reload"])
+                self.assertEqual(info["metrics"]["tail_transition_files"], 0)
+
+                # A later non-empty version reloads as usual.
+                _write_slime_version(root, 3, 2)
+                board.write_latest(None, 3)
+                await manager.sync_to()
+                self.assertEqual(manager.current_version, 3)
+                self.assertEqual(engine.events, ["stage", "stage", "pause", "commit", "continue"])
+
+        asyncio.run(run())
+
+    def test_tail_weight_names_reach_commit(self) -> None:
+        """The tail's union of touched tensor names flows to commit_manifest
+        (for engine-side partial reloads); a tail version with files but no
+        names withholds the whole set."""
+
+        async def run() -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                board = FilesystemBulletinBoard(root, layout="slime")
+                _write_slime_version(root, 1, 0, weight_map={"a": "f1", "b": "f1"})
+                _write_slime_version(root, 2, 1, weight_map={"b": "f1", "c": "f2"})
+                board.write_latest(None, 2)
+                engine = StagedEngine()
+                manager = WeightSyncManager(board=board, engine=engine, commit_mode="in_place")
+                await manager.startup_sync()
+                self.assertEqual(engine.commit_weight_names, [["a", "b", "c"]])
+                info = await manager.server_info()
+                self.assertEqual(info["metrics"]["tail_weights"], 3)
+
+                # A slime-layout version always names its weights, so simulate
+                # an unknown-names version via the stitch layout instead.
+                board2 = FilesystemBulletinBoard(tmp + "-stitch")
+                board2.publish_manifest(
+                    VersionManifest(
+                        version=1, base_version=0, backend="disk_delta",
+                        load_format="auto", transition_files=["model-00001.safetensors"],
+                    )
+                )
+                engine2 = StagedEngine()
+                manager2 = WeightSyncManager(board=board2, engine=engine2, commit_mode="in_place")
+                await manager2.startup_sync()
+                self.assertEqual(engine2.commit_weight_names, [None])
 
         asyncio.run(run())
 


### PR DESCRIPTION
Stacked on #16. Library-only changes (no pins, no behavior change without the fork).

- **VersionManifest.transition_weights**: publishers list the touched tensor names per version; protocol stays engine-neutral.
- **WeightSyncManager staged split**: `stage_manifest` (host delta apply) runs *outside* the commit gate, `commit_manifest` (engine reload) inside — the generation pause now covers only the reload, hoisting ~25s (K2.6) / 20–43s (Moonlight) of XOR apply out of the pause.
- **No-op skip**: all-empty tails skip the reload entirely (`skipped_noop_reload`) — Moonlight NVFP4 QAT's empty deltas cost zero pause (verified live on a real 4-version chain).
- **Touched-name plumbing**: the tail's name union goes to `commit_manifest(weight_names=...)`; engines with the reload load plan use it for O(delta) partial reloads and silently full-reload otherwise. `STITCH_PARTIAL_RELOAD=0` kill switch.
- **Reload metrics**: the fork's `[reload timing]` message is parsed into `server_info()` metrics.

Measured end-to-end with the pinned fork (in #18): **K2.6 NVFP4 steady-state pause 280s → ~10s** on real June deltas (688 touched names → 1,226-name expert closure), byte-equivalence to a full reload checksum-verified twice; **GLM-4.5-Air bf16 218s → ~56s** via plan replay; partial requests on unsupported quants (FP8) fall back to a plain full reload with no double-cost.