### PR TITLE
Cookbook wiring: fork pin, load-plan env, sidecar fsync, rollout memory knob

### DIFF
--- a/cookbook/miles_disagg/configs/base.py
+++ b/cookbook/miles_disagg/configs/base.py
@@ -67,6 +67,12 @@ class ModalConfig:
     # disk; large models exceed Modal's default. None = Modal default (fine for
     # small bases like Moonlight).
     rollout_ephemeral_disk_mib: int | None = None
+    # Host-RAM request (MiB) for the rollout Server. Reloads read the whole
+    # local checkpoint through the page cache; when it doesn't fit, every
+    # reload pays capacity misses at disk speed (measured ~120s of iter_wait
+    # on K2.6's 595 GB base). Request checkpoint size + engine headroom so the
+    # base stays resident. None = Modal default.
+    rollout_memory_mib: int | None = None
     # Nodes x GPUs/node for the prepare_torch_dist conversion. The full 1T K2.6
     # needs >=2 nodes (8-way OOMs); a small proxy (e.g. 2-layer) fits 1 GPU (the
     # convert auto-derives pp=world_size and asserts pp <= num_layers).

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4_disagg.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4_disagg.py
@@ -139,10 +139,12 @@ class _Miles(MilesConfig):
 
     # ── NVFP4 QAT (native Megatron FP4 training; Blackwell + TE >= 2.7.0.dev0) ──
     # --fp4-format takes the element format 'e2m1'; the recipe (fp4_recipe) already
-    # defaults to 'nvfp4' (NVFP4BlockScaling). --fp4-param-gather keeps params in
-    # fp4 to save memory. NVFP4 group size is fixed at 16.
+    # defaults to 'nvfp4' (NVFP4BlockScaling). NVFP4 group size is fixed at 16.
+    # fp4_param_gather stays False, matching the K2.6 recipe: with it True the
+    # params are TE NVFP4Tensor (Megatron DDP's param-buffer repoint crashes) and
+    # miles' NVFP4 checkpoint export rejects the gather outright.
     fp4_format = "e2m1"
-    fp4_param_gather = True
+    fp4_param_gather = False
 
     # ── Disk-delta publish-only over the Modal Volume bulletin board ──
     update_weight_transfer_mode = "disk"

--- a/cookbook/miles_disagg/modal_train.py
+++ b/cookbook/miles_disagg/modal_train.py
@@ -246,6 +246,9 @@ WARMUP_PAYLOAD = {
     # The sidecar copies the full served base (~591 GB for K2.6) to
     # /local-checkpoint on ephemeral disk; Modal's default is too small.
     ephemeral_disk=modal_cfg.rollout_ephemeral_disk_mib,
+    # Keep the local checkpoint page-cache resident across reloads (see
+    # configs/base.py rollout_memory_mib).
+    memory=modal_cfg.rollout_memory_mib,
     include_source=False,
 )
 @modal.experimental.http_server(

--- a/cookbook/serving.py
+++ b/cookbook/serving.py
@@ -30,8 +30,8 @@ import modal
 # prebuilt base image's kernels.
 SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.12"
 SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
-SGLANG_FORK_BRANCH = "timmy/dflash-fa4-fp8"
-SGLANG_FORK_COMMIT = "dafb2b325b40298c5097564811463c585b7e9814"
+SGLANG_FORK_BRANCH = "weight-sync-upstream"
+SGLANG_FORK_COMMIT = "7fd4288bc0c61549c45a9fe92134437ac3bbb03a"
 
 # SGLang runtime tunables carried over from the standalone B200 deployment.
 SERVING_IMAGE_ENV = {
@@ -41,6 +41,11 @@ SERVING_IMAGE_ENV = {
     "SGLANG_DISABLE_CUDNN_CHECK": "1",
     "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
     "SGLANG_TIMEOUT_KEEP_ALIVE": "300",
+    # Reload record/replay (fork model_loader/load_plan.py): the first reload
+    # records the dispatch plan, later ones replay it. Checksum-verified
+    # byte-identical on GLM-4.5-Air (218s -> ~57s) and Kimi K2.6 (~11%);
+    # opt-in per model class and degrade-safe, so pool-wide enable is safe.
+    "SGLANG_ENABLE_RELOAD_LOAD_PLAN": "1",
 }
 
 

--- a/cookbook/sidecar.py
+++ b/cookbook/sidecar.py
@@ -91,7 +91,17 @@ def parallel_init_local_checkpoint(disk_delta_module: str, workers: int = 32) ->
             files = [e for e in os.scandir(base_dir) if e.is_file()]
 
             def _copy(entry: os.DirEntry) -> None:
-                shutil.copy2(entry.path, os.path.join(local_ckpt_dir, entry.name))
+                dest = os.path.join(local_ckpt_dir, entry.name)
+                shutil.copy2(entry.path, dest)
+                # fsync the copy so its pages turn clean now: hundreds of GB of
+                # dirty pages otherwise linger and writeback-stall every read
+                # until reclaimed (measured as 0.2-1 GB/s "cold" reads on disks
+                # that do 5-6 GB/s direct — the reload's iter_wait rides on it).
+                fd = os.open(dest, os.O_RDONLY)
+                try:
+                    os.fsync(fd)
+                finally:
+                    os.close(fd)
                 drop_page_cache(entry.path)  # don't evict the local copy we keep resident
 
             with concurrent.futures.ThreadPoolExecutor(max_workers=min(workers, max(1, len(files)))) as ex:

--- a/cookbook/slime_disagg/modal_train.py
+++ b/cookbook/slime_disagg/modal_train.py
@@ -63,7 +63,7 @@ SLIME_REPO_URL = "https://github.com/modal-projects/slime.git"
 # Pin to an exact commit, not the branch tip: the build's `git fetch ... &&
 # checkout` is a cached image layer, so a moving branch tip silently leaves the
 # container on a stale slime. Bump this SHA to roll slime forward.
-SLIME_REPO_REF = "ebfe153949b1a69c39e92f947ed5d475166dd724"
+SLIME_REPO_REF = "11bb0fa48aa37d5c54fe297143c6bc1d40f311bf"
 
 image = (
     modal.Image.from_registry(SLIME_IMAGE_TAG)
@@ -362,12 +362,16 @@ class Trainer:
         run_id = uuid.uuid4().hex[:12]
         cfg.update_weight_disk_dir = f"{exp.DELTA_BULLETIN_ROOT}/{run_id}"
         # stitch's publish hooks read these off the slime args namespace.
-        cfg.custom_config_path = {
+        hook_knobs = {
             "update_weight_delta_volume_name": exp.DELTA_VOLUME_NAME,
             "rollout_modal_flash_app_name": APP_NAME,
             "rollout_modal_flash_server_cls_name": Server.__name__,
             "run_id": run_id,
         }
+        cfg.custom_config_path = hook_knobs
+        # prepare_slime_config materializes the YAML_CONFIG_FIELDS dicts (including
+        # custom_config_path) to temp YAML file PATHS on cfg — keep hook_knobs for
+        # the claim below, which needs the mapping, not the path.
         helpers.prepare_slime_config(cfg, tempfile.mkdtemp())
         cmd = helpers.build_train_cmd(cfg, SLIME_ROOT)
 
@@ -378,7 +382,7 @@ class Trainer:
         from cookbook.slime_disagg import hooks
 
         hooks.claim_pool(
-            SimpleNamespace(update_weight_disk_dir=cfg.update_weight_disk_dir, **cfg.custom_config_path)
+            SimpleNamespace(update_weight_disk_dir=cfg.update_weight_disk_dir, **hook_knobs)
         )
 
         print(

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -61,7 +61,7 @@ SLIME_REPO_URL = "https://github.com/modal-projects/slime.git"
 # so the image must carry the fork's slime plus its checksum/compression deps.
 # Pin a SHA, not the branch tip: the clone is a cached image layer (see
 # cookbook/slime_disagg/modal_train.py).
-SLIME_REPO_REF = "ebfe153949b1a69c39e92f947ed5d475166dd724"
+SLIME_REPO_REF = "11bb0fa48aa37d5c54fe297143c6bc1d40f311bf"
 
 image = (
     modal.Image.from_registry(SLIME_IMAGE_TAG)


### PR DESCRIPTION
Stacked on #16 → (weight-sync-core). Activates the weight-sync core pool-wide.

- **serving.py**: pin `modal-projects/sglang` `weight-sync-upstream@7fd4288bc` — 7 reviewable commits (extra_config bugfix → reload phase timing → postprocess extraction → record/replay load plans → O(delta) partial reloads → NVFP4 incremental post-loading → CPU unit tests) plus the pre-flight quant-support check so unsupported quants decline partial reloads *before* reading any tensor. `SGLANG_ENABLE_RELOAD_LOAD_PLAN=1` pool-wide.
- **sidecar.py**: fsync each copied shard during base materialization (the first reload otherwise eats the writeback backlog — measured pathological cold-read numbers without it).
- **configs**: `rollout_memory_mib` knob for page-cache residency; moonlight `fp4_param_gather=False` (miles' NVFP4 export hard-rejects True); slime pins bumped to the instrumented fork.

Verified on this exact pin: GLM bf16 replay 55.6–57.9s + checksums; K2.6 partial 9.3–10.1s + checksums; FP8 record/replay/partial checksums all green with #16's patch.