### PR TITLE
standalone_rollouts: derived decoder index + review-weight trim + live-probe fixes

### DIFF
--- a/cookbook/standalone_rollouts/configs/moonlight_hot_load_probe.py
+++ b/cookbook/standalone_rollouts/configs/moonlight_hot_load_probe.py
@@ -1,8 +1,0 @@
-"""Scratch probe variant of moonlight_hot_load (not for check-in): scratch app
-name + transport prefix, one replica. Deploy with PROVIDER_CONFIG=moonlight_hot_load_probe."""
-
-from cookbook.standalone_rollouts.configs.moonlight_hot_load import *  # noqa: F401,F403
-
-APP_NAME = "stitch-moonlight-api-shim-probe"
-S3_TRANSPORT_KEY_PREFIX = "standalone-rollouts/_probe-review-fixes-live"
-ROLLOUT_MIN_CONTAINERS = 1

--- a/cookbook/standalone_rollouts/delta_view.py
+++ b/cookbook/standalone_rollouts/delta_view.py
@@ -93,4 +93,9 @@ def rebuild_delta_view(view_root: str | Path, transport_root: str | Path, ledger
         if vdir.is_symlink():
             vdir.unlink()  # an earlier layout linked the identity dir whole
         if not vdir.exists():
-            _build_version_dir(vdir, transport / identity)
+            identity_dir = transport / identity
+            # A signalled base may have no upload at all (the pool serves the
+            # booted checkpoint); a rebuild must not fail on it. Anything that
+            # uploads later is built on a subsequent refresh.
+            if identity_dir.is_dir():
+                _build_version_dir(vdir, identity_dir)

--- a/cookbook/standalone_rollouts/delta_view.py
+++ b/cookbook/standalone_rollouts/delta_view.py
@@ -63,12 +63,22 @@ def _ensure_symlink(link: Path, target: Path) -> None:
 def _build_version_dir(vdir: Path, identity_dir: Path) -> None:
     """Materialize one weight_vN view dir: a symlink per uploaded file, with the
     derived index presented under the HF name the decoder reads. Built into a
-    tmp dir renamed into place, so a crash never leaves a half-built dir."""
+    tmp dir renamed into place, so a crash never leaves a half-built dir.
+
+    A missing ``identity_dir`` is not an error: a signalled base may have no
+    upload at all (the pool serves the booted checkpoint), and mountpoint-s3
+    answers existence probes for bare prefixes inconsistently — so the listing
+    itself is the authority, and ENOENT means "nothing uploaded yet"."""
     tmp = vdir.with_name(vdir.name + ".tmp")
     shutil.rmtree(tmp, ignore_errors=True)
     tmp.mkdir(parents=True)
     derived = identity_dir / DERIVED_INDEX_FILE
-    for f in identity_dir.iterdir():
+    try:
+        entries = list(identity_dir.iterdir())
+    except FileNotFoundError:
+        tmp.rmdir()
+        return
+    for f in entries:
         if f.name == DERIVED_INDEX_FILE:
             continue
         if f.name == HF_INDEX_FILE and derived.exists():
@@ -93,9 +103,4 @@ def rebuild_delta_view(view_root: str | Path, transport_root: str | Path, ledger
         if vdir.is_symlink():
             vdir.unlink()  # an earlier layout linked the identity dir whole
         if not vdir.exists():
-            identity_dir = transport / identity
-            # A signalled base may have no upload at all (the pool serves the
-            # booted checkpoint); a rebuild must not fail on it. Anything that
-            # uploads later is built on a subsequent refresh.
-            if identity_dir.is_dir():
-                _build_version_dir(vdir, identity_dir)
+            _build_version_dir(vdir, transport / identity)

--- a/cookbook/standalone_rollouts/delta_view.py
+++ b/cookbook/standalone_rollouts/delta_view.py
@@ -1,23 +1,26 @@
 """Host-local ``weight_vN`` view of the customer's identity-named upload dirs.
 
-The customer uploads each checkpoint to ``<transport>/<opaque_identity>/`` (spec
-§1 couples the dir name to the identity), but slime's disk-delta decoder walks
-``<delta_root>/weight_v{N:06d}/``. The front-door ledger maps identity -> version;
-this builds a host-local directory of symlinks (``weight_vN`` -> the transport's
-identity dir, plus ``latest`` -> the transport pointer) so the unmodified decoder
-and bulletin board operate against a normal weight_vN slime layout.
+The customer uploads each checkpoint to ``<transport>/<opaque_identity>/``, but
+slime's disk-delta decoder walks ``<delta_root>/weight_v{N:06d}/``. The
+front-door ledger maps identity -> version; this builds a host-local directory
+per version — one symlink per uploaded file, plus ``latest`` -> the transport
+pointer — so the unmodified decoder operates against a normal weight_vN slime
+layout while the bytes are read straight from the mount.
 
-mountpoint-s3 cannot host a symlink (ENOSYS, same family as rename), but a
-host-local symlink *into* the mount resolves through transparently on read, so
-the view lives on the container's ephemeral disk and the delta bytes are still
-read straight from S3. The view is rebuilt from the ledger on every board
-refresh (i.e. before every sync), so newly-signalled versions appear.
+The customer's upload is never modified. The disk-delta ``metadata`` block the
+decoder needs is written next to the upload as a derived ``stitch.index.json``
+(:func:`merge_index_metadata`), and the view presents that file under the
+standard HF index name. mountpoint-s3 cannot host a symlink, but a host-local
+symlink *into* the mount resolves transparently on read, so the view lives on
+the container's ephemeral disk. It is rebuilt from the ledger on every board
+refresh; each version dir is built once, since a signalled upload is immutable.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import shutil
 from pathlib import Path
 
 from cookbook.standalone_rollouts.ledger import IdentityLedger
@@ -25,12 +28,15 @@ from stitch.protocol import atomic_write_text, weight_identity
 
 
 LATEST_FILE = "latest"
+HF_INDEX_FILE = "model.safetensors.index.json"
+DERIVED_INDEX_FILE = "stitch.index.json"
 
 
 def merge_index_metadata(index_path: Path, metadata: dict[str, str]) -> None:
-    """Merge the disk-delta ``metadata`` block into a customer's uploaded HF
-    index in place, so the decoder can apply the delta without the customer
-    producing a slime-shaped index.
+    """Derive the decoder's index from the customer's uploaded HF index: merge
+    the disk-delta ``metadata`` block and write the result next to the upload
+    as ``stitch.index.json``, leaving the customer's bytes (and any digest or
+    signature over them) untouched.
 
     Raises ``FileNotFoundError`` when the upload has not landed and
     ``ValueError`` when the uploaded index is not a JSON object; the front door
@@ -43,7 +49,7 @@ def merge_index_metadata(index_path: Path, metadata: dict[str, str]) -> None:
     if not isinstance(index, dict):
         raise ValueError(f"uploaded {index_path.name} must be a JSON object")
     index.setdefault("metadata", {}).update(metadata)
-    atomic_write_text(index_path, json.dumps(index))
+    atomic_write_text(index_path.with_name(DERIVED_INDEX_FILE), json.dumps(index))
 
 
 def _ensure_symlink(link: Path, target: Path) -> None:
@@ -54,15 +60,37 @@ def _ensure_symlink(link: Path, target: Path) -> None:
     link.symlink_to(target)
 
 
+def _build_version_dir(vdir: Path, identity_dir: Path) -> None:
+    """Materialize one weight_vN view dir: a symlink per uploaded file, with the
+    derived index presented under the HF name the decoder reads. Built into a
+    tmp dir renamed into place, so a crash never leaves a half-built dir."""
+    tmp = vdir.with_name(vdir.name + ".tmp")
+    shutil.rmtree(tmp, ignore_errors=True)
+    tmp.mkdir(parents=True)
+    derived = identity_dir / DERIVED_INDEX_FILE
+    for f in identity_dir.iterdir():
+        if f.name == DERIVED_INDEX_FILE:
+            continue
+        if f.name == HF_INDEX_FILE and derived.exists():
+            (tmp / HF_INDEX_FILE).symlink_to(derived)
+        else:
+            (tmp / f.name).symlink_to(f)
+    tmp.rename(vdir)
+
+
 def rebuild_delta_view(view_root: str | Path, transport_root: str | Path, ledger: IdentityLedger) -> None:
     """(Re)build the host-local weight_vN view under ``view_root`` from ``ledger``.
 
-    Idempotent: existing correct symlinks are left alone. Links ``latest`` to the
-    transport pointer and each minted version to its identity dir on the transport.
+    Idempotent, and O(newly signalled versions) per call: an existing version
+    dir is left alone. Links ``latest`` to the transport pointer.
     """
     view = Path(view_root)
     transport = Path(transport_root)
     view.mkdir(parents=True, exist_ok=True)
     _ensure_symlink(view / LATEST_FILE, transport / LATEST_FILE)
     for version, identity in ledger.items_by_version():
-        _ensure_symlink(view / weight_identity(version), transport / identity)
+        vdir = view / weight_identity(version)
+        if vdir.is_symlink():
+            vdir.unlink()  # an earlier layout linked the identity dir whole
+        if not vdir.exists():
+            _build_version_dir(vdir, transport / identity)

--- a/cookbook/standalone_rollouts/delta_view_test.py
+++ b/cookbook/standalone_rollouts/delta_view_test.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from cookbook.standalone_rollouts.delta_view import rebuild_delta_view
+from cookbook.standalone_rollouts.delta_view import merge_index_metadata, rebuild_delta_view
 from cookbook.standalone_rollouts.ledger import IdentityLedger
 
 
@@ -18,31 +18,48 @@ class RebuildDeltaViewTest(unittest.TestCase):
         for identity in ("base-ckpt", "ckpt-100"):
             d = transport / identity
             d.mkdir()
+            (d / "model-00001-of-00001.safetensors").write_bytes(b"shard")
             (d / "model.safetensors.index.json").write_text(
-                json.dumps({"metadata": {"version": identity}, "weight_map": {}}), encoding="utf-8"
+                json.dumps({"metadata": {"total_size": 5}, "weight_map": {}}), encoding="utf-8"
             )
         return transport
 
-    def test_view_maps_versions_to_identity_dirs_and_reads_through(self) -> None:
+    def test_view_presents_derived_index_and_reads_through(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             transport = self._transport(tmp)
             ledger = IdentityLedger()
             ledger.record("base-ckpt", previous=None)  # v0
             ledger.record("ckpt-100", previous="base-ckpt")  # v1
+            merge_index_metadata(
+                transport / "ckpt-100" / "model.safetensors.index.json",
+                {"version": "000001", "base_version": "000000"},
+            )
             view = Path(tmp) / "view"
 
             rebuild_delta_view(view, transport, ledger)
 
-            # weight_vN symlinks resolve to the identity dirs...
-            self.assertTrue((view / "weight_v000000").is_symlink())
-            self.assertTrue((view / "weight_v000001").is_symlink())
-            # ...and reading through the view reaches the real (identity-dir) files.
+            # The decoder sees the derived (normalized) index under the HF name,
+            # while the customer's uploaded index is untouched.
             index = json.loads(
                 (view / "weight_v000001" / "model.safetensors.index.json").read_text()
             )
-            self.assertEqual(index["metadata"]["version"], "ckpt-100")
-            # latest pointer is visible through the view.
+            self.assertEqual(index["metadata"]["version"], "000001")
+            self.assertEqual(index["metadata"]["total_size"], 5)
+            raw = json.loads(
+                (transport / "ckpt-100" / "model.safetensors.index.json").read_text()
+            )
+            self.assertNotIn("version", raw["metadata"])
+            # Shards and the latest pointer resolve through the view; a base
+            # with no derived index presents its own upload as-is.
+            self.assertEqual(
+                (view / "weight_v000001" / "model-00001-of-00001.safetensors").read_bytes(),
+                b"shard",
+            )
             self.assertEqual((view / "latest").read_text(), "weight_v000001")
+            base_index = json.loads(
+                (view / "weight_v000000" / "model.safetensors.index.json").read_text()
+            )
+            self.assertEqual(base_index["metadata"], {"total_size": 5})
 
     def test_rebuild_is_idempotent_and_picks_up_new_versions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -58,8 +75,8 @@ class RebuildDeltaViewTest(unittest.TestCase):
             ledger.record("ckpt-100", previous="base-ckpt")
             rebuild_delta_view(view, transport, ledger)
             rebuild_delta_view(view, transport, ledger)  # idempotent second pass
-            self.assertTrue((view / "weight_v000001").is_symlink())
-            self.assertTrue((view / "weight_v000000").is_symlink())
+            self.assertTrue((view / "weight_v000001").is_dir())
+            self.assertTrue((view / "weight_v000000").is_dir())
 
 
 if __name__ == "__main__":

--- a/cookbook/standalone_rollouts/delta_view_test.py
+++ b/cookbook/standalone_rollouts/delta_view_test.py
@@ -61,6 +61,21 @@ class RebuildDeltaViewTest(unittest.TestCase):
             )
             self.assertEqual(base_index["metadata"], {"total_size": 5})
 
+    def test_never_uploaded_base_identity_does_not_break_rebuild(self) -> None:
+        # The booted-base flow signals a base identity with no upload behind it;
+        # the rebuild must still materialize every real version dir.
+        with tempfile.TemporaryDirectory() as tmp:
+            transport = self._transport(tmp)
+            ledger = IdentityLedger()
+            ledger.record("never-uploaded-base", previous=None)  # no dir exists
+            ledger.record("ckpt-100", previous="never-uploaded-base")
+            view = Path(tmp) / "view"
+
+            rebuild_delta_view(view, transport, ledger)
+
+            self.assertFalse((view / "weight_v000000").exists())
+            self.assertTrue((view / "weight_v000001").is_dir())
+
     def test_rebuild_is_idempotent_and_picks_up_new_versions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             transport = self._transport(tmp)

--- a/cookbook/standalone_rollouts/frontdoor.py
+++ b/cookbook/standalone_rollouts/frontdoor.py
@@ -1,26 +1,16 @@
 """Front-door hot-load adapter for the standalone rollout provider.
 
-The front door is the single public entry and the single writer of both the
-bulletin board's monotonic ``latest`` pointer and the identity ledger. It
-implements the customer's hot-load API as an abstraction layer over the
-log-as-truth pool, so the customer's contract (opaque checkpoint identities,
-lineage via ``previous_snapshot_identity``, delta formats in the POST body)
-never leaks the pool's integer-versioned internals:
+The single public entry and the single writer of the ``latest`` pointer and the
+identity ledger. It implements the customer's hot-load API over the
+integer-versioned pool: ``POST /hot_load`` maps the opaque ``identity`` to a
+minted version (idempotent on re-signal), derives the decoder index from the
+POST metadata, advances ``latest``, and best-effort wakes the pool;
+``GET /hot_load`` reports readiness by querying live replicas, translating each
+integer version back to the customer's identity; inference (``v1/*``,
+``generate``) is proxied and every other route 404s (allowlist).
 
-- ``POST /hot_load/...`` maps the signalled opaque ``identity`` to a monotonic
-  stitch version via the :class:`~cookbook.standalone_rollouts.ledger.IdentityLedger`
-  (idempotent on re-signal), normalizes the customer's POST metadata into the
-  version dir's index so the disk-delta decoder can apply it, advances ``latest``,
-  and best-effort wakes the pool.
-- ``GET /hot_load/...`` reports readiness by enumerating the *live* containers and
-  querying each ``/server_info``, translating each replica's integer version back
-  to the customer's identity string so their equality match works.
-- Inference (``v1/*``, ``generate``) is proxied to the rollout gateway; every
-  other route is rejected (allowlist).
-
-All I/O (ledger load/save, index normalization, pointer write, replica
-enumeration, proxy, auth) is injected so the adapter is testable without Modal;
-``modal_serve.py`` supplies the real implementations.
+All I/O is injected so the adapter is testable without Modal; ``modal_serve.py``
+supplies the real implementations.
 
 No ``from __future__ import annotations`` here: the route handlers'
 ``request: Request`` annotation must evaluate eagerly against the factory-local
@@ -44,17 +34,10 @@ RESERVED_IDENTITIES = {".", "..", "latest", LEDGER_FILENAME}
 
 
 def is_customer_inference_route(path: str) -> bool:
-    """Whether a proxied path is a customer-facing inference route.
-
-    The proxy is an allowlist, not a denylist: only OpenAI-compatible ``v1/*``
-    routes and the SGLang-native ``generate`` route reach the rollout pool.
-    Everything else a public client could name — the per-container sidecar's own
-    control routes (``rpc_sync_from_bulletin_board``, ``server_info``,
-    ``get_weight_version``) and the SGLang engine routes behind it
-    (``update_weights_*``, ``start_profile``, …) — is not reachable through the
-    front door, so a new engine/sidecar route can never become customer-exposed
-    by omission from a denylist.
-    """
+    """Allowlist, not denylist: only OpenAI-compatible ``v1/*`` and SGLang's
+    ``generate`` reach the pool. Sidecar control routes and engine routes are
+    unreachable through the front door, and a newly added one can never become
+    customer-exposed by omission."""
     route = path.strip("/")
     return route == "generate" or route == "v1" or route.startswith("v1/")
 
@@ -76,10 +59,9 @@ def delta_index_metadata(
     """The slime disk-delta ``metadata`` block the decoder requires, derived from
     the customer's POST. ``version``/``base_version`` are the ledger-assigned
     integers as zero-padded 6-digit strings (the decoder compares ``base_version``
-    to the applied-version marker by string equality). ``delta_encoding`` is not
-    in the customer's API — spec §3 pins XOR — so it defaults to ``xor``;
-    ``compression_format``/``checksum_format`` come from the POST body (spec §2a),
-    defaulting to the spec's stated ``zstd``/``adler32`` when omitted."""
+    to the applied-version marker by string equality). The customer's API has no
+    ``delta_encoding`` field (their contract fixes XOR) and states ``zstd``/
+    ``adler32`` as the format defaults when the POST omits them."""
     return {
         "version": f"{int(version):06d}",
         "base_version": f"{int(base_version):06d}",
@@ -138,27 +120,19 @@ def create_frontdoor_app(
 ):
     """Build the front-door FastAPI app from injected I/O.
 
-    ``load_ledger``/``save_ledger`` read/write the identity↔version ledger on the
-    transport; ``normalize_index(identity, metadata)`` writes the disk-delta
-    metadata block into that version dir's index; ``advance_to(version)`` writes
-    the ``latest`` pointer; ``list_server_infos`` enumerates live replicas;
-    ``proxy`` forwards inference; ``authorize`` returns a rejection Response or
-    ``None`` and is required — the app is fail-closed by construction, so a
-    test that wants an open app must say so with an explicit allow-all;
-    ``wake`` is a best-effort post-advance nudge.
-
+    ``authorize`` (a rejection Response, or ``None`` to allow) is required — the
+    app is fail-closed by construction; a test that wants an open app says so
+    with an explicit allow-all. ``wake`` is a best-effort post-advance nudge.
     ``expected_base_identity``, when set, pins the one identity allowed to
     anchor a chain: a full snapshot must name it (the pool serves the booted
-    base, never a customer upload, so any other full snapshot would be silently
-    substituted), and a first delta's unknown parent must be it (anything else
-    is a typo'd or never-signalled checkpoint, not the booted base).
+    base, never a customer upload), and so must a first delta's unknown parent
+    (anything else is a typo, not the booted base).
 
     The load-record-normalize-save-advance sequence is serialized under
-    ``advance_lock`` so the singleton front door never races itself. The ledger
-    is loaded fresh from the transport inside the lock (not cached across POSTs),
-    so a partial failure leaves the transport ledger authoritative and a retry
-    converges: normalize is idempotent, save is the commit point, and the pointer
-    is re-advanced to the head even on an idempotent re-signal.
+    ``advance_lock``, and the ledger is loaded fresh from the transport inside
+    the lock, so a partial failure leaves the transport authoritative and a
+    retry converges: normalize is idempotent, save is the commit point, and the
+    pointer is re-advanced to the head even on an idempotent re-signal.
     """
     from fastapi import FastAPI, Request
     from fastapi.responses import JSONResponse, Response
@@ -169,6 +143,9 @@ def create_frontdoor_app(
     def _auth(request: Request):
         return authorize(request.headers)
 
+    def _error(status: int, message) -> Any:
+        return JSONResponse({"error": message}, status_code=status)
+
     @app.post(HOT_LOAD_PATH, response_model=None)
     async def post_hot_load(request: Request) -> Response:
         rejected = _auth(request)
@@ -177,77 +154,58 @@ def create_frontdoor_app(
         try:
             payload = await request.json()
         except Exception:  # noqa: BLE001 — a malformed/non-JSON body is a 400, never a 500
-            return JSONResponse({"error": "request body must be a JSON object"}, status_code=400)
+            return _error(400, "request body must be a JSON object")
         if not isinstance(payload, dict) or not payload.get("identity"):
-            return JSONResponse({"error": "body.identity is required"}, status_code=400)
+            return _error(400, "body.identity is required")
         identity = str(payload["identity"])
         if not is_valid_identity(identity):
-            return JSONResponse(
-                {"error": "body.identity must be a non-empty, single-segment string <= 512 chars"},
-                status_code=400,
-            )
+            return _error(400, "body.identity must be a non-empty, single-segment string <= 512 chars")
         incremental = payload.get("incremental_snapshot_metadata")
         if incremental is not None and not isinstance(incremental, dict):
-            return JSONResponse(
-                {"error": "body.incremental_snapshot_metadata must be an object"}, status_code=400
-            )
+            return _error(400, "body.incremental_snapshot_metadata must be an object")
         previous = incremental.get("previous_snapshot_identity") if incremental else None
         if incremental is not None and (not isinstance(previous, str) or not previous):
-            # A delta without lineage is indistinguishable from a full snapshot
-            # and would be recorded as one; require the parent explicitly.
-            return JSONResponse(
-                {
-                    "error": "incremental_snapshot_metadata.previous_snapshot_identity "
-                    "must be a non-empty string"
-                },
-                status_code=400,
+            # A lineage-less delta would be recorded as a full snapshot.
+            return _error(
+                400,
+                "incremental_snapshot_metadata.previous_snapshot_identity must be a non-empty string",
             )
 
         async with advance_lock:
             ledger = IdentityLedger.from_dict(await load_ledger())
             if expected_base_identity is not None:
                 if incremental is None and identity != expected_base_identity:
-                    return JSONResponse(
-                        {
-                            "error": f"this deployment serves base {expected_base_identity!r}; "
-                            f"full snapshot {identity!r} cannot be activated"
-                        },
-                        status_code=409,
+                    return _error(
+                        409,
+                        f"this deployment serves base {expected_base_identity!r}; "
+                        f"full snapshot {identity!r} cannot be activated",
                     )
                 if incremental is not None and previous != expected_base_identity and ledger.version_for(previous) is None:
-                    return JSONResponse(
-                        {
-                            "error": f"previous_snapshot_identity {previous!r} is neither a "
-                            f"signalled checkpoint nor the deployment base {expected_base_identity!r}"
-                        },
-                        status_code=409,
+                    return _error(
+                        409,
+                        f"previous_snapshot_identity {previous!r} is neither a signalled "
+                        f"checkpoint nor the deployment base {expected_base_identity!r}",
                     )
             try:
                 entry, is_new = ledger.record(identity, previous)
             except LedgerError as exc:
-                return JSONResponse({"error": str(exc)}, status_code=409)
+                return _error(409, str(exc))
             if entry.version != ledger.head_version:
-                # Re-signalling an older identity is a rewind request the pool
-                # cannot serve (versions only move forward); reject it loudly
-                # rather than answering accepted:true for weights that will
-                # never be reported ready.
-                return JSONResponse(
+                # A rewind the pool cannot serve; reject loudly rather than
+                # answering accepted:true for weights that never become ready.
+                return _error(
+                    409,
                     {
-                        "error": {
-                            "type": "WeightRewindRejected",
-                            "message": f"{identity!r} is older than the served head",
-                            "current_version": ledger.head_version,
-                            "requested_version": entry.version,
-                        }
+                        "type": "WeightRewindRejected",
+                        "message": f"{identity!r} is older than the served head",
+                        "current_version": ledger.head_version,
+                        "requested_version": entry.version,
                     },
-                    status_code=409,
                 )
             if is_new:
-                # A delta (incremental metadata present) needs its index normalized
-                # so the decoder can apply it; a full snapshot (base) is served
-                # from the booted base checkpoint and needs no delta metadata.
-                # Normalize before saving/advancing, so a missing upload leaves the
-                # transport ledger and pointer untouched (fail fast, self-clean).
+                # Only a delta needs a derived decoder index (a full snapshot is
+                # the booted base). Derive before save/advance, so a missing or
+                # malformed upload leaves ledger and pointer untouched.
                 if incremental is not None:
                     try:
                         await normalize_index(
@@ -257,14 +215,14 @@ def create_frontdoor_app(
                             ),
                         )
                     except FileNotFoundError:
-                        return JSONResponse(
-                            {"error": f"checkpoint {identity!r} not found on the transport; upload before signalling"},
-                            status_code=409,
+                        return _error(
+                            409,
+                            f"checkpoint {identity!r} not found on the transport; upload before signalling",
                         )
                     except ValueError as exc:
-                        # A malformed uploaded index (truncated write, wrong
-                        # file) is the customer's to fix: 4xx, never a 500.
-                        return JSONResponse({"error": str(exc)}, status_code=400)
+                        # A malformed uploaded index is the customer's to fix:
+                        # 4xx, never a 500.
+                        return _error(400, str(exc))
                 await save_ledger(ledger.to_dict())
             # This identity is the chain head (rewinds were rejected above).
             # Advance idempotently, so a retry after a save-succeeded/
@@ -301,7 +259,7 @@ def create_frontdoor_app(
         if rejected is not None:
             return rejected
         if not is_customer_inference_route(path):
-            return JSONResponse({"error": f"no such route: /{path.strip('/')}"}, status_code=404)
+            return _error(404, f"no such route: /{path.strip('/')}")
         return await proxy(request, path)
 
     return app

--- a/cookbook/standalone_rollouts/frontdoor_test.py
+++ b/cookbook/standalone_rollouts/frontdoor_test.py
@@ -12,6 +12,11 @@ from cookbook.standalone_rollouts.frontdoor import (
 from cookbook.standalone_rollouts.ledger import IdentityLedger
 
 
+def _delta(identity: str, previous: str) -> dict:
+    """Minimal delta-signal body: lineage is the only required field."""
+    return {"identity": identity, "incremental_snapshot_metadata": {"previous_snapshot_identity": previous}}
+
+
 class IdentityValidationTest(unittest.TestCase):
     def test_opaque_identities_are_accepted(self) -> None:
         for identity in ("weight_v000001", "ckpt-100", "step_500", "2026-07-11T00:00:00Z", "wéight"):
@@ -38,7 +43,7 @@ class DeltaMetadataTest(unittest.TestCase):
             {
                 "version": "000002",
                 "base_version": "000001",
-                "delta_encoding": "xor",  # not in the customer API; spec §3 default
+                "delta_encoding": "xor",  # not in the customer API; contract-fixed default
                 "compression_format": "zstd",
                 "checksum_format": "adler32",
             },
@@ -166,17 +171,7 @@ class FrontdoorAppTest(unittest.TestCase):
     def test_delta_signal_mints_next_version_and_normalizes_index(self) -> None:
         client, calls, _ = self._client()
         client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
-        resp = client.post(
-            HOT_LOAD_PATH,
-            json={
-                "identity": "ckpt-100",
-                "incremental_snapshot_metadata": {
-                    "previous_snapshot_identity": "base-ckpt",
-                    "compression_format": "zstd",
-                    "checksum_format": "adler32",
-                },
-            },
-        )
+        resp = client.post(HOT_LOAD_PATH, json=_delta("ckpt-100", "base-ckpt"))
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["version"], 1)
         self.assertEqual(calls["advanced"], [0, 1])
@@ -190,8 +185,8 @@ class FrontdoorAppTest(unittest.TestCase):
     def test_resignal_is_idempotent_no_remint_no_normalize(self) -> None:
         client, calls, _ = self._client()
         client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
-        first = client.post(HOT_LOAD_PATH, json={"identity": "ckpt-100", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base-ckpt", "compression_format": "zstd", "checksum_format": "adler32"}})
-        again = client.post(HOT_LOAD_PATH, json={"identity": "ckpt-100", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base-ckpt", "compression_format": "zstd", "checksum_format": "adler32"}})
+        first = client.post(HOT_LOAD_PATH, json=_delta("ckpt-100", "base-ckpt"))
+        again = client.post(HOT_LOAD_PATH, json=_delta("ckpt-100", "base-ckpt"))
         self.assertEqual(first.json()["version"], 1)
         self.assertEqual(again.json()["version"], 1)
         self.assertTrue(again.json()["already_current"])
@@ -239,10 +234,7 @@ class FrontdoorAppTest(unittest.TestCase):
             authorize=lambda headers: None,
         )
         client = TestClient(app)
-        resp = client.post(
-            HOT_LOAD_PATH,
-            json={"identity": "ckpt-100", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base", "compression_format": "zstd", "checksum_format": "adler32"}},
-        )
+        resp = client.post(HOT_LOAD_PATH, json=_delta("ckpt-100", "base"))
         self.assertEqual(resp.status_code, 409)
         # No pointer move, no ledger commit -> a retry after upload converges.
         self.assertEqual(calls["advanced"], [])
@@ -258,7 +250,7 @@ class FrontdoorAppTest(unittest.TestCase):
     def test_get_reports_readiness_in_customer_identity(self) -> None:
         client, _, _ = self._client()
         client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
-        client.post(HOT_LOAD_PATH, json={"identity": "ckpt-100", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base-ckpt", "compression_format": "zstd", "checksum_format": "adler32"}})
+        client.post(HOT_LOAD_PATH, json=_delta("ckpt-100", "base-ckpt"))
         body = client.get(HOT_LOAD_PATH).json()
         self.assertEqual(len(body["replicas"]), 1)
         self.assertEqual(body["replicas"][0]["current_snapshot_identity"], "ckpt-100")
@@ -293,13 +285,7 @@ class FrontdoorAppTest(unittest.TestCase):
     def test_delta_with_unknown_parent_is_409(self) -> None:
         client, calls, _ = self._client()
         client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
-        resp = client.post(
-            HOT_LOAD_PATH,
-            json={
-                "identity": "ckpt-2",
-                "incremental_snapshot_metadata": {"previous_snapshot_identity": "ckpt-l"},
-            },
-        )
+        resp = client.post(HOT_LOAD_PATH, json=_delta("ckpt-2", "ckpt-l"))
         self.assertEqual(resp.status_code, 409)
         self.assertEqual(calls["normalized"], [])
 
@@ -311,7 +297,7 @@ class FrontdoorAppTest(unittest.TestCase):
         # the booted checkpoint.
         r = client.post(
             HOT_LOAD_PATH,
-            json={"identity": "ckpt-1", "incremental_snapshot_metadata": {"previous_snapshot_identity": "bsae"}},
+            json=_delta("ckpt-1", "bsae"),
         )
         self.assertEqual(r.status_code, 409)
         self.assertEqual(calls["advanced"], [])
@@ -319,7 +305,7 @@ class FrontdoorAppTest(unittest.TestCase):
         self.assertEqual(client.post(HOT_LOAD_PATH, json={"identity": "base"}).status_code, 200)
         r = client.post(
             HOT_LOAD_PATH,
-            json={"identity": "ckpt-1", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base"}},
+            json=_delta("ckpt-1", "base"),
         )
         self.assertEqual(r.json()["version"], 1)
 
@@ -328,15 +314,15 @@ class FrontdoorAppTest(unittest.TestCase):
         # version forever; reject it and leave the head serveable.
         client, calls, _ = self._client()
         client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
-        client.post(HOT_LOAD_PATH, json={"identity": "ckpt-1", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base-ckpt"}})
-        resp = client.post(HOT_LOAD_PATH, json={"identity": "ckpt-fork", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base-ckpt"}})
+        client.post(HOT_LOAD_PATH, json=_delta("ckpt-1", "base-ckpt"))
+        resp = client.post(HOT_LOAD_PATH, json=_delta("ckpt-fork", "base-ckpt"))
         self.assertEqual(resp.status_code, 409)
         self.assertEqual(calls["advanced"], [0, 1])  # pointer stays at head
 
     def test_resignalling_an_older_identity_is_a_409_rewind(self) -> None:
         client, calls, _ = self._client()
         client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
-        client.post(HOT_LOAD_PATH, json={"identity": "ckpt-100", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base-ckpt", "compression_format": "zstd", "checksum_format": "adler32"}})
+        client.post(HOT_LOAD_PATH, json=_delta("ckpt-100", "base-ckpt"))
         resp = client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
         self.assertEqual(resp.status_code, 409)
         self.assertEqual(resp.json()["error"]["type"], "WeightRewindRejected")

--- a/cookbook/standalone_rollouts/frontdoor_test.py
+++ b/cookbook/standalone_rollouts/frontdoor_test.py
@@ -275,19 +275,20 @@ class FrontdoorAppTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(calls["advanced"], [])
 
-    def test_second_full_snapshot_is_409(self) -> None:
-        client, calls, _ = self._client()
-        client.post(HOT_LOAD_PATH, json={"identity": "base-a"})
-        resp = client.post(HOT_LOAD_PATH, json={"identity": "base-b"})
-        self.assertEqual(resp.status_code, 409)
-        self.assertEqual(calls["advanced"], [0])  # pointer untouched by the reject
-
-    def test_delta_with_unknown_parent_is_409(self) -> None:
+    def test_ledger_conflicts_map_to_409(self) -> None:
+        # Second base, unknown parent, and fork from a non-head checkpoint are
+        # all LedgerError -> 409; none of them touch the pointer or normalize.
         client, calls, _ = self._client()
         client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
-        resp = client.post(HOT_LOAD_PATH, json=_delta("ckpt-2", "ckpt-l"))
-        self.assertEqual(resp.status_code, 409)
-        self.assertEqual(calls["normalized"], [])
+        client.post(HOT_LOAD_PATH, json=_delta("ckpt-1", "base-ckpt"))
+        for body in (
+            {"identity": "base-b"},  # the base slot is single-occupancy
+            _delta("ckpt-2", "ckpt-l"),  # typo'd, never-signalled parent
+            _delta("ckpt-fork", "base-ckpt"),  # fork: parent is not the head
+        ):
+            self.assertEqual(client.post(HOT_LOAD_PATH, json=body).status_code, 409, body)
+        self.assertEqual(calls["advanced"], [0, 1])  # pointer stays at head
+        self.assertEqual(len(calls["normalized"]), 1)  # only ckpt-1's derive
 
     def test_expected_base_pin_rejects_other_anchors(self) -> None:
         client, calls, _ = self._client(expected_base_identity="base")
@@ -295,29 +296,12 @@ class FrontdoorAppTest(unittest.TestCase):
         self.assertEqual(client.post(HOT_LOAD_PATH, json={"identity": "their-base"}).status_code, 409)
         # A first delta whose unknown parent is not the base is a typo, not
         # the booted checkpoint.
-        r = client.post(
-            HOT_LOAD_PATH,
-            json=_delta("ckpt-1", "bsae"),
-        )
-        self.assertEqual(r.status_code, 409)
+        self.assertEqual(client.post(HOT_LOAD_PATH, json=_delta("ckpt-1", "bsae")).status_code, 409)
         self.assertEqual(calls["advanced"], [])
         # The pinned identities pass: the base itself, and a first delta on it.
         self.assertEqual(client.post(HOT_LOAD_PATH, json={"identity": "base"}).status_code, 200)
-        r = client.post(
-            HOT_LOAD_PATH,
-            json=_delta("ckpt-1", "base"),
-        )
+        r = client.post(HOT_LOAD_PATH, json=_delta("ckpt-1", "base"))
         self.assertEqual(r.json()["version"], 1)
-
-    def test_delta_forking_an_older_checkpoint_is_409(self) -> None:
-        # One accepted fork would wedge every replica behind the non-contiguous
-        # version forever; reject it and leave the head serveable.
-        client, calls, _ = self._client()
-        client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
-        client.post(HOT_LOAD_PATH, json=_delta("ckpt-1", "base-ckpt"))
-        resp = client.post(HOT_LOAD_PATH, json=_delta("ckpt-fork", "base-ckpt"))
-        self.assertEqual(resp.status_code, 409)
-        self.assertEqual(calls["advanced"], [0, 1])  # pointer stays at head
 
     def test_resignalling_an_older_identity_is_a_409_rewind(self) -> None:
         client, calls, _ = self._client()

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -279,41 +279,8 @@ def check(timeout_seconds: int = 20 * MINUTES) -> None:
 
         uv run --extra modal modal run -m cookbook.standalone_rollouts.modal_serve::check
     """
-    import json
-    import time
-    import urllib.request
-
     gateway = modal.Server.from_name(APP_NAME, "FrontDoor").get_url().rstrip("/")
-    headers = _shim_headers()
-    deadline = time.time() + timeout_seconds
-    last = ""
-    while True:
-        try:
-            req = urllib.request.Request(
-                f"{gateway}/hot_load/v1/models/hot_load", headers=headers
-            )
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                pool = json.load(resp)
-            ready = [r for r in pool.get("replicas", []) if r.get("readiness")]
-            print(
-                f"pool: {len(pool.get('replicas', []))} replicas, {len(ready)} ready :: {pool}"
-            )
-            if len(ready) >= exp.ROLLOUT_MIN_CONTAINERS:
-                break
-            last = f"only {len(ready)} ready"
-        except Exception as exc:  # noqa: BLE001
-            last = f"{type(exc).__name__}: {exc}"
-        if time.time() > deadline:
-            raise TimeoutError(f"front-door readiness timed out: {last}")
-        time.sleep(10)
-
-    req = urllib.request.Request(
-        f"{gateway}/v1/chat/completions",
-        data=json.dumps(WARMUP_PAYLOAD).encode("utf-8"),
-        headers={"Content-Type": "application/json", **headers},
-    )
-    with urllib.request.urlopen(req, timeout=180) as resp:
-        print("completion:", json.dumps(json.load(resp))[:1200])
+    _smoke_frontdoor(gateway, _shim_headers(), timeout_seconds)
 
 
 @app.local_entrypoint()
@@ -343,19 +310,24 @@ def smoke(
     provider_model: str = "",
     provider_deployment: str = "",
 ) -> None:
-    """Check the deployed gateway can report pool state and serve a completion."""
-    import json
-    import time
-    import urllib.request
-
-    gateway = frontdoor_url()
-    deadline = time.time() + timeout_seconds
+    """Check the deployed gateway can report pool readiness and serve a completion."""
     headers = _shim_headers(
         api_key=api_key,
         provider_model=provider_model,
         provider_deployment=provider_deployment,
     )
-    last_error = ""
+    _smoke_frontdoor(frontdoor_url(), headers, timeout_seconds)
+
+
+def _smoke_frontdoor(gateway: str, headers: dict[str, str], timeout_seconds: int) -> None:
+    """Poll readiness until ROLLOUT_MIN_CONTAINERS replicas report ready, then
+    serve one completion through the front door."""
+    import json
+    import time
+    import urllib.request
+
+    deadline = time.time() + timeout_seconds
+    last = ""
     while True:
         try:
             req = urllib.request.Request(
@@ -363,14 +335,15 @@ def smoke(
             )
             with urllib.request.urlopen(req, timeout=30) as resp:
                 pool = json.load(resp)
-            if len(pool.get("replicas", [])) >= exp.ROLLOUT_MIN_CONTAINERS:
+            ready = [r for r in pool.get("replicas", []) if r.get("readiness")]
+            print(f"pool: {len(pool.get('replicas', []))} replicas, {len(ready)} ready")
+            if len(ready) >= exp.ROLLOUT_MIN_CONTAINERS:
                 break
-            last_error = f"expected {exp.ROLLOUT_MIN_CONTAINERS} replicas, got {pool}"
+            last = f"only {len(ready)} of {exp.ROLLOUT_MIN_CONTAINERS} ready"
         except Exception as exc:  # noqa: BLE001
-            last_error = f"{type(exc).__name__}: {exc}"
+            last = f"{type(exc).__name__}: {exc}"
         if time.time() > deadline:
-            raise TimeoutError(f"Provider smoke failed: {last_error}")
-        print(f"Waiting for provider pool: {last_error}")
+            raise TimeoutError(f"front-door readiness timed out: {last}")
         time.sleep(10)
 
     req = urllib.request.Request(
@@ -379,7 +352,7 @@ def smoke(
         headers={"Content-Type": "application/json", **headers},
     )
     with urllib.request.urlopen(req, timeout=180) as resp:
-        print(json.dumps(json.load(resp), indent=2)[:2000])
+        print("completion:", json.dumps(json.load(resp))[:1200])
 
 
 def provider_gateway_url() -> str:

--- a/cookbook/standalone_rollouts/simulator_test.py
+++ b/cookbook/standalone_rollouts/simulator_test.py
@@ -147,10 +147,14 @@ class SimulatorTest(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(r.status_code, 200)
                 self.assertEqual(r.json()["version"], 1)
 
-                # The front door normalized the plain index in place: it now carries
-                # the slime metadata block the decoder needs (this is the F2 fix).
-                normalized = json.loads(
+                # The front door derived the decoder's index next to the upload;
+                # the customer's own index is byte-identical to what they wrote.
+                raw = json.loads(
                     (transport / "ckpt-100" / "model.safetensors.index.json").read_text()
+                )["metadata"]
+                self.assertEqual(raw, {"total_size": 123})
+                normalized = json.loads(
+                    (transport / "ckpt-100" / "stitch.index.json").read_text()
                 )["metadata"]
                 self.assertEqual(normalized["version"], "000001")
                 self.assertEqual(normalized["base_version"], "000000")

--- a/cookbook/standalone_rollouts/simulator_test.py
+++ b/cookbook/standalone_rollouts/simulator_test.py
@@ -1,16 +1,15 @@
 """In-process end-to-end simulator for the standalone rollouts abstraction layer.
 
-Wires the REAL front door (ledger + normalization) to N real WeightSyncManagers
-(delta-view boards + fake engines) over a tmpdir "transport", with no Modal and
-no GPU. It grounds the contract the ledger/normalization/symlink-view commits
-built: a customer who uploads a plain HF index (metadata = {"total_size": ...})
-and signals an opaque identity — the exact shape that bricked the pool per
-battle-plan F2 — now converges, because the front door normalizes the index on
-POST and the sidecar resolves the identity dir through the weight_vN view.
+Wires the REAL front door (ledger + index derivation) to N real
+WeightSyncManagers (delta-view boards + fake engines) over a tmpdir
+"transport", with no Modal and no GPU: a customer who uploads a plain HF index
+and signals an opaque identity converges, because the front door derives the
+decoder index on POST and the sidecar resolves the identity dir through the
+weight_vN view.
 
 The fake engine records applied versions without decoding real delta bytes (the
-codec is the pinned slime fork's concern); everything else — opaque identity ->
-version, index normalization, pointer advance, view rebuild, manifest parse,
+codec is the pinned slime fork's concern); everything else — identity ->
+version, index derivation, pointer advance, view rebuild, manifest parse,
 apply gate, readiness translation — is the real code path.
 """
 
@@ -49,9 +48,13 @@ class _FakeEngine:
     async def continue_generation(self) -> None: ...
 
 
+def _delta(identity: str, previous: str) -> dict:
+    return {"identity": identity, "incremental_snapshot_metadata": {"previous_snapshot_identity": previous}}
+
+
 def _upload_plain_hf_checkpoint(transport: Path, identity: str) -> None:
     """A vanilla HF checkpoint dir: a weight_map and a bare total_size metadata,
-    with NO slime version/base_version/delta_encoding block (F2's failing shape)."""
+    with NO slime version/base_version/delta_encoding block."""
     d = transport / identity
     d.mkdir(parents=True)
     (d / "model.safetensors.index.json").write_text(
@@ -131,19 +134,9 @@ class SimulatorTest(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(r.status_code, 200)
                 self.assertEqual(r.json()["version"], 0)
 
-                # Delta: a PLAIN HF index (F2's brick shape) + opaque identity.
+                # Delta: a plain HF index + opaque identity.
                 _upload_plain_hf_checkpoint(transport, "ckpt-100")
-                r = await client.post(
-                    HOT_LOAD_PATH,
-                    json={
-                        "identity": "ckpt-100",
-                        "incremental_snapshot_metadata": {
-                            "previous_snapshot_identity": "base-ckpt",
-                            "compression_format": "zstd",
-                            "checksum_format": "adler32",
-                        },
-                    },
-                )
+                r = await client.post(HOT_LOAD_PATH, json=_delta("ckpt-100", "base-ckpt"))
                 self.assertEqual(r.status_code, 200)
                 self.assertEqual(r.json()["version"], 1)
 
@@ -183,17 +176,7 @@ class SimulatorTest(unittest.IsolatedAsyncioTestCase):
                 _upload_plain_hf_checkpoint(transport, "base-ckpt")
                 await client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
                 # Signal a delta whose dir has NOT been uploaded yet.
-                r = await client.post(
-                    HOT_LOAD_PATH,
-                    json={
-                        "identity": "ckpt-100",
-                        "incremental_snapshot_metadata": {
-                            "previous_snapshot_identity": "base-ckpt",
-                            "compression_format": "zstd",
-                            "checksum_format": "adler32",
-                        },
-                    },
-                )
+                r = await client.post(HOT_LOAD_PATH, json=_delta("ckpt-100", "base-ckpt"))
                 self.assertEqual(r.status_code, 409)
                 # Pointer never advanced past the base; ledger has no ckpt-100.
                 ledger = json.loads((transport / "identities.json").read_text())
@@ -209,24 +192,20 @@ class SimulatorTest(unittest.IsolatedAsyncioTestCase):
                 _upload_plain_hf_checkpoint(transport, "base-ckpt")
                 await client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
                 _upload_plain_hf_checkpoint(transport, "ckpt-100")
-                delta = lambda ident, prev: {
-                    "identity": ident,
-                    "incremental_snapshot_metadata": {"previous_snapshot_identity": prev},
-                }
-                await client.post(HOT_LOAD_PATH, json=delta("ckpt-100", "base-ckpt"))
+                await client.post(HOT_LOAD_PATH, json=_delta("ckpt-100", "base-ckpt"))
                 for mgr in managers:
                     await mgr.sync_to()
                     self.assertEqual(mgr.current_version, 1)
 
                 # A fork off the base is refused; nothing enters the log.
                 _upload_plain_hf_checkpoint(transport, "ckpt-fork")
-                r = await client.post(HOT_LOAD_PATH, json=delta("ckpt-fork", "base-ckpt"))
+                r = await client.post(HOT_LOAD_PATH, json=_delta("ckpt-fork", "base-ckpt"))
                 self.assertEqual(r.status_code, 409)
 
                 # The chain head still extends and the pool still converges —
                 # an accepted fork would have wedged replicas at v1 forever.
                 _upload_plain_hf_checkpoint(transport, "ckpt-200")
-                r = await client.post(HOT_LOAD_PATH, json=delta("ckpt-200", "ckpt-100"))
+                r = await client.post(HOT_LOAD_PATH, json=_delta("ckpt-200", "ckpt-100"))
                 self.assertEqual(r.json()["version"], 2)
                 for mgr in managers:
                     await mgr.sync_to()
@@ -243,15 +222,7 @@ class SimulatorTest(unittest.IsolatedAsyncioTestCase):
                 d = transport / "ckpt-100"
                 d.mkdir()
                 (d / "model.safetensors.index.json").write_text('{"metadata": {', encoding="utf-8")
-                r = await client.post(
-                    HOT_LOAD_PATH,
-                    json={
-                        "identity": "ckpt-100",
-                        "incremental_snapshot_metadata": {
-                            "previous_snapshot_identity": "base-ckpt",
-                        },
-                    },
-                )
+                r = await client.post(HOT_LOAD_PATH, json=_delta("ckpt-100", "base-ckpt"))
                 self.assertEqual(r.status_code, 400)
                 # The failed signal left no ledger entry, so a fixed re-upload
                 # and re-signal converges.

--- a/src/stitch/protocol.py
+++ b/src/stitch/protocol.py
@@ -582,12 +582,9 @@ def atomic_write_text(path: str | Path, text: str) -> None:
     """Write ``text`` so a concurrent reader sees the old or the new content,
     never a truncated file.
 
-    On a normal filesystem: tmp file + fsync + ``os.replace``. On the S3
-    CloudBucketMount ``os.replace`` raises ENOSYS (mountpoint-s3 has no rename —
-    the same constraint that made the trainer upload path copy instead of
-    rename, commit 8745872), so fall back to an in-place ``open("w")``
-    overwrite, which a probe against the real mount confirmed is one PutObject,
-    atomic at the object level.
+    On a normal filesystem: tmp file + fsync + ``os.replace``. mountpoint-s3
+    has no rename (``os.replace`` raises ENOSYS), so fall back to an in-place
+    ``open("w")`` overwrite there — one PutObject, atomic at the object level.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/stitch/servers/sglang.py
+++ b/src/stitch/servers/sglang.py
@@ -84,13 +84,21 @@ def create_app(
         queue_sync = getattr(manager, "queue_sync", None)
         if board is None or queue_sync is None:
             return
+        failure_tag = "background reconcile failed: "
         while True:
             await asyncio.sleep(interval)
             try:
                 await board.refresh()
                 queue_sync()
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
+                # A replica that cannot follow the board must not report ready;
+                # sticky until a reconcile pass succeeds again.
+                if hasattr(manager, "last_sync_error"):
+                    manager.last_sync_error = f"{failure_tag}{exc}"
                 logger.warning("background reconcile failed", exc_info=True)
+            else:
+                if str(getattr(manager, "last_sync_error", "") or "").startswith(failure_tag):
+                    manager.last_sync_error = None
 
     reconcile: dict[str, Any] = {}
 

--- a/src/stitch/servers/sglang_test.py
+++ b/src/stitch/servers/sglang_test.py
@@ -28,6 +28,44 @@ class FakeEngine:
         self.events.append("continue")
 
 
+class ReconcileLoopTest(unittest.TestCase):
+    def test_refresh_failure_marks_replica_unready_until_recovery(self) -> None:
+        # A replica whose board refresh keeps failing cannot follow the log; it
+        # must surface that in last_sync_error (unready), not just a warning log.
+        import time
+
+        from fastapi.testclient import TestClient
+
+        from stitch.servers.sglang import create_app
+
+        with tempfile.TemporaryDirectory() as tmp:
+            broken = {"on": True}
+
+            def refresh() -> None:
+                if broken["on"]:
+                    raise RuntimeError("mount hiccup")
+
+            board = FilesystemBulletinBoard(tmp, layout="slime", refresh=refresh)
+            manager = WeightSyncManager(board=board, engine=FakeEngine())
+            app = create_app(
+                manager, upstream_url="http://127.0.0.1:9", background_sync_interval=0.01
+            )
+            with TestClient(app) as client:
+                deadline = time.time() + 5
+                while time.time() < deadline and not str(
+                    manager.last_sync_error or ""
+                ).startswith("background reconcile failed"):
+                    time.sleep(0.02)
+                info = client.get("/server_info").json()
+                self.assertIn("background reconcile failed", info["last_sync_error"] or "")
+
+                broken["on"] = False  # recovery clears the sticky error
+                deadline = time.time() + 5
+                while time.time() < deadline and manager.last_sync_error:
+                    time.sleep(0.02)
+                self.assertIsNone(manager.last_sync_error)
+
+
 class SidecarProxyTest(unittest.TestCase):
     def _client(self, tmp: str):
         from fastapi.testclient import TestClient

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -308,12 +308,9 @@ class WeightSyncManager(RolloutAdmissionGate):
                     self.latest_seen_version = max(self.latest_seen_version, latest)
                     queued = self.queued_target_version or 0
                     if queued > latest:
-                        # A wake hint is only a prompt to look at the board; the
-                        # durable head is the authority. A hint the head never
-                        # reaches (stale, or from a previous incarnation) must
-                        # not pin the manager in QUEUED forever — anything
-                        # published after this pass converges via the periodic
-                        # reconcile.
+                        # The board is the authority; a hint it never reaches
+                        # (stale or foreign) must not pin us QUEUED forever.
+                        # Anything published later converges via the reconcile.
                         self.queued_target_version = queued = latest
                     if run_id != self.current_run_id or max(latest, queued) > self.current_version:
                         reached = False


### PR DESCRIPTION
Review-fixes slice 5 of 5 (5 commits): customer uploads are never mutated — the decoder index is derived next to the upload as `stitch.index.json` and the per-version delta view presents it under the HF index name via per-file symlinks; a review-weight trim (unified check/smoke, `_error`/`_delta` helpers, process-referencing comments removed, thin tests folded); plus two defects the live probe caught: the view build now treats ENOENT from the listing as "not uploaded yet" (a signalled-but-never-uploaded base killed every refresh; a stat-based guard was insufficient — mountpoint answers `is_dir()` inconsistently), and a persistently failing background reconcile now sets a sticky `last_sync_error` instead of reporting ready while unable to follow the board.

## Stack (review bottom-up; each PR is a contiguous slice, no rewritten history)
1. #24 one-base serving + front-door hardening → `main`
2. #21 opaque identities + ledger (the abstraction core)
3. #25 lineage validation at the front door
4. #26 atomic transport writes + streaming proxy
5. #27 corrupt control state is an error
6. #28 fork rejection, run-switch integrity, base pin
7. #20 (this PR) derived index + trim + live-probe fixes

## Verification (whole stack, at this tip)
- 163 tests (`uv run --extra modal --extra sglang python -m pytest src/ cookbook/ profiling/`), including an in-process end-to-end simulator driving the real front door + real sync managers through base/delta/fork/malformed flows with real manifest parsing through the delta view.
- Live in Modal (`jason-dev`, scratch app + prefix, since stopped): S3 write fallback (ENOSYS→in-place PutObject, no `.tmp` leak), the full contract matrix (auth 401, allowlist 404, base signal + idempotent re-signal, base-pin 409s, unknown-parent 409, missing-lineage 400, `..` 400), buffered + streaming completions on a real 1×H200 pool, and a live run switch observed in both directions (fresh boot followed a run-scoped pointer; a wake-driven reconcile followed the overwrite back), serving throughout.
- Operational notes from the probe: a default (rolling) `modal deploy` does not replace a warm Flash Server container — use `modal deploy --strategy recreate` when shipping sidecar changes; warm pointer-overwrite reads through the mount lag O(minutes) while the post-advance wake converges immediately (missed-wake backstop is soft).
- Known residual gaps: end-to-end token streaming is still buffered by the sidecar (pre-existing on main; documented follow-up), and the reset-with-reload body is unit-covered but not live-exercised from a patched replica (the reload call is identical to the daily-proven commit path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnEES5LVJpCiATG6w16QTU
