### PR TITLE
Refactor hot-load API to use opaque identities and ledger-based versioning

### DIFF
--- a/cookbook/standalone_rollouts/delta_view.py
+++ b/cookbook/standalone_rollouts/delta_view.py
@@ -1,0 +1,48 @@
+"""Host-local ``weight_vN`` view of the customer's identity-named upload dirs.
+
+The customer uploads each checkpoint to ``<transport>/<opaque_identity>/`` (spec
+§1 couples the dir name to the identity), but slime's disk-delta decoder walks
+``<delta_root>/weight_v{N:06d}/``. The front-door ledger maps identity -> version;
+this builds a host-local directory of symlinks (``weight_vN`` -> the transport's
+identity dir, plus ``latest`` -> the transport pointer) so the unmodified decoder
+and bulletin board operate against a normal weight_vN slime layout.
+
+mountpoint-s3 cannot host a symlink (ENOSYS, same family as rename), but a
+host-local symlink *into* the mount resolves through transparently on read, so
+the view lives on the container's ephemeral disk and the delta bytes are still
+read straight from S3. The view is rebuilt from the ledger on every board
+refresh (i.e. before every sync), so newly-signalled versions appear.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from cookbook.standalone_rollouts.ledger import IdentityLedger
+from stitch.protocol import weight_identity
+
+
+LATEST_FILE = "latest"
+
+
+def _ensure_symlink(link: Path, target: Path) -> None:
+    if link.is_symlink() and os.readlink(link) == str(target):
+        return
+    if link.is_symlink() or link.exists():
+        link.unlink()
+    link.symlink_to(target)
+
+
+def rebuild_delta_view(view_root: str | Path, transport_root: str | Path, ledger: IdentityLedger) -> None:
+    """(Re)build the host-local weight_vN view under ``view_root`` from ``ledger``.
+
+    Idempotent: existing correct symlinks are left alone. Links ``latest`` to the
+    transport pointer and each minted version to its identity dir on the transport.
+    """
+    view = Path(view_root)
+    transport = Path(transport_root)
+    view.mkdir(parents=True, exist_ok=True)
+    _ensure_symlink(view / LATEST_FILE, transport / LATEST_FILE)
+    for version, identity in ledger.items_by_version():
+        _ensure_symlink(view / weight_identity(version), transport / identity)

--- a/cookbook/standalone_rollouts/delta_view_test.py
+++ b/cookbook/standalone_rollouts/delta_view_test.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from cookbook.standalone_rollouts.delta_view import rebuild_delta_view
+from cookbook.standalone_rollouts.ledger import IdentityLedger
+
+
+class RebuildDeltaViewTest(unittest.TestCase):
+    def _transport(self, tmp: str) -> Path:
+        transport = Path(tmp) / "transport"
+        transport.mkdir()
+        (transport / "latest").write_text("weight_v000001", encoding="utf-8")
+        # Customer uploaded to identity-named dirs, not weight_vN.
+        for identity in ("base-ckpt", "ckpt-100"):
+            d = transport / identity
+            d.mkdir()
+            (d / "model.safetensors.index.json").write_text(
+                json.dumps({"metadata": {"version": identity}, "weight_map": {}}), encoding="utf-8"
+            )
+        return transport
+
+    def test_view_maps_versions_to_identity_dirs_and_reads_through(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            transport = self._transport(tmp)
+            ledger = IdentityLedger()
+            ledger.record("base-ckpt", previous=None)  # v0
+            ledger.record("ckpt-100", previous="base-ckpt")  # v1
+            view = Path(tmp) / "view"
+
+            rebuild_delta_view(view, transport, ledger)
+
+            # weight_vN symlinks resolve to the identity dirs...
+            self.assertTrue((view / "weight_v000000").is_symlink())
+            self.assertTrue((view / "weight_v000001").is_symlink())
+            # ...and reading through the view reaches the real (identity-dir) files.
+            index = json.loads(
+                (view / "weight_v000001" / "model.safetensors.index.json").read_text()
+            )
+            self.assertEqual(index["metadata"]["version"], "ckpt-100")
+            # latest pointer is visible through the view.
+            self.assertEqual((view / "latest").read_text(), "weight_v000001")
+
+    def test_rebuild_is_idempotent_and_picks_up_new_versions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            transport = self._transport(tmp)
+            view = Path(tmp) / "view"
+
+            ledger = IdentityLedger()
+            ledger.record("base-ckpt", previous=None)
+            rebuild_delta_view(view, transport, ledger)
+            self.assertFalse((view / "weight_v000001").exists())
+
+            # A later signal adds v1; a rebuild picks it up without disturbing v0.
+            ledger.record("ckpt-100", previous="base-ckpt")
+            rebuild_delta_view(view, transport, ledger)
+            rebuild_delta_view(view, transport, ledger)  # idempotent second pass
+            self.assertTrue((view / "weight_v000001").is_symlink())
+            self.assertTrue((view / "weight_v000000").is_symlink())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cookbook/standalone_rollouts/frontdoor.py
+++ b/cookbook/standalone_rollouts/frontdoor.py
@@ -1,21 +1,26 @@
 """Front-door hot-load adapter for the standalone rollout provider.
 
-The front door is the single public entry and the single writer of the
-bulletin board's monotonic ``latest`` pointer. It implements the customer's
-hot-load API as a thin projection of the canonical log-as-truth design:
+The front door is the single public entry and the single writer of both the
+bulletin board's monotonic ``latest`` pointer and the identity ledger. It
+implements the customer's hot-load API as an abstraction layer over the
+log-as-truth pool, so the customer's contract (opaque checkpoint identities,
+lineage via ``previous_snapshot_identity``, delta formats in the POST body)
+never leaks the pool's integer-versioned internals:
 
-- ``POST /hot_load/...`` advances ``latest`` to the signalled checkpoint
-  (monotonic CAS — a rewind is rejected for now; rolling the fleet back from a
-  recovery anchor is the future story), then best-effort wakes the pool. The
-  elastic rollout pool reconciles to ``latest`` on its own.
-- ``GET /hot_load/...`` reports pool readiness by enumerating the *live*
-  containers and querying each ``/server_info`` — no self-reported replica
-  state, so a scaled-down container can't haunt the readiness fraction.
-- Everything else is proxied to the rollout gateway.
+- ``POST /hot_load/...`` maps the signalled opaque ``identity`` to a monotonic
+  stitch version via the :class:`~cookbook.standalone_rollouts.ledger.IdentityLedger`
+  (idempotent on re-signal), normalizes the customer's POST metadata into the
+  version dir's index so the disk-delta decoder can apply it, advances ``latest``,
+  and best-effort wakes the pool.
+- ``GET /hot_load/...`` reports readiness by enumerating the *live* containers and
+  querying each ``/server_info``, translating each replica's integer version back
+  to the customer's identity string so their equality match works.
+- Inference (``v1/*``, ``generate``) is proxied to the rollout gateway; every
+  other route is rejected (allowlist).
 
-All I/O (reading/writing ``latest``, enumerating replicas, proxying, auth) is
-injected so the adapter logic is testable without Modal; ``modal_serve.py``
-supplies the real implementations.
+All I/O (ledger load/save, index normalization, pointer write, replica
+enumeration, proxy, auth) is injected so the adapter is testable without Modal;
+``modal_serve.py`` supplies the real implementations.
 
 No ``from __future__ import annotations`` here: the route handlers'
 ``request: Request`` annotation must evaluate eagerly against the factory-local
@@ -26,17 +31,12 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from stitch.protocol import (
-    PointerRewind,
-    RolloutPoolState,
-    RolloutReplicaState,
-    decide_pointer_move,
-    format_snapshot_identity,
-    parse_weight_identity,
-)
+from cookbook.standalone_rollouts.ledger import IdentityLedger
+from stitch.protocol import RolloutPoolState, RolloutReplicaState
 
 
 HOT_LOAD_PATH = "/hot_load/v1/models/hot_load"
+MAX_IDENTITY_LEN = 512
 
 
 def is_customer_inference_route(path: str) -> bool:
@@ -55,72 +55,55 @@ def is_customer_inference_route(path: str) -> bool:
     return route == "generate" or route == "v1" or route.startswith("v1/")
 
 
-def advance_latest_decision(
-    current_run_id: str | None,
-    current_version: int,
-    identity: str,
-    request_run_id: str | None,
-) -> dict[str, Any]:
-    """Decide whether a hot-load signal should advance the ``latest`` pointer.
-
-    Run-id partitioning makes this idempotent across runs. A signal from a
-    *different* run (``request_run_id != current_run_id``) is a fresh chain whose
-    version space restarts at 1, so it is accepted and resets the version space
-    (``"reset": True``) — accepting v1 after a finished run reached v5 is the
-    intended begin-a-new-run path, not a rewind. Within the same run (and the
-    run-less customer layout where both are None) the monotonic CAS still applies.
-
-    Returns ``{"run_id": str|None, "version": int, "reset": bool}`` to accept, or
-    ``{"error": {...}}`` to reject (``InvalidIdentity`` / ``WeightRewindRejected``).
-    The accept/reset/rewind call is :func:`stitch.protocol.decide_pointer_move`,
-    the same rule the bulletin-board publish path advances through; this wrapper
-    only parses the wire identity and shapes the error dict. An explicit claim is
-    just a signal at ``weight_v000000`` with a fresh ``run_id`` (a cross-run move,
-    so ``reset=True``).
-    """
-    version = parse_weight_identity(identity)
-    if version is None:
-        return {
-            "error": {
-                "type": "InvalidIdentity",
-                "message": f"identity {identity!r} is not weight_v<NNNNNN>",
-            }
-        }
-    try:
-        move = decide_pointer_move(
-            current_run_id, current_version, run_id=request_run_id, version=version
-        )
-    except PointerRewind as rewind:
-        return {
-            "error": {
-                "type": "WeightRewindRejected",
-                "message": str(rewind),
-                "current_version": rewind.current_version,
-                "requested_version": rewind.requested_version,
-            }
-        }
-    return {"run_id": move.run_id, "version": move.version, "reset": move.reset}
+def is_valid_identity(identity: str) -> bool:
+    """A customer checkpoint identity is opaque, but it becomes an S3 path
+    component (``<prefix>/<identity>/``) and a ledger key, so it must be
+    non-empty, bounded, single-segment (no ``/``, which would escape the prefix),
+    and free of control characters. Bounding it also caps ledger/key growth from
+    a hostile client."""
+    if not identity or len(identity) > MAX_IDENTITY_LEN:
+        return False
+    return "/" not in identity and not any(ord(c) < 0x20 for c in identity)
 
 
-def pool_state_from_server_infos(infos: list[dict[str, Any]]) -> RolloutPoolState:
+def delta_index_metadata(
+    version: int, base_version: int, incremental: dict[str, Any]
+) -> dict[str, str]:
+    """The slime disk-delta ``metadata`` block the decoder requires, derived from
+    the customer's POST. ``version``/``base_version`` are the ledger-assigned
+    integers as zero-padded 6-digit strings (the decoder compares ``base_version``
+    to the applied-version marker by string equality). ``delta_encoding`` is not
+    in the customer's API — spec §3 pins XOR — so it defaults to ``xor``;
+    ``compression_format``/``checksum_format`` come from the POST body (spec §2a),
+    defaulting to the spec's stated ``zstd``/``adler32`` when omitted."""
+    return {
+        "version": f"{int(version):06d}",
+        "base_version": f"{int(base_version):06d}",
+        "delta_encoding": str(incremental.get("delta_encoding", "xor")),
+        "compression_format": str(incremental.get("compression_format", "zstd")),
+        "checksum_format": str(incremental.get("checksum_format", "adler32")),
+    }
+
+
+def pool_state_from_server_infos(
+    infos: list[dict[str, Any]], ledger: IdentityLedger
+) -> RolloutPoolState:
     """Build a pool-readiness report from live ``/server_info`` responses.
 
     A replica is ready when it is reachable and idle (not mid-sync, no sticky
-    sync error). The trainer separately matches ``current_snapshot_identity``
-    against its target, so an idle replica still on an old version is observable
-    but correctly not counted toward the target.
+    sync error). Each replica reports an integer ``current_version``; the ledger
+    translates it back to the customer's opaque identity so their readiness match
+    (``current_snapshot_identity == <signalled identity>``) works. An idle replica
+    on an old version is observable but correctly not counted toward the target.
     """
     replicas: list[RolloutReplicaState] = []
     for info in infos:
         current_version = info.get("current_version")
-        current_run_id = info.get("current_run_id")
         sync_state = info.get("sync_state")
         last_error = info.get("last_sync_error")
         ready = sync_state == "IDLE" and not last_error
-        # The snapshot identity carries the run, so a replica still serving a
-        # finished run's same-numbered version isn't counted ready for a new run.
         identity = (
-            format_snapshot_identity(current_run_id, current_version)
+            ledger.identity_for(current_version)
             if isinstance(current_version, int) and current_version >= 0
             else None
         )
@@ -139,8 +122,10 @@ def pool_state_from_server_infos(infos: list[dict[str, Any]]) -> RolloutPoolStat
 
 def create_frontdoor_app(
     *,
-    read_current_pointer: Callable[[], Awaitable[tuple[str | None, int]]],
-    advance_to: Callable[[str | None, int], Awaitable[None]],
+    load_ledger: Callable[[], Awaitable[dict[str, Any]]],
+    save_ledger: Callable[[dict[str, Any]], Awaitable[None]],
+    normalize_index: Callable[[str, dict[str, str]], Awaitable[None]],
+    advance_to: Callable[[int], Awaitable[None]],
     list_server_infos: Callable[[], Awaitable[list[dict[str, Any]]]],
     proxy: Callable[..., Awaitable[Any]],
     authorize: Callable[[Any], Any] | None = None,
@@ -148,15 +133,19 @@ def create_frontdoor_app(
 ):
     """Build the front-door FastAPI app from injected I/O.
 
-    ``read_current_pointer`` returns the active ``(run_id, version)``;
-    ``advance_to(run_id, version)`` atomically writes the single self-identifying
-    ``latest`` pointer. ``list_server_infos`` enumerates live replicas; ``proxy``
-    forwards non-hot-load requests; ``authorize`` returns a rejection Response or
+    ``load_ledger``/``save_ledger`` read/write the identity↔version ledger on the
+    transport; ``normalize_index(identity, metadata)`` writes the disk-delta
+    metadata block into that version dir's index; ``advance_to(version)`` writes
+    the ``latest`` pointer; ``list_server_infos`` enumerates live replicas;
+    ``proxy`` forwards inference; ``authorize`` returns a rejection Response or
     ``None``; ``wake`` is a best-effort post-advance nudge.
 
-    The read-decide-advance sequence is serialized so the singleton front door
-    never races itself into a transient rewind (two POSTs both reading the same
-    current version and advancing out of order).
+    The load-record-normalize-save-advance sequence is serialized under
+    ``advance_lock`` so the singleton front door never races itself. The ledger
+    is loaded fresh from the transport inside the lock (not cached across POSTs),
+    so a partial failure leaves the transport ledger authoritative and a retry
+    converges: normalize is idempotent, save is the commit point, and the pointer
+    is re-advanced to the head even on an idempotent re-signal.
     """
     from fastapi import FastAPI, Request
     from fastapi.responses import JSONResponse, Response
@@ -179,34 +168,63 @@ def create_frontdoor_app(
         if not isinstance(payload, dict) or not payload.get("identity"):
             return JSONResponse({"error": "body.identity is required"}, status_code=400)
         identity = str(payload["identity"])
-        request_run_id = payload.get("run_id")
-        # run_id, when present, must be a string: the monotonic guard compares it
-        # against the stored run id, and a non-string (e.g. a JSON number) never
-        # compares equal, silently turning every duplicate signal into a
-        # pool-resetting cross-run move.
-        if request_run_id is not None and not isinstance(request_run_id, str):
-            return JSONResponse({"error": "body.run_id must be a string"}, status_code=400)
-        async with advance_lock:
-            current_run_id, current_version = await read_current_pointer()
-            decision = advance_latest_decision(
-                current_run_id, current_version, identity, request_run_id
+        if not is_valid_identity(identity):
+            return JSONResponse(
+                {"error": "body.identity must be a non-empty, single-segment string <= 512 chars"},
+                status_code=400,
             )
-            if "error" in decision:
-                status = 400 if decision["error"]["type"] == "InvalidIdentity" else 409
-                return JSONResponse(decision, status_code=status)
-            await advance_to(decision["run_id"], decision["version"])
-        snapshot_identity = format_snapshot_identity(decision["run_id"], decision["version"])
-        if wake is not None:
+        incremental = payload.get("incremental_snapshot_metadata")
+        if incremental is not None and not isinstance(incremental, dict):
+            return JSONResponse(
+                {"error": "body.incremental_snapshot_metadata must be an object"}, status_code=400
+            )
+        previous = incremental.get("previous_snapshot_identity") if incremental else None
+        if previous is not None and not isinstance(previous, str):
+            return JSONResponse(
+                {"error": "incremental_snapshot_metadata.previous_snapshot_identity must be a string"},
+                status_code=400,
+            )
+
+        async with advance_lock:
+            ledger = IdentityLedger.from_dict(await load_ledger())
+            entry, is_new = ledger.record(identity, previous)
+            if is_new:
+                # A delta (incremental metadata present) needs its index normalized
+                # so the decoder can apply it; a full snapshot (base) is served
+                # from the booted base checkpoint and needs no delta metadata.
+                # Normalize before saving/advancing, so a missing upload leaves the
+                # transport ledger and pointer untouched (fail fast, self-clean).
+                if incremental is not None:
+                    try:
+                        await normalize_index(
+                            identity,
+                            delta_index_metadata(
+                                entry.version, ledger.base_version_for(identity), incremental
+                            ),
+                        )
+                    except FileNotFoundError:
+                        return JSONResponse(
+                            {"error": f"checkpoint {identity!r} not found on the transport; upload before signalling"},
+                            status_code=409,
+                        )
+                await save_ledger(ledger.to_dict())
+            # Advance (idempotently) whenever this identity is the chain head, so a
+            # retry after a save-succeeded/advance-failed POST still moves latest.
+            if entry.version == ledger.head_version:
+                await advance_to(entry.version)
+
+        if is_new and wake is not None:
             try:
-                await wake(decision["version"])
+                await wake(entry.version)
             except Exception:  # noqa: BLE001 — wake is a latency optimization only
                 pass
         return JSONResponse(
             {
                 "accepted": True,
                 "identity": identity,
-                "current_snapshot_identity": snapshot_identity,
-                "run_id": decision["run_id"],
+                "current_snapshot_identity": identity,
+                "version": entry.version,
+                "already_current": not is_new,
             }
         )
 
@@ -215,8 +233,9 @@ def create_frontdoor_app(
         rejected = _auth(request)
         if rejected is not None:
             return rejected
+        ledger = IdentityLedger.from_dict(await load_ledger())
         infos = await list_server_infos()
-        return JSONResponse(pool_state_from_server_infos(infos).to_dict())
+        return JSONResponse(pool_state_from_server_infos(infos, ledger).to_dict())
 
     @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
     async def catch_all(path: str, request: Request) -> Response:

--- a/cookbook/standalone_rollouts/frontdoor_test.py
+++ b/cookbook/standalone_rollouts/frontdoor_test.py
@@ -4,214 +4,281 @@ import unittest
 
 from cookbook.standalone_rollouts.frontdoor import (
     HOT_LOAD_PATH,
-    advance_latest_decision,
-    create_frontdoor_app,
+    delta_index_metadata,
+    is_customer_inference_route,
+    is_valid_identity,
     pool_state_from_server_infos,
 )
+from cookbook.standalone_rollouts.ledger import IdentityLedger
 
 
-class AdvanceDecisionTest(unittest.TestCase):
-    def test_accepts_strictly_newer_same_run(self) -> None:
+class IdentityValidationTest(unittest.TestCase):
+    def test_opaque_identities_are_accepted(self) -> None:
+        for identity in ("weight_v000001", "ckpt-100", "step_500", "2026-07-11T00:00:00Z", "wéight"):
+            self.assertTrue(is_valid_identity(identity), identity)
+
+    def test_rejects_empty_slashed_control_and_overlong(self) -> None:
+        self.assertFalse(is_valid_identity(""))
+        self.assertFalse(is_valid_identity("a/b"))  # would escape the prefix
+        self.assertFalse(is_valid_identity("a\nb"))  # control char
+        self.assertFalse(is_valid_identity("x" * 513))
+
+
+class DeltaMetadataTest(unittest.TestCase):
+    def test_pads_versions_and_defaults_delta_encoding(self) -> None:
+        meta = delta_index_metadata(
+            2, 1, {"compression_format": "zstd", "checksum_format": "adler32"}
+        )
         self.assertEqual(
-            advance_latest_decision("run-a", 4, "weight_v000005", "run-a"),
-            {"run_id": "run-a", "version": 5, "reset": False},
+            meta,
+            {
+                "version": "000002",
+                "base_version": "000001",
+                "delta_encoding": "xor",  # not in the customer API; spec §3 default
+                "compression_format": "zstd",
+                "checksum_format": "adler32",
+            },
         )
 
-    def test_rejects_rewind_same_run(self) -> None:
-        for identity in ("weight_v000004", "weight_v000003"):
-            decision = advance_latest_decision("run-a", 4, identity, "run-a")
-            self.assertEqual(decision["error"]["type"], "WeightRewindRejected")
-            self.assertEqual(decision["error"]["current_version"], 4)
-
-    def test_new_run_resets_even_if_version_lower(self) -> None:
-        # A new run restarts at v1; accepting it after the prior run reached v5 is
-        # the begin-a-new-run path, not a rewind — the idempotency fix.
-        self.assertEqual(
-            advance_latest_decision("run-a", 5, "weight_v000001", "run-b"),
-            {"run_id": "run-b", "version": 1, "reset": True},
+    def test_passes_through_customer_formats(self) -> None:
+        meta = delta_index_metadata(
+            5, 4, {"compression_format": "zstd", "checksum_format": "xxh3-128", "delta_encoding": "overwrite"}
         )
-
-    def test_runless_layout_stays_monotonic(self) -> None:
-        ok = advance_latest_decision(None, 4, "weight_v000005", None)
-        self.assertEqual(ok, {"run_id": None, "version": 5, "reset": False})
-        rewind = advance_latest_decision(None, 5, "weight_v000005", None)
-        self.assertEqual(rewind["error"]["type"], "WeightRewindRejected")
-
-    def test_claim_is_a_base_version_signal_for_a_fresh_run(self) -> None:
-        # An explicit claim is just weight_v000000 with a fresh run id: a
-        # cross-run move, so it resets the pool to base before any delta.
-        self.assertEqual(
-            advance_latest_decision("run-a", 5, "weight_v000000", "run-b"),
-            {"run_id": "run-b", "version": 0, "reset": True},
-        )
-
-    def test_rejects_unparseable_identity(self) -> None:
-        self.assertEqual(
-            advance_latest_decision(None, 0, "base", None)["error"]["type"], "InvalidIdentity"
-        )
+        self.assertEqual(meta["checksum_format"], "xxh3-128")
+        self.assertEqual(meta["delta_encoding"], "overwrite")
 
 
 class PoolStateTest(unittest.TestCase):
+    def _ledger(self) -> IdentityLedger:
+        ledger = IdentityLedger()
+        ledger.record("base-ckpt", previous=None)  # v0
+        ledger.record("ckpt-100", previous="base-ckpt")  # v1
+        return ledger
+
+    def test_translates_version_to_customer_identity(self) -> None:
+        state = pool_state_from_server_infos(
+            [{"current_version": 1, "sync_state": "IDLE", "last_sync_error": None, "replica_id": "a"}],
+            self._ledger(),
+        )
+        self.assertTrue(state.replicas[0].readiness)
+        self.assertEqual(state.replicas[0].current_snapshot_identity, "ckpt-100")
+        self.assertEqual(state.ready_count(target_snapshot_identity="ckpt-100"), 1)
+
     def test_ready_only_when_idle_and_no_error(self) -> None:
         state = pool_state_from_server_infos(
             [
-                {"run_id": "a", "current_run_id": "run-x", "current_version": 5, "sync_state": "IDLE", "last_sync_error": None},
-                {"run_id": "b", "current_run_id": "run-x", "current_version": 4, "sync_state": "PREFETCHING", "last_sync_error": None},
-                {"run_id": "c", "current_run_id": "run-x", "current_version": 5, "sync_state": "ERROR", "last_sync_error": "boom"},
-            ]
+                {"current_version": 1, "sync_state": "IDLE", "last_sync_error": None, "replica_id": "a"},
+                {"current_version": 0, "sync_state": "PREFETCHING", "last_sync_error": None, "replica_id": "b"},
+                {"current_version": 1, "sync_state": "ERROR", "last_sync_error": "boom", "replica_id": "c"},
+            ],
+            self._ledger(),
         )
         by_id = {r.replica_id: r for r in state.replicas}
         self.assertTrue(by_id["a"].readiness)
-        self.assertEqual(by_id["a"].current_snapshot_identity, "run-x/weight_v000005")
         self.assertFalse(by_id["b"].readiness)
         self.assertEqual(by_id["b"].readiness_reason, "PREFETCHING")
         self.assertFalse(by_id["c"].readiness)
         self.assertEqual(by_id["c"].readiness_reason, "boom")
-        self.assertEqual(state.ready_count(target_snapshot_identity="run-x/weight_v000005"), 1)
 
-    def test_identity_carries_run_id(self) -> None:
-        # A replica on run-b advertises a run-scoped identity, so it is not
-        # miscounted ready for a different run's same-numbered version.
+    def test_unreachable_replica_reason(self) -> None:
         state = pool_state_from_server_infos(
-            [{"run_id": "a", "current_run_id": "run-b", "current_version": 1, "sync_state": "IDLE"}]
+            [{"sync_state": None, "last_sync_error": "unreachable"}], self._ledger()
         )
-        self.assertEqual(state.replicas[0].current_snapshot_identity, "run-b/weight_v000001")
-        self.assertEqual(state.ready_count(target_snapshot_identity="run-b/weight_v000001"), 1)
-        self.assertEqual(state.ready_count(target_snapshot_identity="run-a/weight_v000001"), 0)
+        self.assertFalse(state.replicas[0].readiness)
+        self.assertEqual(state.replicas[0].readiness_reason, "unreachable")
+        self.assertIsNone(state.replicas[0].current_snapshot_identity)
+
+
+class RouteAllowlistTest(unittest.TestCase):
+    def test_inference_routes_allowed(self) -> None:
+        for path in ("generate", "v1/completions", "v1/chat/completions", "v1/models"):
+            self.assertTrue(is_customer_inference_route(path), path)
+
+    def test_control_routes_blocked(self) -> None:
+        for path in ("rpc_sync_from_bulletin_board", "server_info", "update_weights_from_ipc", "start_profile"):
+            self.assertFalse(is_customer_inference_route(path), path)
 
 
 class FrontdoorAppTest(unittest.TestCase):
-    def _client(self, *, run_id="run-a", version=5, authorize=None):
-        from fastapi.responses import JSONResponse
+    def _client(self, *, ledger: dict | None = None, authorize=None):
         from fastapi.testclient import TestClient
 
-        state = {"run_id": run_id, "version": version}
-        calls: dict[str, list] = {"advanced": [], "woke": [], "proxied": []}
+        from cookbook.standalone_rollouts.frontdoor import create_frontdoor_app
 
-        async def read_current_pointer():
-            return (state["run_id"], state["version"])
+        state: dict = {"ledger": dict(ledger or {}), "version": None}
+        calls: dict[str, list] = {"advanced": [], "woke": [], "normalized": [], "proxied": [], "saved": []}
 
-        async def advance_to(rid, v: int) -> None:
-            calls["advanced"].append((rid, v))
-            state["run_id"], state["version"] = rid, v
+        async def load_ledger():
+            return state["ledger"]
+
+        async def save_ledger(data):
+            state["ledger"] = data
+            calls["saved"].append(data)
+
+        async def normalize_index(identity, metadata):
+            calls["normalized"].append((identity, metadata))
+
+        async def advance_to(version):
+            state["version"] = version
+            calls["advanced"].append(version)
 
         async def list_server_infos():
-            return [
-                {
-                    "run_id": "a",
-                    "current_run_id": state["run_id"],
-                    "current_version": state["version"],
-                    "sync_state": "IDLE",
-                }
-            ]
+            v = state["version"] if state["version"] is not None else 0
+            return [{"current_version": v, "sync_state": "IDLE", "last_sync_error": None, "replica_id": "a"}]
 
-        async def wake(v: int) -> None:
-            calls["woke"].append(v)
+        async def wake(version):
+            calls["woke"].append(version)
+
+        from fastapi.responses import JSONResponse
 
         async def proxy(request, path):
             calls["proxied"].append(path)
             return JSONResponse({"proxied": path})
 
         app = create_frontdoor_app(
-            read_current_pointer=read_current_pointer,
+            load_ledger=load_ledger,
+            save_ledger=save_ledger,
+            normalize_index=normalize_index,
             advance_to=advance_to,
             list_server_infos=list_server_infos,
             proxy=proxy,
             authorize=authorize,
             wake=wake,
         )
-        return TestClient(app), calls
+        return TestClient(app), calls, state
 
-    def test_post_advances_on_newer_identity_and_wakes(self) -> None:
-        client, calls = self._client(run_id="run-a", version=4)
-        resp = client.post(HOT_LOAD_PATH, json={"identity": "weight_v000005", "run_id": "run-a"})
+    def test_full_snapshot_signal_mints_v0_without_normalizing(self) -> None:
+        client, calls, _ = self._client()
+        resp = client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
         self.assertEqual(resp.status_code, 200)
-        self.assertTrue(resp.json()["accepted"])
-        self.assertEqual(resp.json()["current_snapshot_identity"], "run-a/weight_v000005")
-        self.assertEqual(calls["advanced"], [("run-a", 5)])
-        self.assertEqual(calls["woke"], [5])
+        body = resp.json()
+        self.assertEqual(body["version"], 0)
+        self.assertEqual(body["current_snapshot_identity"], "base-ckpt")
+        self.assertFalse(body["already_current"])
+        self.assertEqual(calls["advanced"], [0])
+        self.assertEqual(calls["normalized"], [])  # a base is not a delta
 
-    def test_post_new_run_accepted_as_reset(self) -> None:
-        client, calls = self._client(run_id="run-a", version=5)
-        resp = client.post(HOT_LOAD_PATH, json={"identity": "weight_v000001", "run_id": "run-b"})
+    def test_delta_signal_mints_next_version_and_normalizes_index(self) -> None:
+        client, calls, _ = self._client()
+        client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
+        resp = client.post(
+            HOT_LOAD_PATH,
+            json={
+                "identity": "ckpt-100",
+                "incremental_snapshot_metadata": {
+                    "previous_snapshot_identity": "base-ckpt",
+                    "compression_format": "zstd",
+                    "checksum_format": "adler32",
+                },
+            },
+        )
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(calls["advanced"], [("run-b", 1)])
-        self.assertEqual(resp.json()["current_snapshot_identity"], "run-b/weight_v000001")
+        self.assertEqual(resp.json()["version"], 1)
+        self.assertEqual(calls["advanced"], [0, 1])
+        self.assertEqual(calls["woke"], [0, 1])
+        self.assertEqual(len(calls["normalized"]), 1)
+        ident, meta = calls["normalized"][0]
+        self.assertEqual(ident, "ckpt-100")
+        self.assertEqual(meta["version"], "000001")
+        self.assertEqual(meta["base_version"], "000000")
 
-    def test_post_rejects_rewind_without_advancing(self) -> None:
-        client, calls = self._client(run_id="run-a", version=5)
-        resp = client.post(HOT_LOAD_PATH, json={"identity": "weight_v000005", "run_id": "run-a"})
+    def test_resignal_is_idempotent_no_remint_no_normalize(self) -> None:
+        client, calls, _ = self._client()
+        client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
+        first = client.post(HOT_LOAD_PATH, json={"identity": "ckpt-100", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base-ckpt", "compression_format": "zstd", "checksum_format": "adler32"}})
+        again = client.post(HOT_LOAD_PATH, json={"identity": "ckpt-100", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base-ckpt", "compression_format": "zstd", "checksum_format": "adler32"}})
+        self.assertEqual(first.json()["version"], 1)
+        self.assertEqual(again.json()["version"], 1)
+        self.assertTrue(again.json()["already_current"])
+        # Only one normalize / one save for the mint; the retry re-advances the
+        # head (idempotent) but does not re-mint or re-normalize.
+        self.assertEqual(len(calls["normalized"]), 1)
+        self.assertEqual(calls["advanced"], [0, 1, 1])
+
+    def test_signal_before_upload_is_409_and_leaves_state_clean(self) -> None:
+        from fastapi.testclient import TestClient
+
+        from cookbook.standalone_rollouts.frontdoor import create_frontdoor_app
+
+        state: dict = {"ledger": {}, "version": None}
+        calls: dict[str, list] = {"advanced": [], "saved": []}
+
+        async def load_ledger():
+            return state["ledger"]
+
+        async def save_ledger(data):
+            state["ledger"] = data
+            calls["saved"].append(data)
+
+        async def normalize_index(identity, metadata):
+            raise FileNotFoundError(identity)  # upload has not landed yet
+
+        async def advance_to(version):
+            calls["advanced"].append(version)
+
+        async def list_server_infos():
+            return []
+
+        async def proxy(request, path):
+            from fastapi.responses import JSONResponse
+
+            return JSONResponse({})
+
+        app = create_frontdoor_app(
+            load_ledger=load_ledger,
+            save_ledger=save_ledger,
+            normalize_index=normalize_index,
+            advance_to=advance_to,
+            list_server_infos=list_server_infos,
+            proxy=proxy,
+        )
+        client = TestClient(app)
+        resp = client.post(
+            HOT_LOAD_PATH,
+            json={"identity": "ckpt-100", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base", "compression_format": "zstd", "checksum_format": "adler32"}},
+        )
         self.assertEqual(resp.status_code, 409)
-        self.assertEqual(resp.json()["error"]["type"], "WeightRewindRejected")
+        # No pointer move, no ledger commit -> a retry after upload converges.
         self.assertEqual(calls["advanced"], [])
-        self.assertEqual(calls["woke"], [])
+        self.assertEqual(calls["saved"], [])
+        self.assertEqual(state["ledger"], {})
+
+    def test_opaque_non_weight_v_identity_is_accepted(self) -> None:
+        client, _, _ = self._client()
+        resp = client.post(HOT_LOAD_PATH, json={"identity": "ckpt-step-500"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["current_snapshot_identity"], "ckpt-step-500")
+
+    def test_get_reports_readiness_in_customer_identity(self) -> None:
+        client, _, _ = self._client()
+        client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
+        client.post(HOT_LOAD_PATH, json={"identity": "ckpt-100", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base-ckpt", "compression_format": "zstd", "checksum_format": "adler32"}})
+        body = client.get(HOT_LOAD_PATH).json()
+        self.assertEqual(len(body["replicas"]), 1)
+        self.assertEqual(body["replicas"][0]["current_snapshot_identity"], "ckpt-100")
+        self.assertTrue(body["replicas"][0]["readiness"])
 
     def test_post_requires_identity(self) -> None:
-        client, _ = self._client()
+        client, _, _ = self._client()
         self.assertEqual(client.post(HOT_LOAD_PATH, json={}).status_code, 400)
 
     def test_post_malformed_body_is_400_not_500(self) -> None:
-        client, calls = self._client(run_id="run-a", version=5)
-        resp = client.post(
-            HOT_LOAD_PATH,
-            content=b"not json",
-            headers={"content-type": "application/json"},
-        )
+        client, calls, _ = self._client()
+        resp = client.post(HOT_LOAD_PATH, content=b"not json", headers={"content-type": "application/json"})
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(calls["advanced"], [])
 
-    def test_post_non_string_run_id_is_400_not_a_reset(self) -> None:
-        # A JSON-number run_id must not slip past the string compare in the
-        # monotonic guard (7 != "7") and turn a duplicate into a cross-run reset.
-        client, calls = self._client(run_id="run-a", version=5)
-        resp = client.post(HOT_LOAD_PATH, json={"identity": "weight_v000006", "run_id": 7})
-        self.assertEqual(resp.status_code, 400)
+    def test_post_overlong_or_slashed_identity_is_400(self) -> None:
+        client, calls, _ = self._client()
+        for identity in ("weight_v" + "9" * 100000, "a/b/c"):
+            self.assertEqual(client.post(HOT_LOAD_PATH, json={"identity": identity}).status_code, 400)
         self.assertEqual(calls["advanced"], [])
 
-    def test_post_pathological_identity_is_400_not_500(self) -> None:
-        client, calls = self._client(run_id="run-a", version=5)
-        for identity in ("weight_v²", "weight_v" + "9" * 100000):
-            resp = client.post(HOT_LOAD_PATH, json={"identity": identity, "run_id": "run-a"})
-            self.assertEqual(resp.status_code, 400)
-            self.assertEqual(resp.json()["error"]["type"], "InvalidIdentity")
-        self.assertEqual(calls["advanced"], [])
-
-    def test_get_reports_pool_readiness(self) -> None:
-        client, _ = self._client(run_id="run-a", version=5)
-        body = client.get(HOT_LOAD_PATH).json()
-        self.assertEqual(len(body["replicas"]), 1)
-        self.assertEqual(body["replicas"][0]["current_snapshot_identity"], "run-a/weight_v000005")
-        self.assertTrue(body["replicas"][0]["readiness"])
-
-    def test_catch_all_proxies(self) -> None:
-        client, calls = self._client()
-        resp = client.post("/v1/chat/completions", json={"model": "m"})
-        self.assertEqual(resp.json(), {"proxied": "v1/chat/completions"})
+    def test_catch_all_proxies_inference_and_404s_internal(self) -> None:
+        client, calls, _ = self._client()
+        self.assertEqual(client.post("/v1/chat/completions", json={}).status_code, 200)
+        self.assertEqual(client.post("/rpc_sync_from_bulletin_board", json={}).status_code, 404)
         self.assertEqual(calls["proxied"], ["v1/chat/completions"])
-
-    def test_proxy_allows_inference_routes(self) -> None:
-        client, calls = self._client()
-        for path in ("/v1/completions", "/v1/chat/completions", "/v1/models", "/generate"):
-            self.assertEqual(client.post(path, json={}).status_code, 200)
-        self.assertEqual(
-            calls["proxied"], ["v1/completions", "v1/chat/completions", "v1/models", "generate"]
-        )
-
-    def test_proxy_blocks_internal_routes_with_404(self) -> None:
-        # Reachable through the front door before the allowlist: sidecar control
-        # routes and SGLang engine routes. None must be proxied.
-        client, calls = self._client()
-        for path in (
-            "/rpc_sync_from_bulletin_board",
-            "/server_info",
-            "/get_weight_version",
-            "/update_weights_from_disk",
-            "/update_weights_from_ipc",
-            "/start_profile",
-            "/flush_cache",
-        ):
-            self.assertEqual(client.post(path, json={}).status_code, 404)
-        self.assertEqual(calls["proxied"], [])
 
     def test_auth_rejection_blocks_every_route(self) -> None:
         from fastapi.responses import JSONResponse
@@ -219,11 +286,8 @@ class FrontdoorAppTest(unittest.TestCase):
         def deny(_headers):
             return JSONResponse({"error": "unauthorized"}, status_code=401)
 
-        client, calls = self._client(authorize=deny)
-        self.assertEqual(
-            client.post(HOT_LOAD_PATH, json={"identity": "weight_v000009", "run_id": "run-a"}).status_code,
-            401,
-        )
+        client, calls, _ = self._client(authorize=deny)
+        self.assertEqual(client.post(HOT_LOAD_PATH, json={"identity": "x"}).status_code, 401)
         self.assertEqual(client.get(HOT_LOAD_PATH).status_code, 401)
         self.assertEqual(client.post("/v1/chat/completions", json={}).status_code, 401)
         self.assertEqual(calls["advanced"], [])

--- a/cookbook/standalone_rollouts/ledger.py
+++ b/cookbook/standalone_rollouts/ledger.py
@@ -1,0 +1,99 @@
+"""Identity ledger: opaque customer checkpoint identities -> stitch versions.
+
+The customer's hot-load API names checkpoints by an opaque ``<identity>`` and
+gives lineage only via ``incremental_snapshot_metadata.previous_snapshot_identity``.
+stitch's core is an integer-versioned monotonic log. The front door bridges the
+two: it is the single writer (under its advance lock) of this ledger, minting a
+monotonic version per newly-signalled identity and recording the parent identity
+so a version dir's index can carry ``base_version``.
+
+Because versions only ever increase, two identities never collide on a number
+and ``run_id`` is unnecessary. Re-signalling a known identity returns its
+existing version (idempotent — a retried POST is not a rewind). A delta whose
+parent is the immediately-preceding identity forms the contiguous chain the
+apply path replays; a delta against an older ancestor (training resume against
+the base) is recorded faithfully but is not yet replayable (the deferred
+fork-from-version case), so its non-contiguous base surfaces at apply time
+rather than being silently reordered here.
+
+Pure and persistence-free: :meth:`to_dict` / :meth:`from_dict` round-trip the
+state, and the front door writes it to the transport with a rename-free write.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from stitch.protocol import BASE_VERSION
+
+
+@dataclass(frozen=True)
+class LedgerEntry:
+    """One signalled checkpoint: the version minted for it and its parent
+    identity (``None`` for a full snapshot / base, which has no delta parent)."""
+
+    version: int
+    previous: str | None
+
+
+class IdentityLedger:
+    def __init__(self, entries: dict[str, LedgerEntry] | None = None) -> None:
+        self._by_identity: dict[str, LedgerEntry] = dict(entries or {})
+        self._by_version: dict[int, str] = {
+            entry.version: identity for identity, entry in self._by_identity.items()
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "IdentityLedger":
+        entries = {
+            str(identity): LedgerEntry(
+                version=int(record["version"]),
+                previous=(None if record.get("previous") is None else str(record["previous"])),
+            )
+            for identity, record in (data.get("entries") or {}).items()
+        }
+        return cls(entries)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entries": {
+                identity: {"version": entry.version, "previous": entry.previous}
+                for identity, entry in self._by_identity.items()
+            }
+        }
+
+    def version_for(self, identity: str) -> int | None:
+        entry = self._by_identity.get(identity)
+        return entry.version if entry is not None else None
+
+    def identity_for(self, version: int) -> str | None:
+        """Reverse lookup, for translating readiness back to the customer's
+        identity string and for resolving a version's on-disk upload dir."""
+        return self._by_version.get(int(version))
+
+    def base_version_for(self, identity: str) -> int:
+        """The version a checkpoint's delta builds on: its parent's version, or
+        ``BASE_VERSION`` when it is a full snapshot or the parent is unknown."""
+        entry = self._by_identity[identity]
+        if entry.previous is None:
+            return BASE_VERSION
+        parent = self._by_identity.get(entry.previous)
+        return parent.version if parent is not None else BASE_VERSION
+
+    def record(self, identity: str, previous: str | None) -> tuple[LedgerEntry, bool]:
+        """Mint a version for ``identity`` (or return its existing entry).
+
+        Returns ``(entry, is_new)``. A known identity is idempotent: its entry is
+        returned unchanged and ``is_new`` is False, so a retried signal never
+        moves the pointer. A new identity is minted the next monotonic version
+        (``BASE_VERSION`` for the first ever, else max+1) and records ``previous``.
+        """
+        existing = self._by_identity.get(identity)
+        if existing is not None:
+            return existing, False
+        version = BASE_VERSION if not self._by_version else max(self._by_version) + 1
+        entry = LedgerEntry(version=version, previous=previous)
+        self._by_identity[identity] = entry
+        self._by_version[version] = identity
+        return entry, True

--- a/cookbook/standalone_rollouts/ledger.py
+++ b/cookbook/standalone_rollouts/ledger.py
@@ -63,6 +63,14 @@ class IdentityLedger:
             }
         }
 
+    @property
+    def head_version(self) -> int | None:
+        """The highest minted version (the chain head), or None when empty. The
+        front door re-advances the pointer to the head even on an idempotent
+        re-signal, so a POST whose save landed but whose pointer write failed
+        converges on retry."""
+        return max(self._by_version) if self._by_version else None
+
     def version_for(self, identity: str) -> int | None:
         entry = self._by_identity.get(identity)
         return entry.version if entry is not None else None

--- a/cookbook/standalone_rollouts/ledger.py
+++ b/cookbook/standalone_rollouts/ledger.py
@@ -80,6 +80,11 @@ class IdentityLedger:
         identity string and for resolving a version's on-disk upload dir."""
         return self._by_version.get(int(version))
 
+    def items_by_version(self) -> list[tuple[int, str]]:
+        """``(version, identity)`` pairs in version order, for building the
+        sidecar's ``weight_vN`` -> identity-dir symlink view."""
+        return sorted(self._by_version.items())
+
     def base_version_for(self, identity: str) -> int:
         """The version a checkpoint's delta builds on: its parent's version, or
         ``BASE_VERSION`` when it is a full snapshot or the parent is unknown."""

--- a/cookbook/standalone_rollouts/ledger.py
+++ b/cookbook/standalone_rollouts/ledger.py
@@ -105,7 +105,17 @@ class IdentityLedger:
         existing = self._by_identity.get(identity)
         if existing is not None:
             return existing, False
-        version = BASE_VERSION if not self._by_version else max(self._by_version) + 1
+        if previous is None:
+            # A full snapshot is the base (version 0), whether the customer
+            # pre-uploaded and signalled it or the pool booted it from
+            # BASE_CHECKPOINT.
+            version = BASE_VERSION
+        else:
+            # A delta always mints a real version >= 1; v0 is reserved for the
+            # base, so a delta signalled before any base (its parent booted, not
+            # signalled) still becomes v1, not a phantom base that never applies.
+            deltas = [v for v in self._by_version if v > BASE_VERSION]
+            version = (max(deltas) + 1) if deltas else BASE_VERSION + 1
         entry = LedgerEntry(version=version, previous=previous)
         self._by_identity[identity] = entry
         self._by_version[version] = identity

--- a/cookbook/standalone_rollouts/ledger_test.py
+++ b/cookbook/standalone_rollouts/ledger_test.py
@@ -44,10 +44,13 @@ class RecordTest(unittest.TestCase):
         self.assertEqual(resume.version, 3)
         self.assertEqual(ledger.base_version_for("ckpt-resume"), 0)
 
-    def test_unknown_parent_falls_back_to_base_version(self) -> None:
+    def test_delta_before_any_base_mints_v1_not_v0(self) -> None:
+        # A delta whose parent was never signalled (the base booted from
+        # BASE_CHECKPOINT) still mints v1 and treats its base as v0, so it is
+        # applied as a delta rather than mistaken for the base and skipped.
         ledger = IdentityLedger()
         entry, _ = ledger.record("ckpt-orphan", previous="never-seen")
-        self.assertEqual(entry.version, 0)
+        self.assertEqual(entry.version, 1)
         self.assertEqual(ledger.base_version_for("ckpt-orphan"), 0)
 
 

--- a/cookbook/standalone_rollouts/ledger_test.py
+++ b/cookbook/standalone_rollouts/ledger_test.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import unittest
+
+from cookbook.standalone_rollouts.ledger import IdentityLedger, LedgerEntry
+
+
+class RecordTest(unittest.TestCase):
+    def test_first_identity_is_base_version(self) -> None:
+        ledger = IdentityLedger()
+        entry, is_new = ledger.record("ckpt-base", previous=None)
+        self.assertEqual((entry.version, entry.previous, is_new), (0, None, True))
+
+    def test_contiguous_deltas_mint_sequential_versions(self) -> None:
+        ledger = IdentityLedger()
+        ledger.record("ckpt-base", previous=None)
+        b, _ = ledger.record("ckpt-100", previous="ckpt-base")
+        c, _ = ledger.record("ckpt-200", previous="ckpt-100")
+        self.assertEqual((b.version, c.version), (1, 2))
+        # base_version tracks lineage -> a contiguous chain (base = version - 1).
+        self.assertEqual(ledger.base_version_for("ckpt-100"), 0)
+        self.assertEqual(ledger.base_version_for("ckpt-200"), 1)
+
+    def test_resignal_is_idempotent_and_does_not_mint(self) -> None:
+        ledger = IdentityLedger()
+        ledger.record("ckpt-base", previous=None)
+        first, is_new_1 = ledger.record("ckpt-100", previous="ckpt-base")
+        again, is_new_2 = ledger.record("ckpt-100", previous="ckpt-base")
+        self.assertTrue(is_new_1)
+        self.assertFalse(is_new_2)
+        self.assertEqual(first, again)
+        # No phantom version was minted for the duplicate.
+        self.assertIsNone(ledger.identity_for(2))
+
+    def test_resume_against_base_records_true_non_contiguous_lineage(self) -> None:
+        # A delta whose parent is the original base while the chain is at v2:
+        # version is still monotonic (v3), but base_version records the real
+        # parent (0), so the non-contiguity is visible to the apply path.
+        ledger = IdentityLedger()
+        ledger.record("ckpt-base", previous=None)
+        ledger.record("ckpt-100", previous="ckpt-base")
+        ledger.record("ckpt-200", previous="ckpt-100")
+        resume, _ = ledger.record("ckpt-resume", previous="ckpt-base")
+        self.assertEqual(resume.version, 3)
+        self.assertEqual(ledger.base_version_for("ckpt-resume"), 0)
+
+    def test_unknown_parent_falls_back_to_base_version(self) -> None:
+        ledger = IdentityLedger()
+        entry, _ = ledger.record("ckpt-orphan", previous="never-seen")
+        self.assertEqual(entry.version, 0)
+        self.assertEqual(ledger.base_version_for("ckpt-orphan"), 0)
+
+
+class LookupTest(unittest.TestCase):
+    def test_version_and_identity_round_trip(self) -> None:
+        ledger = IdentityLedger()
+        ledger.record("ckpt-base", previous=None)
+        ledger.record("ckpt-100", previous="ckpt-base")
+        self.assertEqual(ledger.version_for("ckpt-100"), 1)
+        self.assertEqual(ledger.identity_for(1), "ckpt-100")
+        self.assertIsNone(ledger.version_for("missing"))
+        self.assertIsNone(ledger.identity_for(99))
+
+
+class SerializationTest(unittest.TestCase):
+    def test_to_from_dict_round_trip(self) -> None:
+        ledger = IdentityLedger()
+        ledger.record("ckpt-base", previous=None)
+        ledger.record("ckpt-100", previous="ckpt-base")
+        restored = IdentityLedger.from_dict(ledger.to_dict())
+        self.assertEqual(restored.version_for("ckpt-100"), 1)
+        self.assertEqual(restored.identity_for(0), "ckpt-base")
+        self.assertEqual(restored.base_version_for("ckpt-100"), 0)
+        # Minting continues from the restored high-water mark.
+        entry, is_new = restored.record("ckpt-200", previous="ckpt-100")
+        self.assertEqual((entry.version, is_new), (2, True))
+
+    def test_from_empty_dict(self) -> None:
+        ledger = IdentityLedger.from_dict({})
+        self.assertIsNone(ledger.version_for("anything"))
+        entry, _ = ledger.record("ckpt-base", previous=None)
+        self.assertEqual(entry.version, 0)
+
+    def test_entries_expose_previous(self) -> None:
+        ledger = IdentityLedger({"a": LedgerEntry(version=0, previous=None)})
+        self.assertEqual(ledger.to_dict()["entries"]["a"], {"version": 0, "previous": None})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -29,6 +29,7 @@ from cookbook.standalone_rollouts.base_checkpoint import (
     resolve_base_checkpoint,
 )
 from stitch.bulletin import FilesystemBulletinBoard
+from stitch.protocol import plain_write_text
 from stitch.providers.modal import (
     discover_flash_targets,
     resolve_flash_gateway_url,
@@ -481,7 +482,11 @@ class FrontDoor:
                 f"gate and will not start open. Set it in the {exp.SHIM_SECRET_NAME} secret."
             )
 
+        import json
+
         board = FilesystemBulletinBoard(str(S3_TRANSPORT_MOUNT_PATH), layout="slime")
+        transport_root = Path(str(S3_TRANSPORT_MOUNT_PATH))
+        ledger_path = transport_root / "identities.json"
         gateway: dict[str, str | None] = {"url": None}
         clients: dict[str, httpx.AsyncClient] = {}
 
@@ -492,17 +497,40 @@ class FrontDoor:
                 clients["client"] = client
             return client
 
-        async def read_current_pointer() -> tuple[str | None, int]:
-            return board.read_latest()
+        async def load_ledger() -> dict:
+            def _read() -> dict:
+                try:
+                    return json.loads(ledger_path.read_text(encoding="utf-8"))
+                except FileNotFoundError:
+                    return {}
 
-        async def advance_to(run_id: str | None, version: int) -> None:
-            # Singleton writer: a single small write is one atomic S3 PutObject,
-            # so no rename dance is needed. The pointer is self-identifying
-            # (`<run_id>/weight_vN`), so a new run is a forward move (not a rewind)
-            # and there is no separate run pointer to flip. The monotonic/reset
-            # decision already ran in advance_latest_decision, so this writes the
-            # decided move through the same board the pool reconciles against.
-            board.write_latest(run_id, version)
+            return await asyncio.to_thread(_read)
+
+        async def save_ledger(data: dict) -> None:
+            # Rename-free write on the S3 mount (see plain_write_text); the front
+            # door is the singleton writer, serialized under the app's advance lock.
+            await asyncio.to_thread(
+                plain_write_text, ledger_path, json.dumps(data, sort_keys=True) + "\n"
+            )
+
+        async def normalize_index(identity: str, metadata: dict) -> None:
+            # Merge the disk-delta metadata block into the customer's uploaded
+            # index so the decoder can apply it, without asking the customer to
+            # produce a slime-shaped index. Raises FileNotFoundError if the upload
+            # has not landed (the front door turns that into a 409).
+            index_path = transport_root / identity / "model.safetensors.index.json"
+
+            def _rewrite() -> None:
+                index = json.loads(index_path.read_text(encoding="utf-8"))
+                index.setdefault("metadata", {}).update(metadata)
+                plain_write_text(index_path, json.dumps(index))
+
+            await asyncio.to_thread(_rewrite)
+
+        async def advance_to(version: int) -> None:
+            # Run-less pointer: write the bare weight_vN identity the pool pulls.
+            # One plain PutObject-style overwrite (see plain_write_text).
+            board.write_latest(None, version)
 
         async def list_server_infos() -> list[dict]:
             targets = await asyncio.to_thread(
@@ -545,7 +573,9 @@ class FrontDoor:
             )
 
         asgi_app = frontdoor_mod.create_frontdoor_app(
-            read_current_pointer=read_current_pointer,
+            load_ledger=load_ledger,
+            save_ledger=save_ledger,
+            normalize_index=normalize_index,
             advance_to=advance_to,
             list_server_infos=list_server_infos,
             proxy=proxy,

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -51,6 +51,9 @@ SGLANG_PORT = 8001
 MINUTES = 60
 SERVER_STARTUP_TIMEOUT = 35 * MINUTES
 LOCAL_CHECKPOINT_PATH = exp.LOCAL_CHECKPOINT_PATH
+# Host-local dir holding the weight_vN symlink view of the transport's
+# opaque-identity dirs (rebuilt from the front-door ledger before each sync).
+DELTA_VIEW_PATH = "/local-delta-view"
 S3_TRANSPORT_BUCKET_NAME = os.environ.get(
     "STITCH_SHIM_S3_BUCKET_NAME", exp.S3_TRANSPORT_BUCKET_NAME
 )
@@ -624,6 +627,10 @@ def _start_provider_sidecar(*, base_checkpoint_dir: str) -> subprocess.Popen:
         base_checkpoint_dir,
         "--commit-mode",
         exp.COMMIT_MODE,
+        # Customer uploads to opaque-identity dirs; resolve weight_vN through a
+        # host-local symlink view into the mount (see provider.build_manager).
+        "--delta-view-dir",
+        DELTA_VIEW_PATH,
     ]
     print("Starting provider sidecar:", " ".join(cmd))
     return subprocess.Popen(cmd, start_new_session=True)

--- a/cookbook/standalone_rollouts/provider.py
+++ b/cookbook/standalone_rollouts/provider.py
@@ -18,10 +18,15 @@ door (``modal_serve.py``), not here.
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import uuid
+from collections.abc import Callable
+from pathlib import Path
 
+from cookbook.standalone_rollouts.delta_view import rebuild_delta_view
+from cookbook.standalone_rollouts.ledger import IdentityLedger
 from stitch.bulletin import FilesystemBulletinBoard
 from stitch.engines.sglang import SGLangDiskDeltaAdapter
 from stitch.servers.sglang import create_app as create_sglang_app
@@ -41,11 +46,26 @@ def build_manager(
     commit_mode: CommitMode = "in_place",
     run_id: str | None = None,
     debug_requests: bool = False,
+    delta_view_dir: str | None = None,
 ) -> WeightSyncManager:
-    # The transport root is the object-store mount holding the flat
-    # weight_v{N}/ version dirs and the raw `latest` pointer (slime/customer
-    # layout). Deltas are read straight from the mount during apply.
-    board = FilesystemBulletinBoard(transport_root, layout="slime")
+    # The transport root is the object-store mount holding the version dirs and
+    # the raw `latest` pointer. Deltas are read straight from the mount.
+    #
+    # The customer uploads to opaque-identity dirs (`<transport>/<identity>/`),
+    # not weight_vN, so when delta_view_dir is set the board is rooted at a
+    # host-local weight_vN symlink view of the transport (rebuilt from the
+    # front-door ledger on every refresh), letting the unmodified decoder walk
+    # weight_vN while the bytes still come from the identity dirs on the mount.
+    # Without it (the internal slime harness / tests, which write weight_vN dirs
+    # directly) the board reads the transport as-is.
+    if delta_view_dir:
+        board = FilesystemBulletinBoard(
+            delta_view_dir,
+            layout="slime",
+            refresh=_delta_view_refresh(delta_view_dir, transport_root),
+        )
+    else:
+        board = FilesystemBulletinBoard(transport_root, layout="slime")
     engine = SGLangDiskDeltaAdapter(
         upstream_url=upstream_url,
         local_checkpoint_dir=local_checkpoint_dir,
@@ -58,6 +78,22 @@ def build_manager(
         commit_mode=commit_mode,
         debug_requests=debug_requests,
     )
+
+
+def _delta_view_refresh(view_dir: str, transport_root: str) -> Callable[[], None]:
+    """Board refresh callback: rebuild the host-local weight_vN view from the
+    front door's identity ledger on the transport, so the view tracks
+    newly-signalled versions before each sync reads/apply."""
+    ledger_path = Path(transport_root) / "identities.json"
+
+    def _refresh() -> None:
+        try:
+            data = json.loads(ledger_path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            data = {}
+        rebuild_delta_view(view_dir, transport_root, IdentityLedger.from_dict(data))
+
+    return _refresh
 
 
 def create_app(manager: WeightSyncManager, *, upstream_url: str, poll_interval: float = 5.0):
@@ -104,6 +140,13 @@ def main() -> None:
         default=float(os.environ.get("STITCH_SHIM_POLL_INTERVAL", "5.0")),
         help="Seconds between background reconciles against the `latest` pointer.",
     )
+    parser.add_argument(
+        "--delta-view-dir",
+        default=os.environ.get("STITCH_DELTA_VIEW_DIR"),
+        help="Host-local dir for the weight_vN symlink view of the transport's "
+        "opaque-identity dirs. Set for the customer layout; omit when version "
+        "dirs are already named weight_vN.",
+    )
     parser.add_argument("--run-id", default=os.environ.get("MODAL_TASK_ID") or uuid.uuid4().hex)
     parser.add_argument(
         "--debug-requests",
@@ -130,6 +173,7 @@ def main() -> None:
         commit_mode=args.commit_mode,
         run_id=args.run_id,
         debug_requests=args.debug_requests,
+        delta_view_dir=args.delta_view_dir,
     )
     uvicorn.run(
         create_app(manager, upstream_url=args.upstream_url, poll_interval=args.poll_interval),

--- a/cookbook/standalone_rollouts/simulator_test.py
+++ b/cookbook/standalone_rollouts/simulator_test.py
@@ -1,0 +1,203 @@
+"""In-process end-to-end simulator for the standalone rollouts abstraction layer.
+
+Wires the REAL front door (ledger + normalization) to N real WeightSyncManagers
+(delta-view boards + fake engines) over a tmpdir "transport", with no Modal and
+no GPU. It grounds the contract the ledger/normalization/symlink-view commits
+built: a customer who uploads a plain HF index (metadata = {"total_size": ...})
+and signals an opaque identity — the exact shape that bricked the pool per
+battle-plan F2 — now converges, because the front door normalizes the index on
+POST and the sidecar resolves the identity dir through the weight_vN view.
+
+The fake engine records applied versions without decoding real delta bytes (the
+codec is the pinned slime fork's concern); everything else — opaque identity ->
+version, index normalization, pointer advance, view rebuild, manifest parse,
+apply gate, readiness translation — is the real code path.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import httpx
+
+from cookbook.standalone_rollouts.frontdoor import HOT_LOAD_PATH, create_frontdoor_app
+from cookbook.standalone_rollouts.provider import _delta_view_refresh
+from stitch.bulletin import FilesystemBulletinBoard
+from stitch.protocol import weight_identity
+from stitch.sync import WeightSyncManager
+
+
+class _FakeEngine:
+    backend = "fake"
+
+    def __init__(self) -> None:
+        self.applies: list[int] = []
+
+    async def flush_cache(self) -> None: ...
+
+    async def apply_manifest(self, manifest, version_path) -> None:
+        # The manifest was parsed for real by from_slime_index off the normalized
+        # index reached through the weight_vN view — that is what this grounds.
+        self.applies.append(manifest.version)
+
+    async def pause_generation(self) -> None: ...
+
+    async def continue_generation(self) -> None: ...
+
+
+def _upload_plain_hf_checkpoint(transport: Path, identity: str) -> None:
+    """A vanilla HF checkpoint dir: a weight_map and a bare total_size metadata,
+    with NO slime version/base_version/delta_encoding block (F2's failing shape)."""
+    d = transport / identity
+    d.mkdir(parents=True)
+    (d / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {"total_size": 123},
+                "weight_map": {"w0": "model-00001-of-00001.safetensors"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class SimulatorTest(unittest.IsolatedAsyncioTestCase):
+    async def _stack(self, tmp: str, *, n_replicas: int = 2):
+        transport = Path(tmp) / "transport"
+        transport.mkdir()
+
+        managers: list[WeightSyncManager] = []
+        engines: list[_FakeEngine] = []
+        for i in range(n_replicas):
+            view_dir = str(Path(tmp) / f"view{i}")
+            board = FilesystemBulletinBoard(
+                view_dir, layout="slime", refresh=_delta_view_refresh(view_dir, str(transport))
+            )
+            engine = _FakeEngine()
+            managers.append(
+                WeightSyncManager(board=board, engine=engine, commit_mode="in_place")
+            )
+            engines.append(engine)
+
+        async def load_ledger():
+            p = transport / "identities.json"
+            return json.loads(p.read_text(encoding="utf-8")) if p.exists() else {}
+
+        async def save_ledger(data):
+            (transport / "identities.json").write_text(json.dumps(data), encoding="utf-8")
+
+        async def normalize_index(identity, metadata):
+            p = transport / identity / "model.safetensors.index.json"
+            index = json.loads(p.read_text(encoding="utf-8"))  # FileNotFoundError -> 409
+            index.setdefault("metadata", {}).update(metadata)
+            p.write_text(json.dumps(index), encoding="utf-8")
+
+        async def advance_to(version):
+            (transport / "latest").write_text(weight_identity(version), encoding="utf-8")
+
+        async def list_server_infos():
+            return [await m.server_info() for m in managers]
+
+        async def wake(version):
+            pass  # the sim drives reconciliation explicitly for determinism
+
+        async def proxy(request, path):
+            from fastapi.responses import JSONResponse
+
+            return JSONResponse({})
+
+        app = create_frontdoor_app(
+            load_ledger=load_ledger,
+            save_ledger=save_ledger,
+            normalize_index=normalize_index,
+            advance_to=advance_to,
+            list_server_infos=list_server_infos,
+            proxy=proxy,
+            wake=wake,
+        )
+        client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://fd")
+        return transport, managers, engines, client
+
+    async def test_vanilla_hf_index_converges_after_frontdoor_normalization(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            transport, managers, engines, client = await self._stack(tmp)
+            async with client:
+                # Base: customer pre-uploaded a full snapshot and signals it.
+                _upload_plain_hf_checkpoint(transport, "base-ckpt")
+                r = await client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
+                self.assertEqual(r.status_code, 200)
+                self.assertEqual(r.json()["version"], 0)
+
+                # Delta: a PLAIN HF index (F2's brick shape) + opaque identity.
+                _upload_plain_hf_checkpoint(transport, "ckpt-100")
+                r = await client.post(
+                    HOT_LOAD_PATH,
+                    json={
+                        "identity": "ckpt-100",
+                        "incremental_snapshot_metadata": {
+                            "previous_snapshot_identity": "base-ckpt",
+                            "compression_format": "zstd",
+                            "checksum_format": "adler32",
+                        },
+                    },
+                )
+                self.assertEqual(r.status_code, 200)
+                self.assertEqual(r.json()["version"], 1)
+
+                # The front door normalized the plain index in place: it now carries
+                # the slime metadata block the decoder needs (this is the F2 fix).
+                normalized = json.loads(
+                    (transport / "ckpt-100" / "model.safetensors.index.json").read_text()
+                )["metadata"]
+                self.assertEqual(normalized["version"], "000001")
+                self.assertEqual(normalized["base_version"], "000000")
+                self.assertEqual(normalized["delta_encoding"], "xor")
+                self.assertEqual(normalized["total_size"], 123)  # original field preserved
+
+                # Every replica converges to v1 (manifest parsed for real via the view).
+                for mgr in managers:
+                    await mgr.sync_to()
+                for mgr, engine in zip(managers, engines):
+                    self.assertEqual(mgr.current_version, 1)
+                    self.assertEqual(engine.applies, [1])
+
+                # Readiness reports the customer's opaque identity, so their
+                # equality match (current_snapshot_identity == "ckpt-100") works.
+                body = (await client.get(HOT_LOAD_PATH)).json()
+                self.assertEqual(len(body["replicas"]), 2)
+                for replica in body["replicas"]:
+                    self.assertTrue(replica["readiness"])
+                    self.assertEqual(replica["current_snapshot_identity"], "ckpt-100")
+
+    async def test_signal_before_upload_is_409_and_pool_stays_put(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            transport, managers, engines, client = await self._stack(tmp)
+            async with client:
+                _upload_plain_hf_checkpoint(transport, "base-ckpt")
+                await client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
+                # Signal a delta whose dir has NOT been uploaded yet.
+                r = await client.post(
+                    HOT_LOAD_PATH,
+                    json={
+                        "identity": "ckpt-100",
+                        "incremental_snapshot_metadata": {
+                            "previous_snapshot_identity": "base-ckpt",
+                            "compression_format": "zstd",
+                            "checksum_format": "adler32",
+                        },
+                    },
+                )
+                self.assertEqual(r.status_code, 409)
+                # Pointer never advanced past the base; ledger has no ckpt-100.
+                ledger = json.loads((transport / "identities.json").read_text())
+                self.assertNotIn("ckpt-100", ledger["entries"])
+                for mgr in managers:
+                    await mgr.sync_to()
+                    self.assertEqual(mgr.current_version, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cookbook/standalone_rollouts/slime/hooks.py
+++ b/cookbook/standalone_rollouts/slime/hooks.py
@@ -19,7 +19,7 @@ import shutil
 import time
 import urllib.error
 import urllib.request
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -46,11 +46,6 @@ class ShimConfig:
     readiness_threshold: float = 1.0
     poll_timeout_seconds: float = 30 * 60
     poll_interval_seconds: float = 5.0
-    # Run id: partitions the transport (`<run_id>/weight_v{N}/`) and is folded
-    # into the single self-identifying pointer, so a fresh run's chain is isolated
-    # and a finished run's pointer can't fast-forward a new run's cold start.
-    # None = the run-less customer flat layout.
-    run_id: str | None = None
 
     @classmethod
     def from_env(cls, args: Any | None = None) -> "ShimConfig":
@@ -123,10 +118,6 @@ class ShimConfig:
                     default="5",
                 )
             ),
-            # run_id is NOT read here: a per-launch value can't ride an --api-shim-*
-            # arg (dropped by slime's parser) or a late env var (doesn't reach the
-            # Ray actor this hook runs in). announce_and_wait derives it from the
-            # version dir slime wrote (update_weight_disk_dir = <local>/<run_id>).
         )
 
     def identity_for_version(self, version: int) -> str:
@@ -138,16 +129,11 @@ class ShimConfig:
         return self.identity_for_version(int(version) - 1)
 
     def transport_path_for_identity(self, identity: str) -> Path:
+        # Flat customer layout: <transport>/<identity>/. The front door's identity
+        # ledger orders signals monotonically, so no run partition is needed.
         if self.transport_root is None:
             raise RuntimeError("transport_root is not configured (api_shim_transport_root)")
-        base = self.transport_root / self.run_id if self.run_id else self.transport_root
-        return base / identity
-
-    def readiness_identity(self, identity: str) -> str:
-        """The run-scoped snapshot identity the pool reports for readiness matching
-        (``<run_id>/weight_vN``), so a replica on a finished run's same-numbered
-        version isn't miscounted as ready for this run."""
-        return f"{self.run_id}/{identity}" if self.run_id else identity
+        return self.transport_root / identity
 
 
 def announce_and_wait(args: Any, version_dir: str, rollout_engines: list[Any]) -> None:
@@ -173,62 +159,25 @@ def announce_and_wait(args: Any, version_dir: str, rollout_engines: list[Any]) -
         # announce yet. Only weight_v{N} dirs are hot-loaded.
         return
     cfg = ShimConfig.from_env(args)
-    # The run id is the partition dir slime wrote into
-    # (update_weight_disk_dir = <local>/<run_id>): derive it from the version dir
-    # rather than an env var or --api-shim-* arg, neither of which crosses into the
-    # Ray training actor this hook runs in. update_weight_disk_dir is a known slime
-    # arg, so the partition reliably reaches here.
-    run_id = Path(version_dir).parent.name or None
-    if run_id:
-        cfg = replace(cfg, run_id=run_id)
     # slime's atomic-rename writer can't target the S3 mount (ENOSYS), so the
     # version dir lives on local disk; copy it to the transport (PutObject) the
-    # provider pool reads before signalling the hot-load.
+    # provider pool reads before signalling the hot-load. The transport is flat
+    # (<transport>/<identity>/); the front door's ledger supplies ordering.
     _copy_version_to_transport(Path(version_dir), cfg.transport_path_for_identity(identity))
     _post_hot_load(
         cfg,
         identity=identity,
         previous_identity=cfg.previous_identity_for_version(version),
     )
-    target = cfg.readiness_identity(identity)
+    # Readiness matches the bare signalled identity: the front door translates
+    # each replica's version back to the customer identity we POSTed.
     state = wait_until_ready(cfg, identity)
     logger.info(
         "Provider hot-load ready for %s: %s/%s replicas",
-        target,
-        state.ready_count(target_snapshot_identity=target),
+        identity,
+        state.ready_count(target_snapshot_identity=identity),
         len(state.replicas),
     )
-
-
-def announce_claim(args: Any, *, run_id: str) -> None:
-    """Trainer launch hook (rank 0): claim the rollout pool for this run via the
-    front door, the standalone counterpart to :func:`cookbook.bulletin_hooks.claim_pool`.
-
-    POST the empty pointer (``weight_v000000``) under a fresh ``run_id`` so the
-    front door's cross-run :func:`decide_pointer_move` resets ``latest`` to base
-    *before* the first delta — every replica (cold, or warm on a finished run)
-    reconciles to base up front instead of inferring the reset from the first
-    publish's run mismatch. Best-effort and non-blocking: the pool may be scaled
-    to zero at launch, and the first :func:`announce_and_wait` already blocks on
-    readiness, so a transient claim failure costs only the early reset, not
-    correctness. ``run_id`` must be fresh per launch (the epoch/fence token).
-    """
-    if _distributed_rank() not in (None, 0):
-        return
-    cfg = replace(ShimConfig.from_env(args), run_id=run_id)
-    try:
-        _post_hot_load(
-            cfg,
-            identity=weight_identity(0),
-            previous_identity=cfg.base_snapshot_identity,
-        )
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "Best-effort pool claim failed for run %r; the first publish's "
-            "cross-run reset will still establish base",
-            run_id,
-            exc_info=True,
-        )
 
 
 def rollout_request_weight_version_hook(
@@ -286,10 +235,10 @@ def rollout_request_weight_version_hook(
 
 
 def wait_until_ready(cfg: ShimConfig, identity: str) -> RolloutPoolState:
-    # The pool reports current_snapshot_identity run-scoped (`<run_id>/weight_vN`),
-    # so match against the same composite — otherwise a replica still serving a
-    # finished run's same-numbered version would falsely count as ready.
-    target = cfg.readiness_identity(identity)
+    # The front door reports current_snapshot_identity as the bare customer
+    # identity we signalled (translated from the replica's version via its
+    # ledger), so match against the identity directly.
+    target = identity
     deadline = time.monotonic() + cfg.poll_timeout_seconds
     while True:
         state = _get_hot_load_state(cfg)
@@ -316,9 +265,6 @@ def wait_until_ready(cfg: ShimConfig, identity: str) -> RolloutPoolState:
 def _post_hot_load(cfg: ShimConfig, *, identity: str, previous_identity: str) -> None:
     payload = {
         "identity": identity,
-        # The run id tells the front door which (possibly new) run this belongs to;
-        # a new run restarts the version space instead of being a rewind.
-        "run_id": cfg.run_id,
         "incremental_snapshot_metadata": {
             "previous_snapshot_identity": previous_identity,
             "compression_format": cfg.compression_format,

--- a/cookbook/standalone_rollouts/slime/hooks_test.py
+++ b/cookbook/standalone_rollouts/slime/hooks_test.py
@@ -21,38 +21,31 @@ class ShimConfigTest(unittest.TestCase):
         # The disk-delta branch ships zstd compression + xxh3-128 checksums.
         self.assertEqual(cfg.compression_format, "zstd")
         self.assertEqual(cfg.checksum_format, "xxh3-128")
-        self.assertIsNone(cfg.run_id)  # run-less by default
 
-    def test_run_id_scopes_transport_path_and_readiness(self) -> None:
-        cfg = hooks.ShimConfig(api_base_url="http://p", transport_root=Path("/t"), run_id="run-a")
-        self.assertEqual(cfg.transport_path_for_identity("weight_v000003"), Path("/t/run-a/weight_v000003"))
-        self.assertEqual(cfg.readiness_identity("weight_v000003"), "run-a/weight_v000003")
-        runless = hooks.ShimConfig(api_base_url="http://p", transport_root=Path("/t"))
-        self.assertEqual(runless.transport_path_for_identity("weight_v000003"), Path("/t/weight_v000003"))
-        self.assertEqual(runless.readiness_identity("weight_v000003"), "weight_v000003")
+    def test_transport_path_is_flat(self) -> None:
+        cfg = hooks.ShimConfig(api_base_url="http://p", transport_root=Path("/t"))
+        self.assertEqual(cfg.transport_path_for_identity("weight_v000003"), Path("/t/weight_v000003"))
 
 
 class AnnounceAndWaitTest(unittest.TestCase):
-    def test_copies_to_run_partition_then_announces_on_rank_zero(self) -> None:
+    def test_copies_flat_then_announces_and_matches_bare_identity(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            # slime writes to update_weight_disk_dir = <local>/<run_id>, so the run
-            # id is the version dir's parent — announce_and_wait derives it there.
-            version_dir = root / "local" / "run-a" / "weight_v000003"
+            version_dir = root / "local" / "weight_v000003"
             version_dir.mkdir(parents=True)
             (version_dir / "model-00000-of-00001.safetensors").write_bytes(b"delta")
             (version_dir / "model.safetensors.index.json").write_text("{}", encoding="utf-8")
             transport = root / "transport"
 
-            posted: list[tuple[str | None, str, str]] = []
+            posted: list[tuple[str, str]] = []
 
             def fake_post(cfg, *, identity, previous_identity) -> None:
-                posted.append((cfg.run_id, identity, previous_identity))
+                posted.append((identity, previous_identity))
 
-            # The pool reports the run-scoped identity; readiness must match it.
+            # The front door reports the bare customer identity; readiness matches it.
             ready = RolloutPoolState(
                 replicas=[
-                    RolloutReplicaState(readiness=True, current_snapshot_identity="run-a/weight_v000003")
+                    RolloutReplicaState(readiness=True, current_snapshot_identity="weight_v000003")
                 ]
             )
             args = Namespace(api_shim_base_url="http://provider", api_shim_transport_root=str(transport))
@@ -61,11 +54,10 @@ class AnnounceAndWaitTest(unittest.TestCase):
             ), mock.patch.object(hooks, "_get_hot_load_state", return_value=ready):
                 hooks.announce_and_wait(args, str(version_dir), [])
 
-            # Copied under the run partition (not the flat root), then announced
-            # with the derived run id (v2 as predecessor).
-            self.assertTrue((transport / "run-a" / "weight_v000003" / "model.safetensors.index.json").exists())
-            self.assertFalse((transport / "weight_v000003").exists())
-            self.assertEqual(posted, [("run-a", "weight_v000003", "weight_v000002")])
+            # Copied to the flat transport path and announced with the bare
+            # identity and its predecessor (no run partition, no run_id).
+            self.assertTrue((transport / "weight_v000003" / "model.safetensors.index.json").exists())
+            self.assertEqual(posted, [("weight_v000003", "weight_v000002")])
 
     def test_is_noop_off_rank_zero(self) -> None:
         posted: list[int] = []
@@ -87,46 +79,6 @@ class AnnounceAndWaitTest(unittest.TestCase):
             # weight_v{N} dir — it must be a no-op, not an error.
             hooks.announce_and_wait(args, "/mnt/stitch-s3-transport", [])
         self.assertEqual(posted, [])
-
-
-class AnnounceClaimTest(unittest.TestCase):
-    def test_posts_base_pointer_under_fresh_run_on_rank_zero(self) -> None:
-        # Claim-at-launch parity with bulletin_hooks.claim_pool: POST the empty
-        # pointer (weight_v000000) under the fresh run id so the front door resets
-        # latest to base before the first delta.
-        posted: list[tuple[str | None, str, str]] = []
-
-        def fake_post(cfg, *, identity, previous_identity) -> None:
-            posted.append((cfg.run_id, identity, previous_identity))
-
-        args = Namespace(api_shim_base_url="http://provider")
-        with mock.patch.object(hooks, "_distributed_rank", return_value=0), mock.patch.object(
-            hooks, "_post_hot_load", fake_post
-        ):
-            hooks.announce_claim(args, run_id="run-a")
-        self.assertEqual(posted, [("run-a", "weight_v000000", "base")])
-
-    def test_is_noop_off_rank_zero(self) -> None:
-        posted: list[int] = []
-        args = Namespace(api_shim_base_url="http://provider")
-        with mock.patch.object(hooks, "_distributed_rank", return_value=1), mock.patch.object(
-            hooks, "_post_hot_load", lambda *a, **k: posted.append(1)
-        ):
-            hooks.announce_claim(args, run_id="run-a")
-        self.assertEqual(posted, [])
-
-    def test_swallows_claim_failure(self) -> None:
-        # Best-effort: a transient claim POST failure must not kill the launch
-        # (the first publish's cross-run reset still establishes base).
-        args = Namespace(api_shim_base_url="http://provider")
-
-        def boom(*a, **k) -> None:
-            raise RuntimeError("front door down")
-
-        with mock.patch.object(hooks, "_distributed_rank", return_value=0), mock.patch.object(
-            hooks, "_post_hot_load", boom
-        ):
-            hooks.announce_claim(args, run_id="run-a")  # must not raise
 
 
 class RolloutRequestHookTest(unittest.TestCase):

--- a/cookbook/standalone_rollouts/slime/modal_train.py
+++ b/cookbook/standalone_rollouts/slime/modal_train.py
@@ -11,7 +11,6 @@ import importlib
 import os
 import subprocess
 import tempfile
-import uuid
 from pathlib import Path
 
 import modal
@@ -186,23 +185,16 @@ class Trainer:
 
         cfg.rollout_endpoint_url = provider_url
         cfg.api_shim_base_url = provider_url
-        # Fresh run id per launch, carried on update_weight_disk_dir — a *known*
-        # slime arg, so it reaches the publish hook running in the Ray training
-        # actor. (A per-launch env var doesn't: Ray workers start in @modal.enter()
-        # before train() runs, so they don't inherit this env; and an unknown
-        # --api-shim-run-id arg is dropped by slime's parser.) slime writes this
-        # run's chain to <local>/<run_id>/weight_v{N}/, and announce_and_wait
-        # derives the run id from that dir to scope the S3 transport + pointer.
-        run_id = uuid.uuid4().hex[:12]
-        cfg.update_weight_disk_dir = f"{cfg.update_weight_disk_dir}/{run_id}"
         cfg.custom_config_path = _custom_config(
             cfg, rollout_num_engines=getattr(run, "ROLLOUT_NUM_ENGINES", 1)
         )
-        # Claim the pool for this fresh run before any delta: reset `latest` to
-        # base via the front door so replicas reconcile to base up front instead
-        # of inferring the reset from the first publish (mirrors the bulletin
-        # path's explicit-claim model).
-        hooks.announce_claim(cfg, run_id=run_id)
+        # No run_id / claim: the customer contract has no run concept, and the
+        # front door's identity ledger orders signals monotonically. slime
+        # publishes to a flat local dir and announce_and_wait copies each
+        # weight_v{N}/ to <transport>/weight_v{N}/. NOTE: a fresh launch reuses
+        # the same identities, so re-running against a non-empty transport prefix
+        # requires a clean prefix (multi-run reset is deferred, matching the
+        # deferred fork-from-base story).
         helpers.prepare_slime_config(cfg, tempfile.mkdtemp())
         cmd = helpers.build_train_cmd(cfg, SLIME_ROOT)
 


### PR DESCRIPTION
## Summary

This PR refactors the standalone rollout provider's hot-load API to bridge the customer's opaque checkpoint identity model with the internal integer-versioned monotonic log. The front door now maintains an identity ledger that maps customer-provided identities to stitch versions, normalizes customer-provided index metadata, and translates readiness reports back to customer identities.

## Key Changes

**Identity Ledger System**
- Added `IdentityLedger` class (`ledger.py`) to map opaque customer identities to monotonic versions
- Ledger is the single source of truth for identity→version mapping and lineage tracking
- Supports idempotent re-signalling (same identity returns existing version, not a new one)
- Records parent identity for delta lineage, enabling `base_version` calculation

**Front Door Refactoring**
- Replaced `advance_latest_decision()` with simpler identity validation and ledger-based versioning
- Added `is_valid_identity()` to validate customer identities (non-empty, bounded, no path separators or control chars)
- Added `delta_index_metadata()` to normalize customer POST metadata into the format the disk-delta decoder expects
- Added `is_customer_inference_route()` to implement an allowlist of inference routes (v1/*, generate) while blocking control routes
- Updated `pool_state_from_server_infos()` to accept a ledger and translate replica versions back to customer identities for readiness matching
- Refactored route handlers to use ledger-based versioning instead of run-id partitioning

**Supporting Infrastructure**
- Added `delta_view.py` to build a host-local `weight_vN` symlink view of customer's identity-named upload directories
- Added `base_checkpoint.py` to resolve base checkpoint specs (HF repo id or absolute path)
- Added `auth.py` for authorization policy (fail-closed when API key is unset)
- Updated `provider.py` to support delta view rebuilding and ledger persistence

**Test Coverage**
- Added comprehensive tests for identity validation, ledger operations, delta metadata normalization
- Added `simulator_test.py` for end-to-end testing with real ledger/normalization against fake engines
- Updated existing tests to use ledger-based versioning instead of run-id partitioning

**Protocol Improvements**
- Hardened `parse_weight_identity()` to reject pathological inputs (unicode numerals, over-long digit strings)
- Updated bulletin board to use `plain_write_text` instead of `atomic_write_text` for pointer writes

## Notable Implementation Details

- The ledger is persistence-free (pure `to_dict`/`from_dict`), with the front door responsible for load/save via injected I/O
- Customer identities are opaque strings that become S3 path components and ledger keys, so validation is strict
- Delta view symlinks live on ephemeral disk but resolve through to S3 mounts transparently
- Readiness translation uses the ledger to convert internal versions back to customer identities, enabling proper equality matching
- Authorization is fail-closed: missing API key rejects every request rather than serving an open endpoint

https://claude.ai/code/session_01GnEES5LVJpCiATG6w16QTU