### PR TITLE
docs(AGENTS): add session protocol from July session retrospectives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,19 @@ Use Google-style testing, i.e. test `src/stitch/foo.py` with `src/stitch/foo_tes
 If jj is available, use that instead of git for version control.
 
 Code legibility is highly valued, both for humans and future agents. Throughout the session, ensure that you are maintaining status quo or improving the legibility of the codebase.
+
+## Session protocol (hard-won; do not skip)
+
+Grounding:
+- Reproduce a defect (temp Modal probe or failing test) before fixing it. Never commit a fix whose premise is only code-reading or a subagent audit claim. Grounding first tends to produce *simpler* fixes.
+- Label every finding by confidence: confirmed-by-probe / code-read inference / hypothesis. Subagent audit output is a lead to verify, not a fact.
+- Follow the customer contract exactly; do not staple in assumptions beyond it or force changes onto customer-side code.
+
+Modal:
+- Preflight before any Modal work: confirm auth (`modal profile current`) and the target environment; pass `-e <env>` explicitly on every modal command, monitors included.
+- Before an expensive GPU launch, run a cheap fail-fast check (CPU-only arg-parse/dry-run inside the image). Bundle image-build sanity checks into one probe; don't discover gotchas one rebuild at a time.
+- Watch loops must assert positive progress (app exists, log lines grow) and must not redirect stderr to /dev/null — empty output is a failure signal, not "still booting". Smoke-test the monitor command manually once before trusting it. Long-running probes should print a machine-readable verdict line.
+
+Verification:
+- `uv run pytest` before every commit.
+- A Modal-touching change is not done until exercised in Modal.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,6 @@ Code legibility is highly valued, both for humans and future agents. Throughout 
 Grounding:
 - Reproduce a defect (temp Modal probe or failing test) before fixing it. Never commit a fix whose premise is only code-reading or a subagent audit claim. Grounding first tends to produce *simpler* fixes.
 - Label every finding by confidence: confirmed-by-probe / code-read inference / hypothesis. Subagent audit output is a lead to verify, not a fact.
-- Follow the customer contract exactly; do not staple in assumptions beyond it or force changes onto customer-side code.
 
 Modal:
 - Preflight before any Modal work: confirm auth (`modal profile current`) and the target environment; pass `-e <env>` explicitly on every modal command, monitors included.


### PR DESCRIPTION
Adds a compact session protocol to AGENTS.md encoding the recurring failure modes found by reviewing the Jul 10–11 agent sessions:

- **Grounding**: reproduce defects (probe or failing test) before fixing; confidence-label findings; treat subagent audit output as leads, not facts.
- **Modal**: preflight auth + explicit `-e <env>` on every command; cheap fail-fast dry-runs before expensive GPU launches; monitors must assert positive progress and never swallow stderr.
- **Verification**: pytest before every commit; Modal-touching changes aren't done until exercised in Modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cLo35FK1Rf18kj5v5bQuq