### PR TITLE
standalone_rollouts: one-base serving + front-door hardening

### DIFF
--- a/cookbook/standalone_rollouts/auth.py
+++ b/cookbook/standalone_rollouts/auth.py
@@ -1,0 +1,38 @@
+"""Front-door authorization policy.
+
+Pure, Modal-free so it is unit-testable; ``modal_serve.py`` supplies the env
+values and turns a rejection into a FastAPI response. The Modal server is
+deployed ``unauthenticated=True`` (auth is enforced in-app), so this check is the
+*only* gate in front of the hot-load API and the inference proxy.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def authorize(
+    headers: Mapping[str, str],
+    *,
+    api_key: str | None,
+    provider_model: str | None,
+    provider_deployment: str | None,
+) -> tuple[int, str] | None:
+    """Return ``(status, message)`` to reject a request, or ``None`` to allow it.
+
+    The API key is mandatory. When it is unset the front door rejects *every*
+    request (fail closed) instead of serving an open public endpoint — a missing
+    or mis-named secret key must not silently disable the only auth gate.
+    Provider-Model / Provider-Deployment are optional secondary checks, enforced
+    only when configured. Header lookups are case-insensitive when ``headers`` is
+    a Starlette ``Headers`` (the production caller); tests pass lowercase keys.
+    """
+    if not api_key:
+        return (503, "provider auth is not configured")
+    if headers.get("authorization") != f"Bearer {api_key}":
+        return (401, "unauthorized")
+    if provider_model and headers.get("provider-model") != provider_model:
+        return (400, "Provider-Model header does not match this deployment")
+    if provider_deployment and headers.get("provider-deployment") != provider_deployment:
+        return (400, "Provider-Deployment header does not match this deployment")
+    return None

--- a/cookbook/standalone_rollouts/auth_test.py
+++ b/cookbook/standalone_rollouts/auth_test.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import unittest
+
+from cookbook.standalone_rollouts.auth import authorize
+
+
+GOOD = {"authorization": "Bearer secret"}
+
+
+class AuthorizeTest(unittest.TestCase):
+    def test_unset_api_key_fails_closed_for_every_request(self) -> None:
+        # The Modal server is unauthenticated; a missing key must reject, not
+        # skip the check and serve an open endpoint.
+        for headers in ({}, GOOD, {"authorization": "Bearer anything"}):
+            rejection = authorize(
+                headers, api_key=None, provider_model=None, provider_deployment=None
+            )
+            self.assertIsNotNone(rejection)
+            self.assertEqual(rejection[0], 503)
+
+    def test_correct_bearer_is_allowed(self) -> None:
+        self.assertIsNone(
+            authorize(GOOD, api_key="secret", provider_model=None, provider_deployment=None)
+        )
+
+    def test_missing_or_wrong_bearer_is_401(self) -> None:
+        for headers in ({}, {"authorization": "Bearer wrong"}, {"authorization": "secret"}):
+            rejection = authorize(
+                headers, api_key="secret", provider_model=None, provider_deployment=None
+            )
+            self.assertEqual(rejection, (401, "unauthorized"))
+
+    def test_provider_model_enforced_only_when_configured(self) -> None:
+        # Not configured -> not checked.
+        self.assertIsNone(
+            authorize(GOOD, api_key="secret", provider_model=None, provider_deployment=None)
+        )
+        # Configured + mismatch -> 400.
+        rejection = authorize(
+            GOOD, api_key="secret", provider_model="moonlight", provider_deployment=None
+        )
+        self.assertEqual(rejection[0], 400)
+        # Configured + match -> allowed.
+        self.assertIsNone(
+            authorize(
+                {**GOOD, "provider-model": "moonlight"},
+                api_key="secret",
+                provider_model="moonlight",
+                provider_deployment=None,
+            )
+        )
+
+    def test_provider_deployment_enforced_only_when_configured(self) -> None:
+        rejection = authorize(
+            GOOD, api_key="secret", provider_model=None, provider_deployment="rollout-prod"
+        )
+        self.assertEqual(rejection[0], 400)
+        self.assertIsNone(
+            authorize(
+                {**GOOD, "provider-deployment": "rollout-prod"},
+                api_key="secret",
+                provider_model=None,
+                provider_deployment="rollout-prod",
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cookbook/standalone_rollouts/base_checkpoint.py
+++ b/cookbook/standalone_rollouts/base_checkpoint.py
@@ -1,0 +1,38 @@
+"""Resolve a base-checkpoint spec to a local directory.
+
+The standalone provider boots the engine from, and seeds every delta onto, one
+base checkpoint the deployer names. The spec is either an HF repo id resolved
+from the local hub cache (a public/cached base model) or an absolute directory
+(an S3 CloudBucketMount, a prep volume, or an already-resolved cache snapshot).
+Both forms are just a canonical HF-readable checkpoint dir; which one a customer
+uses is their choice, so the provider assumes nothing about the base beyond that
+it loads and that its tensors match the deltas built against it.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+
+def is_hf_repo_id(spec: str) -> bool:
+    """True when ``spec`` is an HF repo id to resolve from the local cache, False
+    when it is an explicit local directory. Anything that is not an absolute path
+    is treated as a repo id, so the check does not depend on which volumes/mounts
+    happen to be attached to the caller (the pool mounts the S3 base; the
+    downloader function does not)."""
+    return not os.path.isabs(spec)
+
+
+def resolve_base_checkpoint(
+    spec: str, *, snapshot_download: Callable[..., str]
+) -> str:
+    """Return the local directory the engine boots from and deltas seed onto.
+
+    An absolute-path spec is that directory as-is; a repo-id spec is resolved
+    from the local hub cache (``local_files_only=True`` — the cache is prewarmed
+    by ``download_model``, so no network fetch happens on the serving path).
+    """
+    if is_hf_repo_id(spec):
+        return snapshot_download(spec, local_files_only=True)
+    return spec

--- a/cookbook/standalone_rollouts/base_checkpoint_test.py
+++ b/cookbook/standalone_rollouts/base_checkpoint_test.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import unittest
+
+from cookbook.standalone_rollouts.base_checkpoint import (
+    is_hf_repo_id,
+    resolve_base_checkpoint,
+)
+
+
+class IsHfRepoIdTest(unittest.TestCase):
+    def test_repo_id_is_not_an_absolute_path(self) -> None:
+        self.assertTrue(is_hf_repo_id("moonshotai/Moonlight-16B-A3B-Instruct"))
+        self.assertTrue(is_hf_repo_id("zai-org/GLM-4.5-Air-FP8"))
+
+    def test_absolute_dir_is_not_a_repo_id(self) -> None:
+        self.assertFalse(is_hf_repo_id("/mnt/stitch-s3-transport/base"))
+        self.assertFalse(is_hf_repo_id("/prep/kimi-nvfp4"))
+
+
+class ResolveBaseCheckpointTest(unittest.TestCase):
+    def test_absolute_dir_is_returned_verbatim_without_touching_the_cache(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_download(*args, **kwargs):
+            calls.append((args, kwargs))
+            return "/should/not/be/used"
+
+        resolved = resolve_base_checkpoint(
+            "/mnt/stitch-s3-transport/customer-base", snapshot_download=fake_download
+        )
+        self.assertEqual(resolved, "/mnt/stitch-s3-transport/customer-base")
+        self.assertEqual(calls, [])
+
+    def test_repo_id_resolves_from_the_local_cache_only(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_download(spec, **kwargs):
+            calls.append((spec, kwargs))
+            return f"/hf-cache/{spec}/snapshots/abc123"
+
+        resolved = resolve_base_checkpoint(
+            "moonshotai/Moonlight-16B-A3B-Instruct", snapshot_download=fake_download
+        )
+        self.assertEqual(resolved, "/hf-cache/moonshotai/Moonlight-16B-A3B-Instruct/snapshots/abc123")
+        self.assertEqual(
+            calls, [("moonshotai/Moonlight-16B-A3B-Instruct", {"local_files_only": True})]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cookbook/standalone_rollouts/configs/moonlight_hot_load.py
+++ b/cookbook/standalone_rollouts/configs/moonlight_hot_load.py
@@ -12,6 +12,12 @@ from pathlib import Path
 
 APP_NAME = "stitch-moonlight-api-shim"
 MODEL_NAME = "moonshotai/Moonlight-16B-A3B-Instruct"
+# The checkpoint the pool boots from and seeds every delta onto. An HF repo id
+# resolves from the prewarmed hub cache; an absolute path is an S3-mounted or
+# prep-volume base the customer pre-uploaded. Here it is the public base model;
+# a customer running a finetune of the same arch/quant points this at their own
+# base dir instead. MODEL_NAME stays the served-model label clients send.
+BASE_CHECKPOINT = MODEL_NAME
 
 HF_SECRET_NAME = "huggingface-secret"
 SHIM_SECRET_NAME = "stitch-api-shim-provider"

--- a/cookbook/standalone_rollouts/frontdoor.py
+++ b/cookbook/standalone_rollouts/frontdoor.py
@@ -156,11 +156,20 @@ def create_frontdoor_app(
         rejected = _auth(request)
         if rejected is not None:
             return rejected
-        payload = await request.json()
+        try:
+            payload = await request.json()
+        except Exception:  # noqa: BLE001 — a malformed/non-JSON body is a 400, never a 500
+            return JSONResponse({"error": "request body must be a JSON object"}, status_code=400)
         if not isinstance(payload, dict) or not payload.get("identity"):
             return JSONResponse({"error": "body.identity is required"}, status_code=400)
         identity = str(payload["identity"])
         request_run_id = payload.get("run_id")
+        # run_id, when present, must be a string: the monotonic guard compares it
+        # against the stored run id, and a non-string (e.g. a JSON number) never
+        # compares equal, silently turning every duplicate signal into a
+        # pool-resetting cross-run move.
+        if request_run_id is not None and not isinstance(request_run_id, str):
+            return JSONResponse({"error": "body.run_id must be a string"}, status_code=400)
         async with advance_lock:
             current_run_id, current_version = await read_current_pointer()
             decision = advance_latest_decision(

--- a/cookbook/standalone_rollouts/frontdoor.py
+++ b/cookbook/standalone_rollouts/frontdoor.py
@@ -39,6 +39,22 @@ from stitch.protocol import (
 HOT_LOAD_PATH = "/hot_load/v1/models/hot_load"
 
 
+def is_customer_inference_route(path: str) -> bool:
+    """Whether a proxied path is a customer-facing inference route.
+
+    The proxy is an allowlist, not a denylist: only OpenAI-compatible ``v1/*``
+    routes and the SGLang-native ``generate`` route reach the rollout pool.
+    Everything else a public client could name — the per-container sidecar's own
+    control routes (``rpc_sync_from_bulletin_board``, ``server_info``,
+    ``get_weight_version``) and the SGLang engine routes behind it
+    (``update_weights_*``, ``start_profile``, …) — is not reachable through the
+    front door, so a new engine/sidecar route can never become customer-exposed
+    by omission from a denylist.
+    """
+    route = path.strip("/")
+    return route == "generate" or route == "v1" or route.startswith("v1/")
+
+
 def advance_latest_decision(
     current_run_id: str | None,
     current_version: int,
@@ -207,6 +223,8 @@ def create_frontdoor_app(
         rejected = _auth(request)
         if rejected is not None:
             return rejected
+        if not is_customer_inference_route(path):
+            return JSONResponse({"error": f"no such route: /{path.strip('/')}"}, status_code=404)
         return await proxy(request, path)
 
     return app

--- a/cookbook/standalone_rollouts/frontdoor_test.py
+++ b/cookbook/standalone_rollouts/frontdoor_test.py
@@ -150,6 +150,32 @@ class FrontdoorAppTest(unittest.TestCase):
         client, _ = self._client()
         self.assertEqual(client.post(HOT_LOAD_PATH, json={}).status_code, 400)
 
+    def test_post_malformed_body_is_400_not_500(self) -> None:
+        client, calls = self._client(run_id="run-a", version=5)
+        resp = client.post(
+            HOT_LOAD_PATH,
+            content=b"not json",
+            headers={"content-type": "application/json"},
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(calls["advanced"], [])
+
+    def test_post_non_string_run_id_is_400_not_a_reset(self) -> None:
+        # A JSON-number run_id must not slip past the string compare in the
+        # monotonic guard (7 != "7") and turn a duplicate into a cross-run reset.
+        client, calls = self._client(run_id="run-a", version=5)
+        resp = client.post(HOT_LOAD_PATH, json={"identity": "weight_v000006", "run_id": 7})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(calls["advanced"], [])
+
+    def test_post_pathological_identity_is_400_not_500(self) -> None:
+        client, calls = self._client(run_id="run-a", version=5)
+        for identity in ("weight_v²", "weight_v" + "9" * 100000):
+            resp = client.post(HOT_LOAD_PATH, json={"identity": identity, "run_id": "run-a"})
+            self.assertEqual(resp.status_code, 400)
+            self.assertEqual(resp.json()["error"]["type"], "InvalidIdentity")
+        self.assertEqual(calls["advanced"], [])
+
     def test_get_reports_pool_readiness(self) -> None:
         client, _ = self._client(run_id="run-a", version=5)
         body = client.get(HOT_LOAD_PATH).json()

--- a/cookbook/standalone_rollouts/frontdoor_test.py
+++ b/cookbook/standalone_rollouts/frontdoor_test.py
@@ -189,6 +189,30 @@ class FrontdoorAppTest(unittest.TestCase):
         self.assertEqual(resp.json(), {"proxied": "v1/chat/completions"})
         self.assertEqual(calls["proxied"], ["v1/chat/completions"])
 
+    def test_proxy_allows_inference_routes(self) -> None:
+        client, calls = self._client()
+        for path in ("/v1/completions", "/v1/chat/completions", "/v1/models", "/generate"):
+            self.assertEqual(client.post(path, json={}).status_code, 200)
+        self.assertEqual(
+            calls["proxied"], ["v1/completions", "v1/chat/completions", "v1/models", "generate"]
+        )
+
+    def test_proxy_blocks_internal_routes_with_404(self) -> None:
+        # Reachable through the front door before the allowlist: sidecar control
+        # routes and SGLang engine routes. None must be proxied.
+        client, calls = self._client()
+        for path in (
+            "/rpc_sync_from_bulletin_board",
+            "/server_info",
+            "/get_weight_version",
+            "/update_weights_from_disk",
+            "/update_weights_from_ipc",
+            "/start_profile",
+            "/flush_cache",
+        ):
+            self.assertEqual(client.post(path, json={}).status_code, 404)
+        self.assertEqual(calls["proxied"], [])
+
     def test_auth_rejection_blocks_every_route(self) -> None:
         from fastapi.responses import JSONResponse
 

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -23,6 +23,10 @@ import modal.experimental
 
 from cookbook.slime_disagg import helpers
 from cookbook.standalone_rollouts import frontdoor as frontdoor_mod
+from cookbook.standalone_rollouts.base_checkpoint import (
+    is_hf_repo_id,
+    resolve_base_checkpoint,
+)
 from stitch.bulletin import FilesystemBulletinBoard
 from stitch.providers.modal import (
     discover_flash_targets,
@@ -36,6 +40,9 @@ exp = importlib.import_module(f"cookbook.standalone_rollouts.configs.{PROVIDER_C
 
 APP_NAME = exp.APP_NAME
 MODEL_NAME = exp.MODEL_NAME
+# Required: the checkpoint the engine boots from and every delta seeds onto.
+# HF repo id (resolved from the prewarmed cache) or an absolute S3/prep dir.
+BASE_CHECKPOINT = exp.BASE_CHECKPOINT
 ROLLOUT_CONCURRENCY = exp.ROLLOUT_CONCURRENCY
 SIDECAR_PORT = 8000
 SGLANG_PORT = 8001
@@ -191,8 +198,18 @@ class Server:
 
     @modal.enter()
     def startup(self) -> None:
+        from huggingface_hub import snapshot_download
+
+        # Boot the engine from, and seed every delta onto, the one base
+        # checkpoint the config names. The engine's initial served weights are
+        # the customer's base (not a stock stand-in); the sidecar patches a copy
+        # of the same dir per delta and reloads. --served-model-name stays
+        # MODEL_NAME, so the wire label is unchanged whatever the load path is.
+        base_checkpoint_dir = resolve_base_checkpoint(
+            BASE_CHECKPOINT, snapshot_download=snapshot_download
+        )
         self.endpoint = SGLangEndpoint(
-            model_path=MODEL_NAME,
+            model_path=base_checkpoint_dir,
             worker_port=SGLANG_PORT,
             tp=exp.ROLLOUT_NUM_GPUS_PER_ENGINE,
             extra_server_args=SGLANG_SERVER_ARGS,
@@ -207,11 +224,6 @@ class Server:
             request_timeout=120.0,
             max_attempts_per_request=3,
         )
-        # Deltas are applied host-side onto a copy of the base checkpoint; the
-        # base resolves to the same HF cache snapshot the SGLang server loaded.
-        from huggingface_hub import snapshot_download
-
-        base_checkpoint_dir = snapshot_download(MODEL_NAME, local_files_only=True)
         self.sidecar = _start_provider_sidecar(base_checkpoint_dir=base_checkpoint_dir)
         helpers.wait_http(
             f"http://127.0.0.1:{SIDECAR_PORT}/health",
@@ -239,7 +251,11 @@ class Server:
 def download_model() -> None:
     from huggingface_hub import snapshot_download
 
-    snapshot_download(repo_id=MODEL_NAME)
+    # Prewarm the base into the HF cache volume so the serving path resolves it
+    # with local_files_only=True. A path-based base (S3 mount / prep volume) is
+    # provisioned out of band, so there is nothing to download.
+    if is_hf_repo_id(BASE_CHECKPOINT):
+        snapshot_download(repo_id=BASE_CHECKPOINT)
     hf_cache_volume.commit()
 
 

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -23,6 +23,7 @@ import modal.experimental
 
 from cookbook.slime_disagg import helpers
 from cookbook.standalone_rollouts import frontdoor as frontdoor_mod
+from cookbook.standalone_rollouts.auth import authorize
 from cookbook.standalone_rollouts.base_checkpoint import (
     is_hf_repo_id,
     resolve_base_checkpoint,
@@ -417,28 +418,20 @@ def _frontdoor_headers(raw: dict[str, str]) -> dict[str, str]:
 
 def _auth_error(headers):
     """Validate the customer auth headers against the provider secret. Returns a
-    JSONResponse to reject, or None to allow."""
+    JSONResponse to reject, or None to allow. Fail-closed when the API key is
+    unset (see :func:`cookbook.standalone_rollouts.auth.authorize`)."""
     from fastapi.responses import JSONResponse
 
-    api_key = os.environ.get("STITCH_SHIM_API_KEY")
-    if api_key and headers.get("authorization") != f"Bearer {api_key}":
-        return JSONResponse({"error": "unauthorized"}, status_code=401)
-    provider_model = os.environ.get("STITCH_SHIM_PROVIDER_MODEL")
-    if provider_model and headers.get("provider-model") != provider_model:
-        return JSONResponse(
-            {"error": "Provider-Model header does not match this deployment"},
-            status_code=400,
-        )
-    provider_deployment = os.environ.get("STITCH_SHIM_PROVIDER_DEPLOYMENT")
-    if (
-        provider_deployment
-        and headers.get("provider-deployment") != provider_deployment
-    ):
-        return JSONResponse(
-            {"error": "Provider-Deployment header does not match this deployment"},
-            status_code=400,
-        )
-    return None
+    rejection = authorize(
+        headers,
+        api_key=os.environ.get("STITCH_SHIM_API_KEY"),
+        provider_model=os.environ.get("STITCH_SHIM_PROVIDER_MODEL"),
+        provider_deployment=os.environ.get("STITCH_SHIM_PROVIDER_DEPLOYMENT"),
+    )
+    if rejection is None:
+        return None
+    status, message = rejection
+    return JSONResponse({"error": message}, status_code=status)
 
 
 FRONTDOOR_PORT = 8000
@@ -478,6 +471,15 @@ class FrontDoor:
         import httpx
         import uvicorn
         from fastapi.responses import Response
+
+        # Fail closed: this in-app check is the only auth gate (the Modal server
+        # is unauthenticated=True), so refuse to start open rather than serve a
+        # public endpoint with a missing/mis-named secret key.
+        if not os.environ.get("STITCH_SHIM_API_KEY"):
+            raise RuntimeError(
+                "STITCH_SHIM_API_KEY is not set; the front door is the only auth "
+                f"gate and will not start open. Set it in the {exp.SHIM_SECRET_NAME} secret."
+            )
 
         board = FilesystemBulletinBoard(str(S3_TRANSPORT_MOUNT_PATH), layout="slime")
         gateway: dict[str, str | None] = {"url": None}

--- a/src/stitch/bulletin.py
+++ b/src/stitch/bulletin.py
@@ -12,10 +12,10 @@ from stitch.protocol import (
     BASE_VERSION,
     PointerMove,
     VersionManifest,
-    atomic_write_text,
     decide_pointer_move,
     format_snapshot_identity,
     parse_snapshot_identity,
+    plain_write_text,
     read_latest,
     version_dir,
     weight_identity,
@@ -106,7 +106,7 @@ class FilesystemBulletinBoard:
         :meth:`claim`, which enforce the monotonic-within-run rule; this raw
         write is for callers that have already made the move decision."""
         if self.layout == "slime":
-            atomic_write_text(self.root / "latest", format_snapshot_identity(run_id, version))
+            plain_write_text(self.root / "latest", format_snapshot_identity(run_id, version))
         else:
             write_latest(self.root, version)
 

--- a/src/stitch/bulletin_test.py
+++ b/src/stitch/bulletin_test.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import errno
 import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from stitch.bulletin import FilesystemBulletinBoard
 from stitch.protocol import (
@@ -87,6 +89,22 @@ class SlimeLayoutBulletinTest(unittest.TestCase):
             board.write_latest(None, 7)
             self.assertEqual((root / "latest").read_text(encoding="utf-8"), "weight_v000007")
             self.assertEqual(board.read_latest(), (None, 7))
+
+    def test_slime_pointer_write_never_renames(self) -> None:
+        # The front door writes `latest` on the S3 CloudBucketMount, where
+        # os.replace raises ENOSYS. The slime-layout write must not rename, must
+        # tolerate repeated overwrites, and must not strand a latest.tmp.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            board = FilesystemBulletinBoard(root, layout="slime")
+            with mock.patch(
+                "stitch.protocol.os.replace",
+                side_effect=OSError(errno.ENOSYS, "rename not supported"),
+            ):
+                board.write_latest("run-a", 5)
+                board.write_latest("run-a", 6)  # overwrite an existing pointer
+            self.assertEqual(board.read_latest(), ("run-a", 6))
+            self.assertFalse((root / "latest.tmp").exists())
 
     def test_legacy_bare_pointer_parses_runless(self) -> None:
         # A pre-run-id deployment left `latest` = "000005"; it must parse as a

--- a/src/stitch/protocol.py
+++ b/src/stitch/protocol.py
@@ -368,12 +368,23 @@ def weight_identity(version: int) -> str:
 
 
 def parse_weight_identity(identity: str) -> int | None:
-    """Inverse of :func:`weight_identity`; None if not ``weight_v<digits>``."""
+    """Inverse of :func:`weight_identity`; None if not ``weight_v<digits>``.
+
+    Only ASCII digits are accepted and an over-long run of them returns None
+    rather than raising: this parses untrusted customer input, so a unicode
+    numeral (passes ``str.isdigit`` but ``int`` rejects) or a digit string past
+    CPython's int-conversion limit must be a clean rejection, not a 500.
+    """
     prefix = "weight_v"
     if not identity.startswith(prefix):
         return None
     digits = identity[len(prefix):]
-    return int(digits) if digits.isdigit() else None
+    if not (digits.isascii() and digits.isdigit()):
+        return None
+    try:
+        return int(digits)
+    except ValueError:
+        return None
 
 
 def format_snapshot_identity(run_id: str | None, version: int) -> str:

--- a/src/stitch/protocol.py
+++ b/src/stitch/protocol.py
@@ -575,15 +575,24 @@ def atomic_write_json(path: str | Path, payload: dict[str, Any]) -> None:
     os.replace(tmp, path)
 
 
-def atomic_write_text(path: str | Path, text: str) -> None:
+def plain_write_text(path: str | Path, text: str) -> None:
+    """Overwrite ``path`` in place, without a tmp file + atomic rename.
+
+    The JSON pointer (stitch layout) uses :func:`atomic_write_json`, but the
+    slime-layout ``latest`` pointer lives on the S3 CloudBucketMount, where
+    ``os.replace`` raises ENOSYS (mountpoint-s3 has no rename — the same
+    constraint that made the trainer upload path copy instead of rename, commit
+    8745872). A probe against the real mount confirmed both that ``os.replace``
+    raises ENOSYS and that opening an existing key ``"w"`` overwrites it in place
+    as one PutObject, atomic at the object level — so no unlink-first dance is
+    needed (a reader always sees the old or new pointer, never absent). No fsync:
+    the pointer is single-writer (the singleton front door under its advance
+    lock) and re-derivable, and mountpoint-s3 flushes on close.
+    """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(path.name + ".tmp")
-    with tmp.open("w", encoding="utf-8") as f:
+    with path.open("w", encoding="utf-8") as f:
         f.write(text)
-        f.flush()
-        os.fsync(f.fileno())
-    os.replace(tmp, path)
 
 
 def _optional_int(value: Any) -> int | None:

--- a/src/stitch/protocol_test.py
+++ b/src/stitch/protocol_test.py
@@ -141,6 +141,13 @@ class ProtocolTest(unittest.TestCase):
         self.assertIsNone(parse_weight_identity("base"))
         self.assertIsNone(parse_weight_identity("weight_vxyz"))
 
+    def test_parse_weight_identity_rejects_pathological_input_without_raising(self) -> None:
+        # Untrusted customer input: a unicode numeral passes str.isdigit but int
+        # rejects it, and a digit run past CPython's int-conversion limit raises
+        # in int(). Both must return None (-> a clean 400), never propagate.
+        self.assertIsNone(parse_weight_identity("weight_v²"))  # superscript 2
+        self.assertIsNone(parse_weight_identity("weight_v" + "9" * 100000))
+
     def test_evaluate_version_policy(self) -> None:
         self.assertIsNone(evaluate_version_policy(5, WeightVersionPolicy()))
         self.assertIsNone(evaluate_version_policy(5, WeightVersionPolicy(exact_version=5)))


### PR DESCRIPTION
First slice of the opaque-customer-contract stack (5 commits): boot the engine and seed every delta from one configured base checkpoint, reject malformed hot-load POSTs with 4xx (never 5xx), allowlist customer inference routes at the front door, fail closed when the API key is unset, and write the slime-layout pointer without os.replace (mountpoint-s3 has no rename).

Stack: this PR → #21 (opaque identities + ledger) → review-fixes slices (map in #20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnEES5LVJpCiATG6w16QTU