### PR TITLE
standalone_rollouts: validate customer lineage at the front door

### DIFF
--- a/cookbook/standalone_rollouts/frontdoor.py
+++ b/cookbook/standalone_rollouts/frontdoor.py
@@ -31,7 +31,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from cookbook.standalone_rollouts.ledger import IdentityLedger
+from cookbook.standalone_rollouts.ledger import IdentityLedger, LedgerError
 from stitch.protocol import RolloutPoolState, RolloutReplicaState
 
 
@@ -179,15 +179,23 @@ def create_frontdoor_app(
                 {"error": "body.incremental_snapshot_metadata must be an object"}, status_code=400
             )
         previous = incremental.get("previous_snapshot_identity") if incremental else None
-        if previous is not None and not isinstance(previous, str):
+        if incremental is not None and (not isinstance(previous, str) or not previous):
+            # A delta without lineage is indistinguishable from a full snapshot
+            # and would be recorded as one; require the parent explicitly.
             return JSONResponse(
-                {"error": "incremental_snapshot_metadata.previous_snapshot_identity must be a string"},
+                {
+                    "error": "incremental_snapshot_metadata.previous_snapshot_identity "
+                    "must be a non-empty string"
+                },
                 status_code=400,
             )
 
         async with advance_lock:
             ledger = IdentityLedger.from_dict(await load_ledger())
-            entry, is_new = ledger.record(identity, previous)
+            try:
+                entry, is_new = ledger.record(identity, previous)
+            except LedgerError as exc:
+                return JSONResponse({"error": str(exc)}, status_code=409)
             if is_new:
                 # A delta (incremental metadata present) needs its index normalized
                 # so the decoder can apply it; a full snapshot (base) is served

--- a/cookbook/standalone_rollouts/frontdoor.py
+++ b/cookbook/standalone_rollouts/frontdoor.py
@@ -37,6 +37,10 @@ from stitch.protocol import RolloutPoolState, RolloutReplicaState
 
 HOT_LOAD_PATH = "/hot_load/v1/models/hot_load"
 MAX_IDENTITY_LEN = 512
+# Path components that resolve outside the identity's own upload dir, plus the
+# transport's own files (the pointer and the ledger), which an identity dir
+# must never shadow or clobber.
+RESERVED_IDENTITIES = {".", "..", "latest", "identities.json"}
 
 
 def is_customer_inference_route(path: str) -> bool:
@@ -61,7 +65,7 @@ def is_valid_identity(identity: str) -> bool:
     non-empty, bounded, single-segment (no ``/``, which would escape the prefix),
     and free of control characters. Bounding it also caps ledger/key growth from
     a hostile client."""
-    if not identity or len(identity) > MAX_IDENTITY_LEN:
+    if not identity or len(identity) > MAX_IDENTITY_LEN or identity in RESERVED_IDENTITIES:
         return False
     return "/" not in identity and not any(ord(c) < 0x20 for c in identity)
 

--- a/cookbook/standalone_rollouts/frontdoor.py
+++ b/cookbook/standalone_rollouts/frontdoor.py
@@ -200,6 +200,22 @@ def create_frontdoor_app(
                 entry, is_new = ledger.record(identity, previous)
             except LedgerError as exc:
                 return JSONResponse({"error": str(exc)}, status_code=409)
+            if entry.version != ledger.head_version:
+                # Re-signalling an older identity is a rewind request the pool
+                # cannot serve (versions only move forward); reject it loudly
+                # rather than answering accepted:true for weights that will
+                # never be reported ready.
+                return JSONResponse(
+                    {
+                        "error": {
+                            "type": "WeightRewindRejected",
+                            "message": f"{identity!r} is older than the served head",
+                            "current_version": ledger.head_version,
+                            "requested_version": entry.version,
+                        }
+                    },
+                    status_code=409,
+                )
             if is_new:
                 # A delta (incremental metadata present) needs its index normalized
                 # so the decoder can apply it; a full snapshot (base) is served
@@ -220,10 +236,10 @@ def create_frontdoor_app(
                             status_code=409,
                         )
                 await save_ledger(ledger.to_dict())
-            # Advance (idempotently) whenever this identity is the chain head, so a
-            # retry after a save-succeeded/advance-failed POST still moves latest.
-            if entry.version == ledger.head_version:
-                await advance_to(entry.version)
+            # This identity is the chain head (rewinds were rejected above).
+            # Advance idempotently, so a retry after a save-succeeded/
+            # advance-failed POST still moves latest.
+            await advance_to(entry.version)
 
         if is_new and wake is not None:
             try:

--- a/cookbook/standalone_rollouts/frontdoor_test.py
+++ b/cookbook/standalone_rollouts/frontdoor_test.py
@@ -301,6 +301,15 @@ class FrontdoorAppTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 409)
         self.assertEqual(calls["normalized"], [])
 
+    def test_resignalling_an_older_identity_is_a_409_rewind(self) -> None:
+        client, calls, _ = self._client()
+        client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
+        client.post(HOT_LOAD_PATH, json={"identity": "ckpt-100", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base-ckpt", "compression_format": "zstd", "checksum_format": "adler32"}})
+        resp = client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(resp.json()["error"]["type"], "WeightRewindRejected")
+        self.assertEqual(calls["advanced"], [0, 1])  # pointer stays at head
+
     def test_post_overlong_or_slashed_identity_is_400(self) -> None:
         client, calls, _ = self._client()
         for identity in ("weight_v" + "9" * 100000, "a/b/c"):

--- a/cookbook/standalone_rollouts/frontdoor_test.py
+++ b/cookbook/standalone_rollouts/frontdoor_test.py
@@ -268,6 +268,35 @@ class FrontdoorAppTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(calls["advanced"], [])
 
+    def test_delta_without_previous_identity_is_400(self) -> None:
+        client, calls, _ = self._client()
+        resp = client.post(
+            HOT_LOAD_PATH,
+            json={"identity": "ckpt-100", "incremental_snapshot_metadata": {"compression_format": "zstd"}},
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(calls["advanced"], [])
+
+    def test_second_full_snapshot_is_409(self) -> None:
+        client, calls, _ = self._client()
+        client.post(HOT_LOAD_PATH, json={"identity": "base-a"})
+        resp = client.post(HOT_LOAD_PATH, json={"identity": "base-b"})
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(calls["advanced"], [0])  # pointer untouched by the reject
+
+    def test_delta_with_unknown_parent_is_409(self) -> None:
+        client, calls, _ = self._client()
+        client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
+        resp = client.post(
+            HOT_LOAD_PATH,
+            json={
+                "identity": "ckpt-2",
+                "incremental_snapshot_metadata": {"previous_snapshot_identity": "ckpt-l"},
+            },
+        )
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(calls["normalized"], [])
+
     def test_post_overlong_or_slashed_identity_is_400(self) -> None:
         client, calls, _ = self._client()
         for identity in ("weight_v" + "9" * 100000, "a/b/c"):

--- a/cookbook/standalone_rollouts/frontdoor_test.py
+++ b/cookbook/standalone_rollouts/frontdoor_test.py
@@ -23,6 +23,10 @@ class IdentityValidationTest(unittest.TestCase):
         self.assertFalse(is_valid_identity("a\nb"))  # control char
         self.assertFalse(is_valid_identity("x" * 513))
 
+    def test_rejects_traversal_and_reserved_names(self) -> None:
+        for identity in (".", "..", "latest", "identities.json"):
+            self.assertFalse(is_valid_identity(identity), identity)
+
 
 class DeltaMetadataTest(unittest.TestCase):
     def test_pads_versions_and_defaults_delta_encoding(self) -> None:

--- a/cookbook/standalone_rollouts/ledger.py
+++ b/cookbook/standalone_rollouts/ledger.py
@@ -28,6 +28,12 @@ from typing import Any
 from stitch.protocol import BASE_VERSION
 
 
+class LedgerError(ValueError):
+    """A signal whose lineage cannot be recorded safely: a second full snapshot
+    (the base slot is single-occupancy) or a delta naming an unknown parent.
+    The front door reports it to the customer as a 409."""
+
+
 @dataclass(frozen=True)
 class LedgerEntry:
     """One signalled checkpoint: the version minted for it and its parent
@@ -87,7 +93,8 @@ class IdentityLedger:
 
     def base_version_for(self, identity: str) -> int:
         """The version a checkpoint's delta builds on: its parent's version, or
-        ``BASE_VERSION`` when it is a full snapshot or the parent is unknown."""
+        ``BASE_VERSION`` for a full snapshot / the first delta's unsignalled
+        (booted) parent — the one case :meth:`record` admits an unknown parent."""
         entry = self._by_identity[identity]
         if entry.previous is None:
             return BASE_VERSION
@@ -101,6 +108,13 @@ class IdentityLedger:
         returned unchanged and ``is_new`` is False, so a retried signal never
         moves the pointer. A new identity is minted the next monotonic version
         (``BASE_VERSION`` for the first ever, else max+1) and records ``previous``.
+
+        Raises :class:`LedgerError` on lineage that cannot be recorded safely:
+        a second full snapshot (it would take over the base's version 0), or a
+        delta naming a parent this ledger has never seen — unless the ledger is
+        empty, the one case where the parent is legitimately the booted,
+        never-signalled base. Rejecting is what keeps a typo'd parent from being
+        silently applied against the wrong base weights.
         """
         existing = self._by_identity.get(identity)
         if existing is not None:
@@ -108,9 +122,19 @@ class IdentityLedger:
         if previous is None:
             # A full snapshot is the base (version 0), whether the customer
             # pre-uploaded and signalled it or the pool booted it from
-            # BASE_CHECKPOINT.
+            # BASE_CHECKPOINT. The base slot is single-occupancy.
+            claimed = self._by_version.get(BASE_VERSION)
+            if claimed is not None:
+                raise LedgerError(
+                    f"base already signalled as {claimed!r}; cannot record a second full snapshot"
+                )
             version = BASE_VERSION
         else:
+            if previous not in self._by_identity and self._by_identity:
+                raise LedgerError(
+                    f"previous_snapshot_identity {previous!r} was never signalled; "
+                    "signal the parent checkpoint first"
+                )
             # A delta always mints a real version >= 1; v0 is reserved for the
             # base, so a delta signalled before any base (its parent booted, not
             # signalled) still becomes v1, not a phantom base that never applies.

--- a/cookbook/standalone_rollouts/ledger_test.py
+++ b/cookbook/standalone_rollouts/ledger_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 
-from cookbook.standalone_rollouts.ledger import IdentityLedger, LedgerEntry
+from cookbook.standalone_rollouts.ledger import IdentityLedger, LedgerEntry, LedgerError
 
 
 class RecordTest(unittest.TestCase):
@@ -52,6 +52,26 @@ class RecordTest(unittest.TestCase):
         entry, _ = ledger.record("ckpt-orphan", previous="never-seen")
         self.assertEqual(entry.version, 1)
         self.assertEqual(ledger.base_version_for("ckpt-orphan"), 0)
+
+    def test_second_full_snapshot_is_rejected_not_a_v0_takeover(self) -> None:
+        # v0 is single-occupancy: silently repointing it would strand pollers
+        # waiting on the first base and rewire the sidecar's weight_v000000 link.
+        ledger = IdentityLedger()
+        ledger.record("base-a", previous=None)
+        with self.assertRaises(LedgerError):
+            ledger.record("base-b", previous=None)
+        # The first base re-signals idempotently.
+        entry, is_new = ledger.record("base-a", previous=None)
+        self.assertEqual((entry.version, is_new), (0, False))
+
+    def test_unknown_parent_on_nonempty_ledger_is_rejected(self) -> None:
+        # A typo'd parent must not be coerced to base_version=0 — the delta
+        # would be applied against the wrong weights and serve garbage.
+        ledger = IdentityLedger()
+        ledger.record("ckpt-base", previous=None)
+        ledger.record("ckpt-1", previous="ckpt-base")
+        with self.assertRaises(LedgerError):
+            ledger.record("ckpt-2", previous="ckpt-l")  # typo of "ckpt-1"
 
 
 class LookupTest(unittest.TestCase):


### PR DESCRIPTION
Review-fixes slice 1 of 5 (4 commits): the ledger rejects colliding or unknown lineage instead of coercing it to the base (silent v0 takeover / wrong-base delta application), deltas must carry previous_snapshot_identity (400), traversal and reserved-name identities ('.', '..', 'latest', 'identities.json') are invalid, and re-signalling an older identity is a WeightRewindRejected 409 instead of accepted:true.

Full stack map in #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnEES5LVJpCiATG6w16QTU