### PR TITLE
stitch/standalone_rollouts: atomic transport writes + streaming proxy

### DIFF
--- a/cookbook/standalone_rollouts/delta_view.py
+++ b/cookbook/standalone_rollouts/delta_view.py
@@ -16,14 +16,34 @@ refresh (i.e. before every sync), so newly-signalled versions appear.
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
 from cookbook.standalone_rollouts.ledger import IdentityLedger
-from stitch.protocol import weight_identity
+from stitch.protocol import atomic_write_text, weight_identity
 
 
 LATEST_FILE = "latest"
+
+
+def merge_index_metadata(index_path: Path, metadata: dict[str, str]) -> None:
+    """Merge the disk-delta ``metadata`` block into a customer's uploaded HF
+    index in place, so the decoder can apply the delta without the customer
+    producing a slime-shaped index.
+
+    Raises ``FileNotFoundError`` when the upload has not landed and
+    ``ValueError`` when the uploaded index is not a JSON object; the front door
+    maps both to customer-actionable 4xx responses, never a 500.
+    """
+    try:
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"uploaded {index_path.name} is not valid JSON: {exc}") from exc
+    if not isinstance(index, dict):
+        raise ValueError(f"uploaded {index_path.name} must be a JSON object")
+    index.setdefault("metadata", {}).update(metadata)
+    atomic_write_text(index_path, json.dumps(index))
 
 
 def _ensure_symlink(link: Path, target: Path) -> None:

--- a/cookbook/standalone_rollouts/frontdoor.py
+++ b/cookbook/standalone_rollouts/frontdoor.py
@@ -132,7 +132,7 @@ def create_frontdoor_app(
     advance_to: Callable[[int], Awaitable[None]],
     list_server_infos: Callable[[], Awaitable[list[dict[str, Any]]]],
     proxy: Callable[..., Awaitable[Any]],
-    authorize: Callable[[Any], Any] | None = None,
+    authorize: Callable[[Any], Any],
     wake: Callable[[int], Awaitable[None]] | None = None,
 ):
     """Build the front-door FastAPI app from injected I/O.
@@ -142,7 +142,9 @@ def create_frontdoor_app(
     metadata block into that version dir's index; ``advance_to(version)`` writes
     the ``latest`` pointer; ``list_server_infos`` enumerates live replicas;
     ``proxy`` forwards inference; ``authorize`` returns a rejection Response or
-    ``None``; ``wake`` is a best-effort post-advance nudge.
+    ``None`` and is required — the app is fail-closed by construction, so a
+    test that wants an open app must say so with an explicit allow-all;
+    ``wake`` is a best-effort post-advance nudge.
 
     The load-record-normalize-save-advance sequence is serialized under
     ``advance_lock`` so the singleton front door never races itself. The ledger
@@ -158,7 +160,7 @@ def create_frontdoor_app(
     advance_lock = asyncio.Lock()
 
     def _auth(request: Request):
-        return authorize(request.headers) if authorize is not None else None
+        return authorize(request.headers)
 
     @app.post(HOT_LOAD_PATH, response_model=None)
     async def post_hot_load(request: Request) -> Response:

--- a/cookbook/standalone_rollouts/frontdoor.py
+++ b/cookbook/standalone_rollouts/frontdoor.py
@@ -235,6 +235,10 @@ def create_frontdoor_app(
                             {"error": f"checkpoint {identity!r} not found on the transport; upload before signalling"},
                             status_code=409,
                         )
+                    except ValueError as exc:
+                        # A malformed uploaded index (truncated write, wrong
+                        # file) is the customer's to fix: 4xx, never a 500.
+                        return JSONResponse({"error": str(exc)}, status_code=400)
                 await save_ledger(ledger.to_dict())
             # This identity is the chain head (rewinds were rejected above).
             # Advance idempotently, so a retry after a save-succeeded/

--- a/cookbook/standalone_rollouts/frontdoor.py
+++ b/cookbook/standalone_rollouts/frontdoor.py
@@ -31,7 +31,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from cookbook.standalone_rollouts.ledger import IdentityLedger, LedgerError
+from cookbook.standalone_rollouts.ledger import LEDGER_FILENAME, IdentityLedger, LedgerError
 from stitch.protocol import RolloutPoolState, RolloutReplicaState
 
 
@@ -40,7 +40,7 @@ MAX_IDENTITY_LEN = 512
 # Path components that resolve outside the identity's own upload dir, plus the
 # transport's own files (the pointer and the ledger), which an identity dir
 # must never shadow or clobber.
-RESERVED_IDENTITIES = {".", "..", "latest", "identities.json"}
+RESERVED_IDENTITIES = {".", "..", "latest", LEDGER_FILENAME}
 
 
 def is_customer_inference_route(path: str) -> bool:

--- a/cookbook/standalone_rollouts/frontdoor_test.py
+++ b/cookbook/standalone_rollouts/frontdoor_test.py
@@ -146,7 +146,7 @@ class FrontdoorAppTest(unittest.TestCase):
             advance_to=advance_to,
             list_server_infos=list_server_infos,
             proxy=proxy,
-            authorize=authorize,
+            authorize=authorize or (lambda headers: None),  # explicit allow-all
             wake=wake,
         )
         return TestClient(app), calls, state
@@ -235,6 +235,7 @@ class FrontdoorAppTest(unittest.TestCase):
             advance_to=advance_to,
             list_server_infos=list_server_infos,
             proxy=proxy,
+            authorize=lambda headers: None,
         )
         client = TestClient(app)
         resp = client.post(

--- a/cookbook/standalone_rollouts/ledger.py
+++ b/cookbook/standalone_rollouts/ledger.py
@@ -16,16 +16,32 @@ the base) is recorded faithfully but is not yet replayable (the deferred
 fork-from-version case), so its non-contiguous base surfaces at apply time
 rather than being silently reordered here.
 
-Pure and persistence-free: :meth:`to_dict` / :meth:`from_dict` round-trip the
-state, and the front door persists it to the transport.
+The ledger itself is pure: :meth:`to_dict` / :meth:`from_dict` round-trip the
+state. Persistence is one JSON file on the transport (``LEDGER_FILENAME``,
+written by the front door, read back via :func:`load_ledger_dict`).
 """
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from stitch.protocol import BASE_VERSION
+
+
+LEDGER_FILENAME = "identities.json"
+
+
+def load_ledger_dict(transport_root: str | Path) -> dict[str, Any]:
+    """The persisted ledger dict from the transport, or ``{}`` before the
+    front door's first save."""
+    try:
+        path = Path(transport_root) / LEDGER_FILENAME
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
 
 
 class LedgerError(ValueError):

--- a/cookbook/standalone_rollouts/ledger.py
+++ b/cookbook/standalone_rollouts/ledger.py
@@ -17,7 +17,7 @@ fork-from-version case), so its non-contiguous base surfaces at apply time
 rather than being silently reordered here.
 
 Pure and persistence-free: :meth:`to_dict` / :meth:`from_dict` round-trip the
-state, and the front door writes it to the transport with a rename-free write.
+state, and the front door persists it to the transport.
 """
 
 from __future__ import annotations

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -29,7 +29,7 @@ from cookbook.standalone_rollouts.base_checkpoint import (
     resolve_base_checkpoint,
 )
 from stitch.bulletin import FilesystemBulletinBoard
-from stitch.protocol import plain_write_text
+from stitch.protocol import atomic_write_text
 from stitch.providers.modal import (
     discover_flash_targets,
     resolve_flash_gateway_url,
@@ -510,10 +510,10 @@ class FrontDoor:
             return await asyncio.to_thread(_read)
 
         async def save_ledger(data: dict) -> None:
-            # Rename-free write on the S3 mount (see plain_write_text); the front
-            # door is the singleton writer, serialized under the app's advance lock.
+            # The front door is the singleton writer, serialized under the
+            # app's advance lock.
             await asyncio.to_thread(
-                plain_write_text, ledger_path, json.dumps(data, sort_keys=True) + "\n"
+                atomic_write_text, ledger_path, json.dumps(data, sort_keys=True) + "\n"
             )
 
         async def normalize_index(identity: str, metadata: dict) -> None:
@@ -526,13 +526,12 @@ class FrontDoor:
             def _rewrite() -> None:
                 index = json.loads(index_path.read_text(encoding="utf-8"))
                 index.setdefault("metadata", {}).update(metadata)
-                plain_write_text(index_path, json.dumps(index))
+                atomic_write_text(index_path, json.dumps(index))
 
             await asyncio.to_thread(_rewrite)
 
         async def advance_to(version: int) -> None:
             # Run-less pointer: write the bare weight_vN identity the pool pulls.
-            # One plain PutObject-style overwrite (see plain_write_text).
             board.write_latest(None, version)
 
         async def list_server_infos() -> list[dict]:

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -511,17 +511,17 @@ class FrontDoor:
             targets = await asyncio.to_thread(
                 discover_flash_targets, APP_NAME, Server.__name__
             )
-            infos: list[dict] = []
+
+            async def _info(client: httpx.AsyncClient, target: str) -> dict:
+                try:
+                    return (await client.get(f"{target}/server_info")).json()
+                except Exception:  # noqa: BLE001 — unreachable replica reported as not-ready
+                    return {"sync_state": None, "last_sync_error": "unreachable"}
+
+            # Concurrently: polled on the readiness path, so k unreachable
+            # replicas must cost one timeout, not k stacked timeouts.
             async with httpx.AsyncClient(timeout=10.0, trust_env=False) as client:
-                for target in targets:
-                    try:
-                        resp = await client.get(f"{target}/server_info")
-                        infos.append(resp.json())
-                    except Exception:  # noqa: BLE001 — unreachable replica reported as not-ready
-                        infos.append(
-                            {"sync_state": None, "last_sync_error": "unreachable"}
-                        )
-            return infos
+                return list(await asyncio.gather(*(_info(client, t) for t in targets)))
 
         async def wake(version: int) -> None:
             targets = await asyncio.to_thread(

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -475,7 +475,8 @@ class FrontDoor:
 
         import httpx
         import uvicorn
-        from fastapi.responses import Response
+        from fastapi.responses import Response, StreamingResponse
+        from starlette.background import BackgroundTask
 
         # Fail closed: this in-app check is the only auth gate (the Modal server
         # is unauthenticated=True), so refuse to start open rather than serve a
@@ -548,22 +549,36 @@ class FrontDoor:
             await asyncio.to_thread(wake_targets, targets, version)
 
         async def proxy(request, path: str) -> Response:
-            if gateway["url"] is None:
-                gateway["url"] = provider_gateway_url()
             headers = _frontdoor_headers(dict(request.headers))
             body = await request.body()
-            resp = await _proxy_client().request(
-                request.method,
-                f"{gateway['url']}/{path}",
-                headers=headers,
-                content=body,
-                params=request.query_params,
-            )
-            return Response(
-                content=resp.content,
-                status_code=resp.status_code,
-                media_type=resp.headers.get("content-type") or None,
-            )
+            # Two attempts: a connect failure drops the cached gateway URL (the
+            # pool may have been redeployed under a new one) and re-resolves.
+            for attempt in (1, 2):
+                if gateway["url"] is None:
+                    gateway["url"] = provider_gateway_url()
+                upstream_request = _proxy_client().build_request(
+                    request.method,
+                    f"{gateway['url']}/{path}",
+                    headers=headers,
+                    content=body,
+                    params=request.query_params,
+                )
+                try:
+                    upstream = await _proxy_client().send(upstream_request, stream=True)
+                except httpx.ConnectError:
+                    gateway["url"] = None
+                    if attempt == 2:
+                        raise
+                    continue
+                # Stream the body through so stream:true completions reach the
+                # client token by token; closing the response releases the
+                # upstream connection.
+                return StreamingResponse(
+                    upstream.aiter_raw(),
+                    status_code=upstream.status_code,
+                    media_type=upstream.headers.get("content-type") or None,
+                    background=BackgroundTask(upstream.aclose),
+                )
 
         asgi_app = frontdoor_mod.create_frontdoor_app(
             load_ledger=load_ledger,

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -553,11 +553,19 @@ class FrontDoor:
                     continue
                 # Stream the body through so stream:true completions reach the
                 # client token by token; closing the response releases the
-                # upstream connection.
+                # upstream connection. aiter_raw() forwards the bytes as-is
+                # (possibly compressed), so the upstream headers — notably
+                # Content-Encoding — must travel with them; only the framing
+                # headers are dropped (the re-streamed response re-frames).
+                response_headers = {
+                    k: v
+                    for k, v in upstream.headers.items()
+                    if k.lower() not in {"content-length", "transfer-encoding", "connection"}
+                }
                 return StreamingResponse(
                     upstream.aiter_raw(),
                     status_code=upstream.status_code,
-                    media_type=upstream.headers.get("content-type") or None,
+                    headers=response_headers,
                     background=BackgroundTask(upstream.aclose),
                 )
 

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -29,6 +29,7 @@ from cookbook.standalone_rollouts.base_checkpoint import (
     resolve_base_checkpoint,
 )
 from cookbook.standalone_rollouts.delta_view import merge_index_metadata
+from cookbook.standalone_rollouts.ledger import LEDGER_FILENAME, load_ledger_dict
 from stitch.bulletin import FilesystemBulletinBoard
 from stitch.protocol import atomic_write_text
 from stitch.providers.modal import (
@@ -306,16 +307,9 @@ def check(timeout_seconds: int = 20 * MINUTES) -> None:
             raise TimeoutError(f"front-door readiness timed out: {last}")
         time.sleep(10)
 
-    payload = {
-        "model": MODEL_NAME,
-        "messages": [{"role": "user", "content": "Reply with exactly OK."}],
-        "max_tokens": 8,
-        "temperature": 0,
-        "chat_template_kwargs": {"enable_thinking": False},
-    }
     req = urllib.request.Request(
         f"{gateway}/v1/chat/completions",
-        data=json.dumps(payload).encode("utf-8"),
+        data=json.dumps(WARMUP_PAYLOAD).encode("utf-8"),
         headers={"Content-Type": "application/json", **headers},
     )
     with urllib.request.urlopen(req, timeout=180) as resp:
@@ -378,16 +372,9 @@ def smoke(
         print(f"Waiting for provider pool: {last_error}")
         time.sleep(10)
 
-    payload = {
-        "model": MODEL_NAME,
-        "messages": [{"role": "user", "content": "Reply with exactly OK."}],
-        "max_tokens": 8,
-        "temperature": 0,
-        "chat_template_kwargs": {"enable_thinking": False},
-    }
     req = urllib.request.Request(
         f"{gateway}/v1/chat/completions",
-        data=json.dumps(payload).encode("utf-8"),
+        data=json.dumps(WARMUP_PAYLOAD).encode("utf-8"),
         headers={"Content-Type": "application/json", **headers},
     )
     with urllib.request.urlopen(req, timeout=180) as resp:
@@ -491,7 +478,7 @@ class FrontDoor:
 
         board = FilesystemBulletinBoard(str(S3_TRANSPORT_MOUNT_PATH), layout="slime")
         transport_root = Path(str(S3_TRANSPORT_MOUNT_PATH))
-        ledger_path = transport_root / "identities.json"
+        ledger_path = transport_root / LEDGER_FILENAME
         gateway: dict[str, str | None] = {"url": None}
         clients: dict[str, httpx.AsyncClient] = {}
 
@@ -503,13 +490,7 @@ class FrontDoor:
             return client
 
         async def load_ledger() -> dict:
-            def _read() -> dict:
-                try:
-                    return json.loads(ledger_path.read_text(encoding="utf-8"))
-                except FileNotFoundError:
-                    return {}
-
-            return await asyncio.to_thread(_read)
+            return await asyncio.to_thread(load_ledger_dict, transport_root)
 
         async def save_ledger(data: dict) -> None:
             # The front door is the singleton writer, serialized under the

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -28,6 +28,7 @@ from cookbook.standalone_rollouts.base_checkpoint import (
     is_hf_repo_id,
     resolve_base_checkpoint,
 )
+from cookbook.standalone_rollouts.delta_view import merge_index_metadata
 from stitch.bulletin import FilesystemBulletinBoard
 from stitch.protocol import atomic_write_text
 from stitch.providers.modal import (
@@ -517,18 +518,8 @@ class FrontDoor:
             )
 
         async def normalize_index(identity: str, metadata: dict) -> None:
-            # Merge the disk-delta metadata block into the customer's uploaded
-            # index so the decoder can apply it, without asking the customer to
-            # produce a slime-shaped index. Raises FileNotFoundError if the upload
-            # has not landed (the front door turns that into a 409).
             index_path = transport_root / identity / "model.safetensors.index.json"
-
-            def _rewrite() -> None:
-                index = json.loads(index_path.read_text(encoding="utf-8"))
-                index.setdefault("metadata", {}).update(metadata)
-                atomic_write_text(index_path, json.dumps(index))
-
-            await asyncio.to_thread(_rewrite)
+            await asyncio.to_thread(merge_index_metadata, index_path, metadata)
 
         async def advance_to(version: int) -> None:
             # Run-less pointer: write the bare weight_vN identity the pool pulls.

--- a/cookbook/standalone_rollouts/provider.py
+++ b/cookbook/standalone_rollouts/provider.py
@@ -18,15 +18,13 @@ door (``modal_serve.py``), not here.
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import os
 import uuid
 from collections.abc import Callable
-from pathlib import Path
 
 from cookbook.standalone_rollouts.delta_view import rebuild_delta_view
-from cookbook.standalone_rollouts.ledger import IdentityLedger
+from cookbook.standalone_rollouts.ledger import IdentityLedger, load_ledger_dict
 from stitch.bulletin import FilesystemBulletinBoard
 from stitch.engines.sglang import SGLangDiskDeltaAdapter
 from stitch.servers.sglang import create_app as create_sglang_app
@@ -84,14 +82,9 @@ def _delta_view_refresh(view_dir: str, transport_root: str) -> Callable[[], None
     """Board refresh callback: rebuild the host-local weight_vN view from the
     front door's identity ledger on the transport, so the view tracks
     newly-signalled versions before each sync reads/apply."""
-    ledger_path = Path(transport_root) / "identities.json"
-
     def _refresh() -> None:
-        try:
-            data = json.loads(ledger_path.read_text(encoding="utf-8"))
-        except FileNotFoundError:
-            data = {}
-        rebuild_delta_view(view_dir, transport_root, IdentityLedger.from_dict(data))
+        ledger = IdentityLedger.from_dict(load_ledger_dict(transport_root))
+        rebuild_delta_view(view_dir, transport_root, ledger)
 
     return _refresh
 

--- a/cookbook/standalone_rollouts/simulator_test.py
+++ b/cookbook/standalone_rollouts/simulator_test.py
@@ -115,6 +115,7 @@ class SimulatorTest(unittest.IsolatedAsyncioTestCase):
             advance_to=advance_to,
             list_server_infos=list_server_infos,
             proxy=proxy,
+            authorize=lambda headers: None,
             wake=wake,
         )
         client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://fd")

--- a/cookbook/standalone_rollouts/simulator_test.py
+++ b/cookbook/standalone_rollouts/simulator_test.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import httpx
 
+from cookbook.standalone_rollouts.delta_view import merge_index_metadata
 from cookbook.standalone_rollouts.frontdoor import HOT_LOAD_PATH, create_frontdoor_app
 from cookbook.standalone_rollouts.provider import _delta_view_refresh
 from stitch.bulletin import FilesystemBulletinBoard
@@ -90,10 +91,8 @@ class SimulatorTest(unittest.IsolatedAsyncioTestCase):
             (transport / "identities.json").write_text(json.dumps(data), encoding="utf-8")
 
         async def normalize_index(identity, metadata):
-            p = transport / identity / "model.safetensors.index.json"
-            index = json.loads(p.read_text(encoding="utf-8"))  # FileNotFoundError -> 409
-            index.setdefault("metadata", {}).update(metadata)
-            p.write_text(json.dumps(index), encoding="utf-8")
+            # The real merge (FileNotFoundError -> 409, malformed -> 400).
+            merge_index_metadata(transport / identity / "model.safetensors.index.json", metadata)
 
         async def advance_to(version):
             (transport / "latest").write_text(weight_identity(version), encoding="utf-8")
@@ -197,6 +196,31 @@ class SimulatorTest(unittest.IsolatedAsyncioTestCase):
                 for mgr in managers:
                     await mgr.sync_to()
                     self.assertEqual(mgr.current_version, 0)
+
+    async def test_malformed_uploaded_index_is_400_not_500(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            transport, _, _, client = await self._stack(tmp)
+            async with client:
+                _upload_plain_hf_checkpoint(transport, "base-ckpt")
+                await client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
+                # A truncated/interrupted upload left an unparseable index.
+                d = transport / "ckpt-100"
+                d.mkdir()
+                (d / "model.safetensors.index.json").write_text('{"metadata": {', encoding="utf-8")
+                r = await client.post(
+                    HOT_LOAD_PATH,
+                    json={
+                        "identity": "ckpt-100",
+                        "incremental_snapshot_metadata": {
+                            "previous_snapshot_identity": "base-ckpt",
+                        },
+                    },
+                )
+                self.assertEqual(r.status_code, 400)
+                # The failed signal left no ledger entry, so a fixed re-upload
+                # and re-signal converges.
+                ledger = json.loads((transport / "identities.json").read_text())
+                self.assertNotIn("ckpt-100", ledger["entries"])
 
 
 if __name__ == "__main__":

--- a/cookbook/standalone_rollouts/slime/hooks.py
+++ b/cookbook/standalone_rollouts/slime/hooks.py
@@ -216,12 +216,7 @@ def rollout_request_weight_version_hook(
     # the same auth headers it sends to the hot-load API.
     cfg = ShimConfig.from_env(args)
     headers = dict(request.get("headers") or {})
-    if cfg.api_key:
-        headers["Authorization"] = f"Bearer {cfg.api_key}"
-    if cfg.provider_model:
-        headers["Provider-Model"] = cfg.provider_model
-    if cfg.provider_deployment:
-        headers["Provider-Deployment"] = cfg.provider_deployment
+    headers.update(_auth_headers(cfg))
     request["headers"] = headers
     # Neutral by default. The front-door relabel proxy maps this to
     # Modal-Session-ID before the gateway.
@@ -315,8 +310,10 @@ def _request_json(
     return json.loads(content.decode("utf-8"))
 
 
-def _headers(cfg: ShimConfig) -> dict[str, str]:
-    headers = {"Content-Type": "application/json"}
+def _auth_headers(cfg: ShimConfig) -> dict[str, str]:
+    """The provider auth headers every request carries — the hot-load API and
+    proxied inference alike."""
+    headers: dict[str, str] = {}
     if cfg.api_key:
         headers["Authorization"] = f"Bearer {cfg.api_key}"
     if cfg.provider_model:
@@ -324,6 +321,10 @@ def _headers(cfg: ShimConfig) -> dict[str, str]:
     if cfg.provider_deployment:
         headers["Provider-Deployment"] = cfg.provider_deployment
     return headers
+
+
+def _headers(cfg: ShimConfig) -> dict[str, str]:
+    return {"Content-Type": "application/json", **_auth_headers(cfg)}
 
 
 def _copy_version_to_transport(version_dir: Path, destination: Path) -> None:

--- a/cookbook/standalone_rollouts/slime/modal_train.py
+++ b/cookbook/standalone_rollouts/slime/modal_train.py
@@ -191,10 +191,8 @@ class Trainer:
         # No run_id / claim: the customer contract has no run concept, and the
         # front door's identity ledger orders signals monotonically. slime
         # publishes to a flat local dir and announce_and_wait copies each
-        # weight_v{N}/ to <transport>/weight_v{N}/. NOTE: a fresh launch reuses
-        # the same identities, so re-running against a non-empty transport prefix
-        # requires a clean prefix (multi-run reset is deferred, matching the
-        # deferred fork-from-base story).
+        # weight_v{N}/ to <transport>/weight_v{N}/.
+        _require_clean_transport(Path(str(provider_app.S3_TRANSPORT_MOUNT_PATH)))
         helpers.prepare_slime_config(cfg, tempfile.mkdtemp())
         cmd = helpers.build_train_cmd(cfg, SLIME_ROOT)
 
@@ -203,6 +201,22 @@ class Trainer:
         )
         print(f"Command: {cmd}")
         subprocess.run(["bash", "-lc", cmd], check=True)
+
+
+def _require_clean_transport(transport_root: Path) -> None:
+    """A fresh launch reuses the same weight_v{N} identities, so signalling into
+    a transport that already holds a ledger or pointer would make replicas still
+    serving the previous run's same-numbered weights count as ready — silently
+    generating rollouts from stale weights. Multi-run reset is deferred; until
+    then a dirty prefix is a launch error, not silent reuse."""
+    leftovers = [
+        name for name in ("identities.json", "latest") if (transport_root / name).exists()
+    ]
+    if leftovers:
+        raise RuntimeError(
+            f"transport prefix {transport_root} already holds {leftovers} from a previous "
+            "run; launch against a fresh STITCH_SHIM_S3_KEY_PREFIX or clear the old run first"
+        )
 
 
 @app.function(

--- a/src/stitch/bulletin.py
+++ b/src/stitch/bulletin.py
@@ -15,7 +15,7 @@ from stitch.protocol import (
     decide_pointer_move,
     format_snapshot_identity,
     parse_snapshot_identity,
-    plain_write_text,
+    atomic_write_text,
     read_latest,
     version_dir,
     weight_identity,
@@ -106,7 +106,7 @@ class FilesystemBulletinBoard:
         :meth:`claim`, which enforce the monotonic-within-run rule; this raw
         write is for callers that have already made the move decision."""
         if self.layout == "slime":
-            plain_write_text(self.root / "latest", format_snapshot_identity(run_id, version))
+            atomic_write_text(self.root / "latest", format_snapshot_identity(run_id, version))
         else:
             write_latest(self.root, version)
 

--- a/src/stitch/protocol.py
+++ b/src/stitch/protocol.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import time
@@ -575,24 +576,32 @@ def atomic_write_json(path: str | Path, payload: dict[str, Any]) -> None:
     os.replace(tmp, path)
 
 
-def plain_write_text(path: str | Path, text: str) -> None:
-    """Overwrite ``path`` in place, without a tmp file + atomic rename.
+def atomic_write_text(path: str | Path, text: str) -> None:
+    """Write ``text`` so a concurrent reader sees the old or the new content,
+    never a truncated file.
 
-    The JSON pointer (stitch layout) uses :func:`atomic_write_json`, but the
-    slime-layout ``latest`` pointer lives on the S3 CloudBucketMount, where
-    ``os.replace`` raises ENOSYS (mountpoint-s3 has no rename — the same
-    constraint that made the trainer upload path copy instead of rename, commit
-    8745872). A probe against the real mount confirmed both that ``os.replace``
-    raises ENOSYS and that opening an existing key ``"w"`` overwrites it in place
-    as one PutObject, atomic at the object level — so no unlink-first dance is
-    needed (a reader always sees the old or new pointer, never absent). No fsync:
-    the pointer is single-writer (the singleton front door under its advance
-    lock) and re-derivable, and mountpoint-s3 flushes on close.
+    On a normal filesystem: tmp file + fsync + ``os.replace``. On the S3
+    CloudBucketMount ``os.replace`` raises ENOSYS (mountpoint-s3 has no rename —
+    the same constraint that made the trainer upload path copy instead of
+    rename, commit 8745872), so fall back to an in-place ``open("w")``
+    overwrite, which a probe against the real mount confirmed is one PutObject,
+    atomic at the object level.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
-        f.write(text)
+    tmp = path.with_name(path.name + ".tmp")
+    try:
+        with tmp.open("w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except OSError as exc:
+        if exc.errno != errno.ENOSYS:
+            raise
+        tmp.unlink(missing_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            f.write(text)
 
 
 def _optional_int(value: Any) -> int | None:


### PR DESCRIPTION
Review-fixes slice 2 of 5 (8 commits): atomic_write_text (tmp+fsync+rename with an ENOSYS fallback for mountpoint-s3, probe-confirmed) replaces plain truncate-then-write repo-wide; a malformed uploaded index is a 400, never a 500; the inference proxy streams responses, forwards upstream headers (live probe caught a dropped Content-Encoding), and re-resolves a dead gateway URL; authorize is a required parameter; the trainer fails fast on a dirty transport prefix; replica polling is concurrent; ledger persistence/auth-header/smoke-payload duplication removed.

Full stack map in #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnEES5LVJpCiATG6w16QTU