### PR TITLE
stitch: corrupt control state is an error, not silently absorbed

### DIFF
--- a/cookbook/standalone_rollouts/ledger.py
+++ b/cookbook/standalone_rollouts/ledger.py
@@ -62,9 +62,17 @@ class LedgerEntry:
 class IdentityLedger:
     def __init__(self, entries: dict[str, LedgerEntry] | None = None) -> None:
         self._by_identity: dict[str, LedgerEntry] = dict(entries or {})
-        self._by_version: dict[int, str] = {
-            entry.version: identity for identity, entry in self._by_identity.items()
-        }
+        self._by_version: dict[int, str] = {}
+        for identity, entry in self._by_identity.items():
+            other = self._by_version.get(entry.version)
+            if other is not None:
+                # A persisted ledger that violates the one-identity-per-version
+                # invariant must fail loudly, not silently collapse the reverse
+                # map onto whichever entry deserialized last.
+                raise LedgerError(
+                    f"ledger maps both {other!r} and {identity!r} to version {entry.version}"
+                )
+            self._by_version[entry.version] = identity
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "IdentityLedger":

--- a/cookbook/standalone_rollouts/ledger_test.py
+++ b/cookbook/standalone_rollouts/ledger_test.py
@@ -104,6 +104,18 @@ class SerializationTest(unittest.TestCase):
         entry, _ = ledger.record("ckpt-base", previous=None)
         self.assertEqual(entry.version, 0)
 
+    def test_duplicate_versions_in_persisted_ledger_are_rejected(self) -> None:
+        # A corrupt identities.json must not silently collapse the reverse map.
+        with self.assertRaises(LedgerError):
+            IdentityLedger.from_dict(
+                {
+                    "entries": {
+                        "identity-a": {"version": 1, "previous": "base"},
+                        "identity-b": {"version": 1, "previous": "base"},
+                    }
+                }
+            )
+
     def test_entries_expose_previous(self) -> None:
         ledger = IdentityLedger({"a": LedgerEntry(version=0, previous=None)})
         self.assertEqual(ledger.to_dict()["entries"]["a"], {"version": 0, "previous": None})

--- a/src/stitch/bulletin_test.py
+++ b/src/stitch/bulletin_test.py
@@ -22,11 +22,15 @@ class SnapshotIdentityTest(unittest.TestCase):
         self.assertEqual(format_snapshot_identity(None, 5), "weight_v000005")
         self.assertEqual(parse_snapshot_identity("run-a/weight_v000005"), ("run-a", 5))
 
-    def test_parse_tolerates_bare_legacy_and_garbage(self) -> None:
+    def test_parse_tolerates_bare_and_legacy_but_rejects_garbage(self) -> None:
         self.assertEqual(parse_snapshot_identity("weight_v000005"), (None, 5))  # bare
         self.assertEqual(parse_snapshot_identity("000005"), (None, 5))  # legacy flat pointer
-        self.assertEqual(parse_snapshot_identity(""), (None, 0))  # missing -> not-ready
-        self.assertEqual(parse_snapshot_identity("garbage"), (None, 0))  # unparseable -> not-ready
+        # Corrupt pointer content is an error (replica unready), never a
+        # silent base; a *missing* pointer is handled by read_latest.
+        with self.assertRaises(ValueError):
+            parse_snapshot_identity("")
+        with self.assertRaises(ValueError):
+            parse_snapshot_identity("definitely-not-a-pointer")
 
 
 class SlimeLayoutBulletinTest(unittest.TestCase):

--- a/src/stitch/protocol.py
+++ b/src/stitch/protocol.py
@@ -403,12 +403,14 @@ def parse_snapshot_identity(text: str) -> tuple[str | None, int]:
 
     ``<run_id>/weight_v<NNNNNN>`` -> ``(run_id, version)``; a bare
     ``weight_v<NNNNNN>`` -> ``(None, version)``; a legacy raw ``<NNNNNN>`` ->
-    ``(None, version)``; empty / unparseable -> ``(None, 0)`` (treated as
-    no-valid-pointer, i.e. not-ready rather than a misparse).
+    ``(None, version)``.
+
+    Raises ``ValueError`` on empty or unparseable text: a pointer that exists
+    but cannot be read is corrupt control state, and must surface as an error
+    (replica unready), never be mistaken for the base — a *missing* pointer is
+    the caller's pre-first-publish case, not this function's.
     """
     text = (text or "").strip()
-    if not text:
-        return (None, 0)
     run_id: str | None = None
     tail = text
     if "/" in text:
@@ -418,7 +420,7 @@ def parse_snapshot_identity(text: str) -> tuple[str | None, int]:
     if version is None:
         version = int(tail) if tail.isdigit() else None
     if version is None:
-        return (None, 0)
+        raise ValueError(f"unparseable snapshot pointer: {text!r}")
     return (run_id, version)
 
 

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -301,6 +301,14 @@ class WeightSyncManager(RolloutAdmissionGate):
                     run_id, latest = self.board.read_latest()
                     self.latest_seen_version = max(self.latest_seen_version, latest)
                     queued = self.queued_target_version or 0
+                    if queued > latest:
+                        # A wake hint is only a prompt to look at the board; the
+                        # durable head is the authority. A hint the head never
+                        # reaches (stale, or from a previous incarnation) must
+                        # not pin the manager in QUEUED forever — anything
+                        # published after this pass converges via the periodic
+                        # reconcile.
+                        self.queued_target_version = queued = latest
                     if run_id != self.current_run_id or max(latest, queued) > self.current_version:
                         reached = False
             except Exception as exc:  # noqa: BLE001

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -113,6 +113,22 @@ class SyncManagerTest(unittest.TestCase):
 
         asyncio.run(run())
 
+    def test_stale_high_wake_hint_is_discarded_and_manager_goes_idle(self) -> None:
+        async def run() -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                board = FilesystemBulletinBoard(tmp)
+                manager = WeightSyncManager(board=board, engine=FakeEngine())
+
+                # A hint above anything the board will ever publish (a stale or
+                # foreign wake) must not keep the manager QUEUED forever.
+                await manager.sync_to(target_version=99)
+
+                self.assertEqual(manager.sync_state, SyncState.IDLE)
+                self.assertIsNone(manager.queued_target_version)
+                self.assertEqual(manager.current_version, 0)
+
+        asyncio.run(run())
+
     def test_sync_keeps_queued_work_that_arrives_during_commit(self) -> None:
         async def run() -> None:
             with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Review-fixes slice 3 of 5 (3 commits): persisted ledgers with duplicate versions are rejected at load, wake hints above the durable head are discarded after each pass (a stale hint pinned the manager QUEUED forever), and unparseable pointer text raises instead of parsing as the base.

Full stack map in #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnEES5LVJpCiATG6w16QTU