### PR TITLE
stitch/standalone_rollouts: fork rejection, run-switch integrity, base pin

### DIFF
--- a/cookbook/standalone_rollouts/configs/moonlight_hot_load_probe.py
+++ b/cookbook/standalone_rollouts/configs/moonlight_hot_load_probe.py
@@ -1,0 +1,8 @@
+"""Scratch probe variant of moonlight_hot_load (not for check-in): scratch app
+name + transport prefix, one replica. Deploy with PROVIDER_CONFIG=moonlight_hot_load_probe."""
+
+from cookbook.standalone_rollouts.configs.moonlight_hot_load import *  # noqa: F401,F403
+
+APP_NAME = "stitch-moonlight-api-shim-probe"
+S3_TRANSPORT_KEY_PREFIX = "standalone-rollouts/_probe-review-fixes-live"
+ROLLOUT_MIN_CONTAINERS = 1

--- a/cookbook/standalone_rollouts/frontdoor.py
+++ b/cookbook/standalone_rollouts/frontdoor.py
@@ -134,6 +134,7 @@ def create_frontdoor_app(
     proxy: Callable[..., Awaitable[Any]],
     authorize: Callable[[Any], Any],
     wake: Callable[[int], Awaitable[None]] | None = None,
+    expected_base_identity: str | None = None,
 ):
     """Build the front-door FastAPI app from injected I/O.
 
@@ -145,6 +146,12 @@ def create_frontdoor_app(
     ``None`` and is required — the app is fail-closed by construction, so a
     test that wants an open app must say so with an explicit allow-all;
     ``wake`` is a best-effort post-advance nudge.
+
+    ``expected_base_identity``, when set, pins the one identity allowed to
+    anchor a chain: a full snapshot must name it (the pool serves the booted
+    base, never a customer upload, so any other full snapshot would be silently
+    substituted), and a first delta's unknown parent must be it (anything else
+    is a typo'd or never-signalled checkpoint, not the booted base).
 
     The load-record-normalize-save-advance sequence is serialized under
     ``advance_lock`` so the singleton front door never races itself. The ledger
@@ -198,6 +205,23 @@ def create_frontdoor_app(
 
         async with advance_lock:
             ledger = IdentityLedger.from_dict(await load_ledger())
+            if expected_base_identity is not None:
+                if incremental is None and identity != expected_base_identity:
+                    return JSONResponse(
+                        {
+                            "error": f"this deployment serves base {expected_base_identity!r}; "
+                            f"full snapshot {identity!r} cannot be activated"
+                        },
+                        status_code=409,
+                    )
+                if incremental is not None and previous != expected_base_identity and ledger.version_for(previous) is None:
+                    return JSONResponse(
+                        {
+                            "error": f"previous_snapshot_identity {previous!r} is neither a "
+                            f"signalled checkpoint nor the deployment base {expected_base_identity!r}"
+                        },
+                        status_code=409,
+                    )
             try:
                 entry, is_new = ledger.record(identity, previous)
             except LedgerError as exc:

--- a/cookbook/standalone_rollouts/frontdoor_test.py
+++ b/cookbook/standalone_rollouts/frontdoor_test.py
@@ -104,7 +104,7 @@ class RouteAllowlistTest(unittest.TestCase):
 
 
 class FrontdoorAppTest(unittest.TestCase):
-    def _client(self, *, ledger: dict | None = None, authorize=None):
+    def _client(self, *, ledger: dict | None = None, authorize=None, expected_base_identity=None):
         from fastapi.testclient import TestClient
 
         from cookbook.standalone_rollouts.frontdoor import create_frontdoor_app
@@ -148,6 +148,7 @@ class FrontdoorAppTest(unittest.TestCase):
             proxy=proxy,
             authorize=authorize or (lambda headers: None),  # explicit allow-all
             wake=wake,
+            expected_base_identity=expected_base_identity,
         )
         return TestClient(app), calls, state
 
@@ -301,6 +302,26 @@ class FrontdoorAppTest(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 409)
         self.assertEqual(calls["normalized"], [])
+
+    def test_expected_base_pin_rejects_other_anchors(self) -> None:
+        client, calls, _ = self._client(expected_base_identity="base")
+        # A full snapshot that is not the deployment base cannot be served.
+        self.assertEqual(client.post(HOT_LOAD_PATH, json={"identity": "their-base"}).status_code, 409)
+        # A first delta whose unknown parent is not the base is a typo, not
+        # the booted checkpoint.
+        r = client.post(
+            HOT_LOAD_PATH,
+            json={"identity": "ckpt-1", "incremental_snapshot_metadata": {"previous_snapshot_identity": "bsae"}},
+        )
+        self.assertEqual(r.status_code, 409)
+        self.assertEqual(calls["advanced"], [])
+        # The pinned identities pass: the base itself, and a first delta on it.
+        self.assertEqual(client.post(HOT_LOAD_PATH, json={"identity": "base"}).status_code, 200)
+        r = client.post(
+            HOT_LOAD_PATH,
+            json={"identity": "ckpt-1", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base"}},
+        )
+        self.assertEqual(r.json()["version"], 1)
 
     def test_delta_forking_an_older_checkpoint_is_409(self) -> None:
         # One accepted fork would wedge every replica behind the non-contiguous

--- a/cookbook/standalone_rollouts/frontdoor_test.py
+++ b/cookbook/standalone_rollouts/frontdoor_test.py
@@ -302,6 +302,16 @@ class FrontdoorAppTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 409)
         self.assertEqual(calls["normalized"], [])
 
+    def test_delta_forking_an_older_checkpoint_is_409(self) -> None:
+        # One accepted fork would wedge every replica behind the non-contiguous
+        # version forever; reject it and leave the head serveable.
+        client, calls, _ = self._client()
+        client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
+        client.post(HOT_LOAD_PATH, json={"identity": "ckpt-1", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base-ckpt"}})
+        resp = client.post(HOT_LOAD_PATH, json={"identity": "ckpt-fork", "incremental_snapshot_metadata": {"previous_snapshot_identity": "base-ckpt"}})
+        self.assertEqual(resp.status_code, 409)
+        self.assertEqual(calls["advanced"], [0, 1])  # pointer stays at head
+
     def test_resignalling_an_older_identity_is_a_409_rewind(self) -> None:
         client, calls, _ = self._client()
         client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})

--- a/cookbook/standalone_rollouts/ledger.py
+++ b/cookbook/standalone_rollouts/ledger.py
@@ -9,12 +9,11 @@ so a version dir's index can carry ``base_version``.
 
 Because versions only ever increase, two identities never collide on a number
 and ``run_id`` is unnecessary. Re-signalling a known identity returns its
-existing version (idempotent — a retried POST is not a rewind). A delta whose
-parent is the immediately-preceding identity forms the contiguous chain the
-apply path replays; a delta against an older ancestor (training resume against
-the base) is recorded faithfully but is not yet replayable (the deferred
-fork-from-version case), so its non-contiguous base surfaces at apply time
-rather than being silently reordered here.
+existing version (idempotent — a retried POST is not a rewind). Every delta
+must extend the chain head: the apply path replays a contiguous chain, so a
+delta against an older ancestor (a fork/resume) is rejected at signal time —
+once minted, a non-contiguous version would sit in the log forever and block
+every replica from serving anything published after it.
 
 The ledger itself is pure: :meth:`to_dict` / :meth:`from_dict` round-trip the
 state. Persistence is one JSON file on the transport (``LEDGER_FILENAME``,
@@ -45,9 +44,9 @@ def load_ledger_dict(transport_root: str | Path) -> dict[str, Any]:
 
 
 class LedgerError(ValueError):
-    """A signal whose lineage cannot be recorded safely: a second full snapshot
-    (the base slot is single-occupancy) or a delta naming an unknown parent.
-    The front door reports it to the customer as a 409."""
+    """A signal whose lineage cannot be recorded (second full snapshot, unknown
+    parent, or fork from a non-head checkpoint) or a persisted ledger that
+    violates an invariant. The front door reports it as a 409."""
 
 
 @dataclass(frozen=True)
@@ -133,20 +132,19 @@ class IdentityLedger:
         moves the pointer. A new identity is minted the next monotonic version
         (``BASE_VERSION`` for the first ever, else max+1) and records ``previous``.
 
-        Raises :class:`LedgerError` on lineage that cannot be recorded safely:
-        a second full snapshot (it would take over the base's version 0), or a
-        delta naming a parent this ledger has never seen — unless the ledger is
-        empty, the one case where the parent is legitimately the booted,
-        never-signalled base. Rejecting is what keeps a typo'd parent from being
-        silently applied against the wrong base weights.
+        Raises :class:`LedgerError` on lineage the pool could not serve: a
+        second full snapshot (the base slot is single-occupancy), a parent this
+        ledger has never seen (typo'd or lost signals would otherwise be applied
+        against the wrong base weights), or a known parent that is not the chain
+        head (fork/resume — unsupported, and a non-contiguous version would
+        permanently block the replay of everything after it). The one sanctioned
+        unknown parent is a first delta on an empty ledger, whose base booted
+        from BASE_CHECKPOINT and was never signalled.
         """
         existing = self._by_identity.get(identity)
         if existing is not None:
             return existing, False
         if previous is None:
-            # A full snapshot is the base (version 0), whether the customer
-            # pre-uploaded and signalled it or the pool booted it from
-            # BASE_CHECKPOINT. The base slot is single-occupancy.
             claimed = self._by_version.get(BASE_VERSION)
             if claimed is not None:
                 raise LedgerError(
@@ -154,10 +152,16 @@ class IdentityLedger:
                 )
             version = BASE_VERSION
         else:
-            if previous not in self._by_identity and self._by_identity:
+            parent = self._by_identity.get(previous)
+            if parent is None and self._by_identity:
                 raise LedgerError(
                     f"previous_snapshot_identity {previous!r} was never signalled; "
                     "signal the parent checkpoint first"
+                )
+            if parent is not None and parent.version != max(self._by_version):
+                raise LedgerError(
+                    f"previous_snapshot_identity {previous!r} is not the latest checkpoint; "
+                    "forking from an older checkpoint is not supported"
                 )
             # A delta always mints a real version >= 1; v0 is reserved for the
             # base, so a delta signalled before any base (its parent booted, not

--- a/cookbook/standalone_rollouts/ledger_test.py
+++ b/cookbook/standalone_rollouts/ledger_test.py
@@ -32,17 +32,18 @@ class RecordTest(unittest.TestCase):
         # No phantom version was minted for the duplicate.
         self.assertIsNone(ledger.identity_for(2))
 
-    def test_resume_against_base_records_true_non_contiguous_lineage(self) -> None:
-        # A delta whose parent is the original base while the chain is at v2:
-        # version is still monotonic (v3), but base_version records the real
-        # parent (0), so the non-contiguity is visible to the apply path.
+    def test_fork_from_non_head_parent_is_rejected(self) -> None:
+        # A minted non-contiguous version would permanently block the linear
+        # replay of everything after it, so a fork is refused at signal time.
         ledger = IdentityLedger()
         ledger.record("ckpt-base", previous=None)
         ledger.record("ckpt-100", previous="ckpt-base")
         ledger.record("ckpt-200", previous="ckpt-100")
-        resume, _ = ledger.record("ckpt-resume", previous="ckpt-base")
-        self.assertEqual(resume.version, 3)
-        self.assertEqual(ledger.base_version_for("ckpt-resume"), 0)
+        with self.assertRaises(LedgerError):
+            ledger.record("ckpt-resume", previous="ckpt-base")
+        # The head is untouched and still extendable.
+        entry, _ = ledger.record("ckpt-300", previous="ckpt-200")
+        self.assertEqual(entry.version, 3)
 
     def test_delta_before_any_base_mints_v1_not_v0(self) -> None:
         # A delta whose parent was never signalled (the base booted from

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -329,7 +329,8 @@ def print_secret_template() -> None:
                 f"modal secret create {exp.SHIM_SECRET_NAME} \\",
                 "  STITCH_SHIM_API_KEY=... \\",
                 "  STITCH_SHIM_PROVIDER_MODEL=moonlight \\",
-                "  STITCH_SHIM_PROVIDER_DEPLOYMENT=rollout-prod",
+                "  STITCH_SHIM_PROVIDER_DEPLOYMENT=rollout-prod \\",
+                "  STITCH_SHIM_BASE_SNAPSHOT_IDENTITY=base",
             ]
         )
     )
@@ -578,6 +579,9 @@ class FrontDoor:
             proxy=proxy,
             authorize=_auth_error,
             wake=wake,
+            # Same var the trainer uses for its first delta's parent, so one
+            # secret pins both sides; unset disables the pin.
+            expected_base_identity=os.environ.get("STITCH_SHIM_BASE_SNAPSHOT_IDENTITY"),
         )
         config = uvicorn.Config(
             asgi_app, host="0.0.0.0", port=FRONTDOOR_PORT, log_level="info"

--- a/cookbook/standalone_rollouts/simulator_test.py
+++ b/cookbook/standalone_rollouts/simulator_test.py
@@ -198,6 +198,37 @@ class SimulatorTest(unittest.IsolatedAsyncioTestCase):
                     await mgr.sync_to()
                     self.assertEqual(mgr.current_version, 0)
 
+    async def test_fork_signal_is_409_and_pool_keeps_converging(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            transport, managers, _, client = await self._stack(tmp, n_replicas=1)
+            async with client:
+                _upload_plain_hf_checkpoint(transport, "base-ckpt")
+                await client.post(HOT_LOAD_PATH, json={"identity": "base-ckpt"})
+                _upload_plain_hf_checkpoint(transport, "ckpt-100")
+                delta = lambda ident, prev: {
+                    "identity": ident,
+                    "incremental_snapshot_metadata": {"previous_snapshot_identity": prev},
+                }
+                await client.post(HOT_LOAD_PATH, json=delta("ckpt-100", "base-ckpt"))
+                for mgr in managers:
+                    await mgr.sync_to()
+                    self.assertEqual(mgr.current_version, 1)
+
+                # A fork off the base is refused; nothing enters the log.
+                _upload_plain_hf_checkpoint(transport, "ckpt-fork")
+                r = await client.post(HOT_LOAD_PATH, json=delta("ckpt-fork", "base-ckpt"))
+                self.assertEqual(r.status_code, 409)
+
+                # The chain head still extends and the pool still converges —
+                # an accepted fork would have wedged replicas at v1 forever.
+                _upload_plain_hf_checkpoint(transport, "ckpt-200")
+                r = await client.post(HOT_LOAD_PATH, json=delta("ckpt-200", "ckpt-100"))
+                self.assertEqual(r.json()["version"], 2)
+                for mgr in managers:
+                    await mgr.sync_to()
+                    self.assertEqual(mgr.current_version, 2)
+                    self.assertIsNone(mgr.last_sync_error)
+
     async def test_malformed_uploaded_index_is_400_not_500(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             transport, _, _, client = await self._stack(tmp)

--- a/src/stitch/engines/sglang.py
+++ b/src/stitch/engines/sglang.py
@@ -103,18 +103,22 @@ class SGLangDiskDeltaAdapter:
         )
 
     async def reset(self) -> None:
-        """Discard the local checkpoint and re-materialize the base from scratch.
+        """Discard the local checkpoint, re-materialize the base, and reload it
+        into the engine.
 
         Used on a run switch: the new run's chain forks at base, so the locally
-        patched checkpoint must be thrown away before replaying the new chain. The
-        sync manager invokes this under the commit gate (engine paused), so no
-        request decodes across the wipe; ``prepare`` then rebuilds a complete base
-        (a partial wipe from a crash is re-seeded by ``init_local_checkpoint``).
+        patched checkpoint is thrown away before replaying the new chain. The
+        engine reload is what makes the manager's post-reset identity (new run,
+        v0) true on the GPU — without it the engine would keep serving the old
+        run's weights while readiness reported base. The sync manager invokes
+        this under the commit gate with the engine paused, the same conditions
+        as an ordinary version commit's reload.
         """
         import shutil
 
         await asyncio.to_thread(shutil.rmtree, self.local_checkpoint_dir, ignore_errors=True)
         await self.prepare()
+        await self._reload_from_disk(weight_version="0")
 
     async def flush_cache(self) -> None:
         import httpx
@@ -178,14 +182,26 @@ class SGLangDiskDeltaAdapter:
         engine with the reload load plan uses it to reload only the touched
         modules (O(delta)) and silently full-reloads otherwise. Set
         ``STITCH_PARTIAL_RELOAD=0`` to withhold the names entirely."""
+        _t_reload = time.perf_counter()
+        data = await self._reload_from_disk(
+            weight_version=str(manifest.version), weight_names=weight_names
+        )
+        elapsed = time.perf_counter() - _t_reload
+        logger.info("[apply timing] v=%s engine_reload=%.2fs", manifest.version, elapsed)
+        detail: dict[str, Any] = {"engine_reload_s": round(elapsed, 3)}
+        detail.update(parse_reload_timing(str(data.get("message") or "")))
+        return detail
+
+    async def _reload_from_disk(
+        self, *, weight_version: str, weight_names: list[str] | None = None
+    ) -> dict[str, Any]:
         import os
 
         import httpx
 
-        _t_reload = time.perf_counter()
         payload: dict[str, Any] = {
             "model_path": self.local_checkpoint_dir,
-            "weight_version": str(manifest.version),
+            "weight_version": weight_version,
             # The sync manager flushes via GET /flush_cache while quiesced.
             # The engine-side post-apply flush hard-asserts on failure
             # (killing the scheduler process) if any request slipped in, so
@@ -200,11 +216,7 @@ class SGLangDiskDeltaAdapter:
             data = resp.json()
             if data.get("success") is False:
                 raise RuntimeError(f"SGLang rejected weight update: {data}")
-        elapsed = time.perf_counter() - _t_reload
-        logger.info("[apply timing] v=%s engine_reload=%.2fs", manifest.version, elapsed)
-        detail: dict[str, Any] = {"engine_reload_s": round(elapsed, 3)}
-        detail.update(parse_reload_timing(str(data.get("message") or "")))
-        return detail
+        return data
 
     async def apply_manifest(self, manifest: VersionManifest, version_path: str) -> None:
         """Combined stage + reload, kept for callers that don't use the staged

--- a/src/stitch/engines/sglang_test.py
+++ b/src/stitch/engines/sglang_test.py
@@ -99,6 +99,31 @@ class SGLangDiskDeltaAdapterTest(unittest.TestCase):
 
         asyncio.run(run())
 
+    def test_reset_rematerializes_base_and_reloads_engine(self) -> None:
+        # The manager relabels to (new run, v0) after reset returns, so reset
+        # must leave the GPU actually serving the base — not just rebuild the
+        # host copy while the engine keeps the old run's weights.
+        async def run() -> None:
+            calls: dict[str, list] = {"init": []}
+            adapter = SGLangDiskDeltaAdapter(
+                upstream_url="http://up",
+                local_checkpoint_dir="/nonexistent-local",
+                base_checkpoint_dir="/base",
+                init_local_checkpoint=lambda local, base: calls["init"].append((local, base)),
+            )
+            with mock.patch("httpx.AsyncClient", _RecordingPost):
+                _RecordingPost.last_json = None
+                await adapter.reset()
+
+            self.assertEqual(calls["init"], [("/nonexistent-local", "/base")])
+            self.assertEqual(_RecordingPost.last_url, "http://up/update_weights_from_disk")
+            self.assertEqual(
+                _RecordingPost.last_json,
+                {"model_path": "/nonexistent-local", "weight_version": "0", "flush_cache": False},
+            )
+
+        asyncio.run(run())
+
     def test_staged_split_reports_metrics(self) -> None:
         async def run() -> None:
             apply_stats = [{"version": "000005", "apply_s": 1.2}]

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -163,6 +163,7 @@ class RolloutAdmissionGate:
         on_applied: Callable[[], None],
         pause: Callable[[], Awaitable[None]] | None = None,
         resume: Callable[[], Awaitable[None]] | None = None,
+        drain_all: bool = False,
     ) -> None:
         """Drive one commit through the gate: wait for the commit point and
         close the admission gate, apply the new weights, advance the served
@@ -173,8 +174,13 @@ class RolloutAdmissionGate:
         the new namespace. On failure the gate (and pause) are unwound and the
         served version is left unchanged — ``on_applied`` runs only after a
         successful apply.
+
+        ``drain_all`` waits for every in-flight request regardless of commit
+        mode, for transitions no request may span (a run switch replaces the
+        base rather than extending the chain a rolling request admitted on).
         """
-        await self._begin_commit(self._commit_ready)
+        ready = (lambda: self._active_requests == 0) if drain_all else self._commit_ready
+        await self._begin_commit(ready)
         try:
             if self.commit_mode == "in_place" and pause is not None:
                 await pause()
@@ -328,9 +334,13 @@ class WeightSyncManager(RolloutAdmissionGate):
 
         A new run forks at base (slime sets ``base_version=000000`` for v1 of every
         run), so switching chains means discarding the current weights and replaying
-        the new chain. The re-materialize runs through the commit gate (pause →
-        reset → resume) exactly like a version commit, so no in-flight request
-        decodes across the weight wipe.
+        the new chain. Unlike a same-chain delta commit this drains ALL in-flight
+        requests in both commit modes — a rolling request may span chain
+        extensions, never a base swap. Reset runs whenever this process may have
+        touched the checkpoint (any applied version, or a failed pass whose
+        host-side staging landed without a commit); only the pristine cold-start
+        switch skips it, so container boot does not pay a redundant
+        re-materialize + reload.
         """
         logger.info(
             "run change %r -> %r: re-materializing base, resetting to v0",
@@ -338,10 +348,10 @@ class WeightSyncManager(RolloutAdmissionGate):
             new_run_id,
         )
         reset = getattr(self.engine, "reset", None)
-        was_patched = self.current_version > 0
+        maybe_dirty = self.current_version > 0 or self.last_sync_error is not None
 
         async def _apply() -> None:
-            if reset is not None and was_patched:
+            if reset is not None and maybe_dirty:
                 await reset()
 
         def _applied() -> None:
@@ -355,6 +365,7 @@ class WeightSyncManager(RolloutAdmissionGate):
             on_applied=_applied,
             pause=self.engine.pause_generation,
             resume=self.engine.continue_generation,
+            drain_all=True,
         )
 
     async def _sync_once(self) -> bool:

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -46,6 +46,7 @@ class FakeEngine:
         self.events: list[str] = []
         self.apply_gate: asyncio.Event | None = None
         self.apply_started: asyncio.Event = asyncio.Event()
+        self.fail_next_apply = False
 
     async def flush_cache(self) -> None:
         self.flushes += 1
@@ -55,6 +56,9 @@ class FakeEngine:
         self.apply_started.set()
         if self.apply_gate is not None:
             await self.apply_gate.wait()
+        if self.fail_next_apply:
+            self.fail_next_apply = False
+            raise RuntimeError("injected apply failure")
         self.applies.append((manifest.version, version_path))
         self.events.append("apply")
 
@@ -152,6 +156,74 @@ class SyncManagerTest(unittest.TestCase):
                 self.assertEqual(manager.sync_state, SyncState.IDLE)
                 self.assertIsNone(manager.queued_target_version)
                 self.assertEqual([version for version, _ in engine.applies], [1, 2])
+
+        asyncio.run(run())
+
+    def test_run_switch_drains_rolling_requests_in_in_place_mode(self) -> None:
+        # A rolling request may span same-chain delta commits, but never a base
+        # swap: the switch waits for ALL in-flight requests, not just exact pins.
+        async def run() -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                board = FilesystemBulletinBoard(root, layout="slime")
+                _write_slime_version(root / "run-a", 1, 0)
+                board.write_latest("run-a", 1)
+                engine = FakeEngine()
+                manager = WeightSyncManager(board=board, engine=engine, commit_mode="in_place")
+                await manager.startup_sync()
+
+                entered = asyncio.Event()
+                release = asyncio.Event()
+
+                async def rolling() -> None:
+                    async with manager.request_context(WeightVersionPolicy()):
+                        entered.set()
+                        await release.wait()
+
+                request = asyncio.create_task(rolling())
+                await entered.wait()
+
+                board.write_latest("run-b", 0)
+                switch = asyncio.create_task(manager.sync_to())
+                await _settle()
+                # Blocked on the rolling request; the old chain is still live.
+                self.assertEqual(manager.current_run_id, "run-a")
+                self.assertNotIn("reset", engine.events)
+
+                release.set()
+                await request
+                await switch
+                self.assertEqual(manager.current_run_id, "run-b")
+                self.assertIn("reset", engine.events)
+
+        asyncio.run(run())
+
+    def test_run_switch_resets_after_failed_pass_even_at_v0(self) -> None:
+        # Staging is host-side and pre-gate, so a failed pass can leave the
+        # local checkpoint dirty while the served version is still 0. A switch
+        # in that state must re-materialize; only a pristine cold-start switch
+        # (no version applied, no failed pass) skips the reset.
+        async def run() -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                board = FilesystemBulletinBoard(root, layout="slime")
+                board.write_latest("run-a", 0)
+                engine = FakeEngine()
+                manager = WeightSyncManager(board=board, engine=engine, commit_mode="in_place")
+                await manager.startup_sync()
+                self.assertNotIn("reset", engine.events)  # pristine switch
+
+                _write_slime_version(root / "run-a", 1, 0)
+                board.write_latest("run-a", 1)
+                engine.fail_next_apply = True
+                await manager.sync_to()
+                self.assertEqual(manager.sync_state, SyncState.ERROR)
+                self.assertEqual(manager.current_version, 0)
+
+                board.write_latest("run-b", 0)
+                await manager.sync_to()
+                self.assertEqual(manager.current_run_id, "run-b")
+                self.assertIn("reset", engine.events)
 
         asyncio.run(run())
 


### PR DESCRIPTION
Review-fixes slice 4 of 5 (4 commits): a delta forking from a non-head checkpoint is a 409 at signal time (an accepted fork permanently wedged every replica behind the non-contiguous version — confirmed by execution); a run switch drains ALL in-flight requests in both commit modes and resets whenever the process may have dirtied the host checkpoint; reset() reloads the rebuilt base into the engine so post-switch identity is backed by an actual GPU load; STITCH_SHIM_BASE_SNAPSHOT_IDENTITY pins the one identity allowed to anchor a chain (validated live).

Full stack map in #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnEES5LVJpCiATG6w16QTU