### PR TITLE
fix(stitch): make slime latest writes backend-safe

### DIFF
--- a/src/stitch/bulletin_test.py
+++ b/src/stitch/bulletin_test.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import errno
 import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from stitch.bulletin import FilesystemBulletinBoard
 from stitch.protocol import (
@@ -87,6 +89,35 @@ class SlimeLayoutBulletinTest(unittest.TestCase):
             board.write_latest(None, 7)
             self.assertEqual((root / "latest").read_text(encoding="utf-8"), "weight_v000007")
             self.assertEqual(board.read_latest(), (None, 7))
+
+    def test_write_latest_falls_back_when_backend_cannot_rename(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            board = FilesystemBulletinBoard(root, layout="slime")
+
+            with mock.patch(
+                "stitch.protocol.os.replace",
+                side_effect=OSError(errno.ENOSYS, "rename"),
+            ):
+                board.write_latest("run-a", 7)
+
+            self.assertEqual((root / "latest").read_text(encoding="utf-8"), "run-a/weight_v000007")
+            self.assertFalse((root / "latest.tmp").exists())
+
+    def test_write_latest_does_not_hide_other_rename_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            board = FilesystemBulletinBoard(root, layout="slime")
+            board.write_latest("run-a", 6)
+
+            with mock.patch(
+                "stitch.protocol.os.replace",
+                side_effect=OSError(errno.EACCES, "rename"),
+            ):
+                with self.assertRaisesRegex(OSError, "rename"):
+                    board.write_latest("run-a", 7)
+
+            self.assertEqual((root / "latest").read_text(), "run-a/weight_v000006")
 
     def test_legacy_bare_pointer_parses_runless(self) -> None:
         # A pre-run-id deployment left `latest` = "000005"; it must parse as a

--- a/src/stitch/protocol.py
+++ b/src/stitch/protocol.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import time
@@ -565,14 +566,27 @@ def atomic_write_json(path: str | Path, payload: dict[str, Any]) -> None:
 
 
 def atomic_write_text(path: str | Path, text: str) -> None:
+    """Write text atomically on local filesystems and Mountpoint-backed S3.
+
+    Local filesystems use a flushed temporary file and atomic rename. Mountpoint
+    does not implement rename, but closing an in-place write publishes one S3
+    object atomically, so ``ENOSYS`` falls back to that backend-specific path.
+    """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(path.name + ".tmp")
-    with tmp.open("w", encoding="utf-8") as f:
-        f.write(text)
-        f.flush()
-        os.fsync(f.fileno())
-    os.replace(tmp, path)
+    try:
+        with tmp.open("w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except OSError as exc:
+        if exc.errno != errno.ENOSYS:
+            raise
+        tmp.unlink(missing_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            f.write(text)
 
 
 def _optional_int(value: Any) -> int | None:


### PR DESCRIPTION
## Summary

Add a control-file writer that uses fsync plus rename locally and falls back only when Mountpoint reports ENOSYS. Use it for the SLIME latest pointer.

## Why

The protocol commit pointer must be publishable on the S3 Mountpoint backend without masking unrelated write failures.

## Validation

- Focused coverage: `src/stitch/bulletin_test.py`
- Stack tip: `uv run pytest` (170 passed)

## Stack

PR 1 of 14. Base: `main`. Next: `rewrite-2-fail-closed-pointer`.