### PR TITLE
fix(stitch): treat corrupt snapshot pointers as control-state errors

### DIFF
--- a/src/stitch/bulletin.py
+++ b/src/stitch/bulletin.py
@@ -91,8 +91,9 @@ class FilesystemBulletinBoard:
         """The active snapshot pointer as ``(run_id, version)``.
 
         slime: parse ``<run_id>/weight_v{N}`` (or a bare/legacy pointer) from the
-        ``latest`` file; missing/empty/unparseable -> ``(None, 0)``. stitch: the
-        JSON pointer is run-less, so ``(None, <version>)``.
+        ``latest`` file; a missing pointer means ``(None, 0)``, while corrupt
+        content raises. stitch: the JSON pointer is run-less, so
+        ``(None, <version>)``.
         """
         if self.layout == "slime":
             path = self.root / "latest"

--- a/src/stitch/bulletin_test.py
+++ b/src/stitch/bulletin_test.py
@@ -22,11 +22,12 @@ class SnapshotIdentityTest(unittest.TestCase):
         self.assertEqual(format_snapshot_identity(None, 5), "weight_v000005")
         self.assertEqual(parse_snapshot_identity("run-a/weight_v000005"), ("run-a", 5))
 
-    def test_parse_tolerates_bare_legacy_and_garbage(self) -> None:
+    def test_parse_tolerates_bare_legacy_and_rejects_corruption(self) -> None:
         self.assertEqual(parse_snapshot_identity("weight_v000005"), (None, 5))  # bare
         self.assertEqual(parse_snapshot_identity("000005"), (None, 5))  # legacy flat pointer
-        self.assertEqual(parse_snapshot_identity(""), (None, 0))  # missing -> not-ready
-        self.assertEqual(parse_snapshot_identity("garbage"), (None, 0))  # unparseable -> not-ready
+        for text in ("", "garbage", "run-a/not-a-version"):
+            with self.subTest(text=text), self.assertRaises(ValueError):
+                parse_snapshot_identity(text)
 
 
 class SlimeLayoutBulletinTest(unittest.TestCase):
@@ -73,6 +74,14 @@ class SlimeLayoutBulletinTest(unittest.TestCase):
     def test_read_latest_absent_is_none_zero(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             self.assertEqual(FilesystemBulletinBoard(Path(tmp), layout="slime").read_latest(), (None, 0))
+
+    def test_read_latest_rejects_corrupt_existing_pointer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "latest").write_text("garbage", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "unparseable snapshot pointer"):
+                FilesystemBulletinBoard(root, layout="slime").read_latest()
 
     def test_write_latest_run_id_round_trips(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/src/stitch/protocol.py
+++ b/src/stitch/protocol.py
@@ -392,12 +392,10 @@ def parse_snapshot_identity(text: str) -> tuple[str | None, int]:
 
     ``<run_id>/weight_v<NNNNNN>`` -> ``(run_id, version)``; a bare
     ``weight_v<NNNNNN>`` -> ``(None, version)``; a legacy raw ``<NNNNNN>`` ->
-    ``(None, version)``; empty / unparseable -> ``(None, 0)`` (treated as
-    no-valid-pointer, i.e. not-ready rather than a misparse).
+    ``(None, version)``. Empty or unparseable content is corrupt control state;
+    callers handle a missing pointer before invoking this parser.
     """
     text = (text or "").strip()
-    if not text:
-        return (None, 0)
     run_id: str | None = None
     tail = text
     if "/" in text:
@@ -407,7 +405,7 @@ def parse_snapshot_identity(text: str) -> tuple[str | None, int]:
     if version is None:
         version = int(tail) if tail.isdigit() else None
     if version is None:
-        return (None, 0)
+        raise ValueError(f"unparseable snapshot pointer: {text!r}")
     return (run_id, version)
 
 
@@ -491,7 +489,13 @@ def read_latest(root: str | Path) -> int:
         return 0
     with path.open("r", encoding="utf-8") as f:
         data = json.load(f)
-    return int(data.get("version", 0))
+    if (
+        not isinstance(data, dict)
+        or type(data.get("version")) is not int
+        or data["version"] < 0
+    ):
+        raise ValueError(f"invalid latest pointer at {path}: expected a non-negative integer version")
+    return data["version"]
 
 
 def write_latest(root: str | Path, version: int) -> None:

--- a/src/stitch/protocol_test.py
+++ b/src/stitch/protocol_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -57,6 +58,18 @@ class DecidePointerMoveTest(unittest.TestCase):
 
 
 class ProtocolTest(unittest.TestCase):
+    def test_read_latest_distinguishes_missing_from_corrupt_pointer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertEqual(read_latest(root), 0)
+
+            latest = root / "latest.json"
+            for payload in ({}, {"version": "3"}, {"version": True}, {"version": -1}, []):
+                with self.subTest(payload=payload):
+                    latest.write_text(json.dumps(payload), encoding="utf-8")
+                    with self.assertRaisesRegex(ValueError, "invalid latest pointer"):
+                        read_latest(root)
+
     def test_manifest_round_trips_extended_and_legacy_fields(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -95,8 +108,6 @@ class ProtocolTest(unittest.TestCase):
             self.assertEqual(loaded.checksum_format, "xxh3-128")
 
     def test_manifest_from_slime_index(self) -> None:
-        import json
-
         with tempfile.TemporaryDirectory() as tmp:
             version_dir = Path(tmp) / "weight_v000007"
             version_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Make malformed SLIME and JSON latest pointers fail closed while preserving the missing-pointer base case.

## Why

Treating corrupt control state as version zero can silently serve or extend the wrong weights.

## Validation

- Focused coverage: `src/stitch/bulletin_test.py and src/stitch/protocol_test.py`
- Stack tip: `uv run pytest` (170 passed)

## Stack

PR 2 of 14. Base: `rewrite-1-backend-safe-latest`. Next: `rewrite-3-run-switch-atomicity`.