### PR TITLE
fix(stitch): make run switches admission-atomic

### DIFF
--- a/src/stitch/engines/sglang.py
+++ b/src/stitch/engines/sglang.py
@@ -103,18 +103,18 @@ class SGLangDiskDeltaAdapter:
         )
 
     async def reset(self) -> None:
-        """Discard the local checkpoint and re-materialize the base from scratch.
+        """Re-materialize the base checkpoint and reload it into the engine.
 
         Used on a run switch: the new run's chain forks at base, so the locally
-        patched checkpoint must be thrown away before replaying the new chain. The
-        sync manager invokes this under the commit gate (engine paused), so no
-        request decodes across the wipe; ``prepare`` then rebuilds a complete base
-        (a partial wipe from a crash is re-seeded by ``init_local_checkpoint``).
+        patched checkpoint must be discarded before replaying the new chain. The
+        reload makes the manager's post-reset v0 identity true on the GPU, not just
+        on the host filesystem.
         """
         import shutil
 
         await asyncio.to_thread(shutil.rmtree, self.local_checkpoint_dir, ignore_errors=True)
         await self.prepare()
+        await self._reload_from_disk(weight_version="0")
 
     async def flush_cache(self) -> None:
         import httpx
@@ -178,14 +178,26 @@ class SGLangDiskDeltaAdapter:
         engine with the reload load plan uses it to reload only the touched
         modules (O(delta)) and silently full-reloads otherwise. Set
         ``STITCH_PARTIAL_RELOAD=0`` to withhold the names entirely."""
+        _t_reload = time.perf_counter()
+        data = await self._reload_from_disk(
+            weight_version=str(manifest.version), weight_names=weight_names
+        )
+        elapsed = time.perf_counter() - _t_reload
+        logger.info("[apply timing] v=%s engine_reload=%.2fs", manifest.version, elapsed)
+        detail: dict[str, Any] = {"engine_reload_s": round(elapsed, 3)}
+        detail.update(parse_reload_timing(str(data.get("message") or "")))
+        return detail
+
+    async def _reload_from_disk(
+        self, *, weight_version: str, weight_names: list[str] | None = None
+    ) -> dict[str, Any]:
         import os
 
         import httpx
 
-        _t_reload = time.perf_counter()
         payload: dict[str, Any] = {
             "model_path": self.local_checkpoint_dir,
-            "weight_version": str(manifest.version),
+            "weight_version": weight_version,
             # The sync manager flushes via GET /flush_cache while quiesced.
             # The engine-side post-apply flush hard-asserts on failure
             # (killing the scheduler process) if any request slipped in, so
@@ -200,11 +212,7 @@ class SGLangDiskDeltaAdapter:
             data = resp.json()
             if data.get("success") is False:
                 raise RuntimeError(f"SGLang rejected weight update: {data}")
-        elapsed = time.perf_counter() - _t_reload
-        logger.info("[apply timing] v=%s engine_reload=%.2fs", manifest.version, elapsed)
-        detail: dict[str, Any] = {"engine_reload_s": round(elapsed, 3)}
-        detail.update(parse_reload_timing(str(data.get("message") or "")))
-        return detail
+        return data
 
     async def apply_manifest(self, manifest: VersionManifest, version_path: str) -> None:
         """Combined stage + reload, kept for callers that don't use the staged

--- a/src/stitch/engines/sglang_test.py
+++ b/src/stitch/engines/sglang_test.py
@@ -99,6 +99,33 @@ class SGLangDiskDeltaAdapterTest(unittest.TestCase):
 
         asyncio.run(run())
 
+    def test_reset_rematerializes_base_and_reloads_engine(self) -> None:
+        async def run() -> None:
+            calls: list[tuple[str, str]] = []
+            adapter = SGLangDiskDeltaAdapter(
+                upstream_url="http://up",
+                local_checkpoint_dir="/nonexistent-local",
+                base_checkpoint_dir="/base",
+                init_local_checkpoint=lambda local, base: calls.append((local, base)),
+            )
+
+            with mock.patch("httpx.AsyncClient", _RecordingPost):
+                _RecordingPost.last_json = None
+                await adapter.reset()
+
+            self.assertEqual(calls, [("/nonexistent-local", "/base")])
+            self.assertEqual(_RecordingPost.last_url, "http://up/update_weights_from_disk")
+            self.assertEqual(
+                _RecordingPost.last_json,
+                {
+                    "model_path": "/nonexistent-local",
+                    "weight_version": "0",
+                    "flush_cache": False,
+                },
+            )
+
+        asyncio.run(run())
+
     def test_staged_split_reports_metrics(self) -> None:
         async def run() -> None:
             apply_stats = [{"version": "000005", "apply_s": 1.2}]

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -70,6 +70,7 @@ class RolloutAdmissionGate:
         self._active_cond = asyncio.Condition()
         self._active_requests = 0
         self._committing = False
+        self._block_all_admissions = False
         # Exact-version pins in flight, summed across versions, so a commit can
         # wait for strict traffic to drain. Tracked on the gate (not per
         # subclass) so the bulletin-board manager and the hot-load shim share
@@ -85,6 +86,8 @@ class RolloutAdmissionGate:
         return {str(version): count for version, count in sorted(self._exact_inflight.items()) if count}
 
     def _admission_gated(self, policy: WeightVersionPolicy) -> bool:
+        if self._block_all_admissions:
+            return True
         if not self._committing:
             return False
         if self.commit_mode == "in_place":
@@ -144,16 +147,33 @@ class RolloutAdmissionGate:
                 self._on_release(policy)
                 self._active_cond.notify_all()
 
-    async def _begin_commit(self, ready: Callable[[], bool]) -> None:
+    async def _begin_commit(
+        self, ready: Callable[[], bool], *, block_all_admissions: bool = False
+    ) -> None:
         """Wait for the quiesce predicate, then close the admission gate under
-        the same lock acquisition (so no request slips in between)."""
-        async with self._active_cond:
-            await self._active_cond.wait_for(ready)
-            self._committing = True
+        the same lock acquisition (so no request slips in between).
 
-    async def _end_commit(self) -> None:
+        A base switch sets ``block_all_admissions`` before waiting for active
+        requests to drain. That barrier is distinct from the ordinary in-place
+        commit gate, which intentionally permits non-strict rolling requests.
+        """
+        async with self._active_cond:
+            if block_all_admissions:
+                self._block_all_admissions = True
+            try:
+                await self._active_cond.wait_for(ready)
+                self._committing = True
+            except BaseException:
+                if block_all_admissions:
+                    self._block_all_admissions = False
+                    self._active_cond.notify_all()
+                raise
+
+    async def _end_commit(self, *, block_all_admissions: bool = False) -> None:
         async with self._active_cond:
             self._committing = False
+            if block_all_admissions:
+                self._block_all_admissions = False
             self._active_cond.notify_all()
 
     async def commit_version(
@@ -163,6 +183,7 @@ class RolloutAdmissionGate:
         on_applied: Callable[[], None],
         pause: Callable[[], Awaitable[None]] | None = None,
         resume: Callable[[], Awaitable[None]] | None = None,
+        drain_all: bool = False,
     ) -> None:
         """Drive one commit through the gate: wait for the commit point and
         close the admission gate, apply the new weights, advance the served
@@ -173,8 +194,13 @@ class RolloutAdmissionGate:
         the new namespace. On failure the gate (and pause) are unwound and the
         served version is left unchanged — ``on_applied`` runs only after a
         successful apply.
+
+        ``drain_all`` closes admission for every policy before waiting for all
+        active requests to finish, then holds that barrier through the commit.
+        It is used for run switches, where no request may span the base swap.
         """
-        await self._begin_commit(self._commit_ready)
+        ready = (lambda: self._active_requests == 0) if drain_all else self._commit_ready
+        await self._begin_commit(ready, block_all_admissions=drain_all)
         try:
             if self.commit_mode == "in_place" and pause is not None:
                 await pause()
@@ -188,7 +214,7 @@ class RolloutAdmissionGate:
                 await apply()
                 on_applied()
         finally:
-            await self._end_commit()
+            await self._end_commit(block_all_admissions=drain_all)
 
 
 class WeightSyncManager(RolloutAdmissionGate):
@@ -320,9 +346,10 @@ class WeightSyncManager(RolloutAdmissionGate):
 
         A new run forks at base (slime sets ``base_version=000000`` for v1 of every
         run), so switching chains means discarding the current weights and replaying
-        the new chain. The re-materialize runs through the commit gate (pause →
-        reset → resume) exactly like a version commit, so no in-flight request
-        decodes across the weight wipe.
+        the new chain. The switch blocks all new admissions before draining every
+        in-flight request, then holds that barrier through pause, reset, and resume.
+        Reset also runs after a failed pass that may have dirtied host-side staging,
+        even if the served version never advanced from v0.
         """
         logger.info(
             "run change %r -> %r: re-materializing base, resetting to v0",
@@ -330,10 +357,12 @@ class WeightSyncManager(RolloutAdmissionGate):
             new_run_id,
         )
         reset = getattr(self.engine, "reset", None)
-        was_patched = self.current_version > 0
+        maybe_dirty = self.current_version > 0 or self.last_sync_error is not None
 
         async def _apply() -> None:
-            if reset is not None and was_patched:
+            if maybe_dirty and reset is None:
+                raise RuntimeError("engine adapter cannot reset a dirty checkpoint on run switch")
+            if maybe_dirty:
                 await reset()
 
         def _applied() -> None:
@@ -347,6 +376,7 @@ class WeightSyncManager(RolloutAdmissionGate):
             on_applied=_applied,
             pause=self.engine.pause_generation,
             resume=self.engine.continue_generation,
+            drain_all=True,
         )
 
     async def _sync_once(self) -> bool:

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -46,6 +46,9 @@ class FakeEngine:
         self.events: list[str] = []
         self.apply_gate: asyncio.Event | None = None
         self.apply_started: asyncio.Event = asyncio.Event()
+        self.fail_next_apply = False
+        self.reset_gate: asyncio.Event | None = None
+        self.reset_started = asyncio.Event()
 
     async def flush_cache(self) -> None:
         self.flushes += 1
@@ -55,10 +58,16 @@ class FakeEngine:
         self.apply_started.set()
         if self.apply_gate is not None:
             await self.apply_gate.wait()
+        if self.fail_next_apply:
+            self.fail_next_apply = False
+            raise RuntimeError("injected apply failure")
         self.applies.append((manifest.version, version_path))
         self.events.append("apply")
 
     async def reset(self) -> None:
+        self.reset_started.set()
+        if self.reset_gate is not None:
+            await self.reset_gate.wait()
         self.events.append("reset")
 
     async def pause_generation(self) -> None:
@@ -93,6 +102,44 @@ class StagedEngine(FakeEngine):
 
 
 class SyncManagerTest(unittest.TestCase):
+    def test_cancelled_run_switch_drain_reopens_admission(self) -> None:
+        async def run() -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                manager = WeightSyncManager(
+                    board=FilesystemBulletinBoard(tmp),
+                    engine=FakeEngine(),
+                    commit_mode="in_place",
+                )
+                existing = manager.request_context()
+                await existing.__aenter__()
+
+                async def apply() -> None:
+                    raise AssertionError("commit must still be draining")
+
+                commit = asyncio.create_task(
+                    manager.commit_version(
+                        apply=apply,
+                        on_applied=lambda: None,
+                        drain_all=True,
+                    )
+                )
+                await _settle()
+
+                new_context = manager.request_context()
+                newcomer = asyncio.create_task(new_context.__aenter__())
+                await _settle()
+                self.assertFalse(newcomer.done())
+
+                commit.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await commit
+                self.assertEqual(await asyncio.wait_for(newcomer, 0.1), 0)
+
+                await new_context.__aexit__(None, None, None)
+                await existing.__aexit__(None, None, None)
+
+        asyncio.run(run())
+
     def test_startup_sync_composes_tail_into_one_apply(self) -> None:
         async def run() -> None:
             with tempfile.TemporaryDirectory() as tmp:
@@ -169,6 +216,110 @@ class SyncManagerTest(unittest.TestCase):
                 i = engine.events.index("reset")
                 self.assertEqual(engine.events[i - 1], "pause")
                 self.assertEqual(engine.events[i + 1], "continue")
+
+        asyncio.run(run())
+
+    def test_run_switch_blocks_existing_and_new_rolling_requests(self) -> None:
+        async def run() -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                board = FilesystemBulletinBoard(root, layout="slime")
+                _write_slime_version(root / "run-a", 1, 0)
+                board.write_latest("run-a", 1)
+                engine = FakeEngine()
+                manager = WeightSyncManager(board=board, engine=engine, commit_mode="in_place")
+                await manager.startup_sync()
+
+                release_existing = asyncio.Event()
+                existing_entered = asyncio.Event()
+
+                async def existing_request() -> None:
+                    async with manager.request_context():
+                        existing_entered.set()
+                        await release_existing.wait()
+
+                existing = asyncio.create_task(existing_request())
+                await existing_entered.wait()
+
+                engine.reset_gate = asyncio.Event()
+                board.write_latest("run-b", 0)
+                switch = asyncio.create_task(manager.sync_to())
+                await _settle()
+                self.assertFalse(engine.reset_started.is_set())
+
+                new_entered = asyncio.Event()
+                new_versions: list[int] = []
+
+                async def new_request() -> None:
+                    async with manager.request_context() as version:
+                        new_versions.append(version)
+                        new_entered.set()
+
+                newcomer = asyncio.create_task(new_request())
+                await _settle()
+                self.assertFalse(new_entered.is_set())
+
+                release_existing.set()
+                await existing
+                await engine.reset_started.wait()
+                self.assertFalse(new_entered.is_set())
+
+                engine.reset_gate.set()
+                await switch
+                await newcomer
+                self.assertEqual(manager.current_run_id, "run-b")
+                self.assertEqual(new_versions, [0])
+
+        asyncio.run(run())
+
+    def test_run_switch_resets_after_failed_pass_at_v0(self) -> None:
+        async def run() -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                board = FilesystemBulletinBoard(root, layout="slime")
+                board.write_latest("run-a", 0)
+                engine = FakeEngine()
+                manager = WeightSyncManager(board=board, engine=engine, commit_mode="in_place")
+                await manager.startup_sync()
+                self.assertFalse(engine.reset_started.is_set())
+
+                _write_slime_version(root / "run-a", 1, 0)
+                board.write_latest("run-a", 1)
+                engine.fail_next_apply = True
+                await manager.sync_to()
+                self.assertEqual(manager.sync_state, SyncState.ERROR)
+                self.assertEqual(manager.current_version, 0)
+
+                board.write_latest("run-b", 0)
+                await manager.sync_to()
+                self.assertTrue(engine.reset_started.is_set())
+                self.assertEqual(manager.current_run_id, "run-b")
+
+        asyncio.run(run())
+
+    def test_dirty_run_switch_without_reset_fails_closed(self) -> None:
+        class NoResetEngine(FakeEngine):
+            reset = None  # type: ignore[assignment]
+
+        async def run() -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                board = FilesystemBulletinBoard(root, layout="slime")
+                board.write_latest("run-b", 0)
+                manager = WeightSyncManager(
+                    board=board,
+                    engine=NoResetEngine(),
+                    commit_mode="in_place",
+                )
+                manager.current_run_id = "run-a"
+                manager.current_version = 1
+
+                await manager.sync_to()
+
+                self.assertEqual(manager.current_run_id, "run-a")
+                self.assertEqual(manager.current_version, 1)
+                self.assertEqual(manager.sync_state, SyncState.ERROR)
+                self.assertIn("cannot reset", manager.last_sync_error or "")
 
         asyncio.run(run())
 


### PR DESCRIPTION
## Summary

Close all admission before draining and resetting during a run switch, recover cleanly from cancellation, and reset dirty version-zero state.

## Why

No request may straddle a base reset or observe mutated weights under the previous run identity.

## Validation

- Focused coverage: `src/stitch/sync_test.py and src/stitch/engines/sglang_test.py`
- Stack tip: `uv run pytest` (170 passed)

## Stack

PR 3 of 14. Base: `rewrite-2-fail-closed-pointer`. Next: `rewrite-4-wake-generation`.