### PR TITLE
fix(stitch): make wake reconciliation generation-aware

### DIFF
--- a/src/stitch/servers/sglang.py
+++ b/src/stitch/servers/sglang.py
@@ -89,8 +89,15 @@ def create_app(
             try:
                 await board.refresh()
                 queue_sync()
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
+                set_error = getattr(manager, "set_background_refresh_error", None)
+                if set_error is not None:
+                    set_error(str(exc))
                 logger.warning("background reconcile failed", exc_info=True)
+            else:
+                set_error = getattr(manager, "set_background_refresh_error", None)
+                if set_error is not None:
+                    set_error(None)
 
     reconcile: dict[str, Any] = {}
 

--- a/src/stitch/servers/sglang_test.py
+++ b/src/stitch/servers/sglang_test.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
+import time
 import unittest
 from unittest import mock
 
 from stitch.bulletin import FilesystemBulletinBoard
+from stitch.protocol import SyncState
 from stitch.sync import WeightSyncManager
 
 
@@ -26,6 +28,79 @@ class FakeEngine:
 
     async def continue_generation(self) -> None:
         self.events.append("continue")
+
+
+class ReconcileLoopTest(unittest.TestCase):
+    def test_successful_reconcile_recovers_startup_refresh_failure(self) -> None:
+        from fastapi.testclient import TestClient
+
+        from stitch.servers.sglang import create_app
+
+        with tempfile.TemporaryDirectory() as tmp:
+            attempts = 0
+
+            def refresh() -> None:
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise RuntimeError("startup mount hiccup")
+
+            board = FilesystemBulletinBoard(tmp, refresh=refresh)
+            manager = WeightSyncManager(board=board, engine=FakeEngine())
+            app = create_app(
+                manager,
+                upstream_url="http://127.0.0.1:9",
+                background_sync_interval=0.01,
+            )
+            with TestClient(app) as client:
+                deadline = time.monotonic() + 2
+                while time.monotonic() < deadline and manager.sync_state is not SyncState.IDLE:
+                    time.sleep(0.01)
+
+                info = client.get("/server_info").json()
+                self.assertGreaterEqual(attempts, 2)
+                self.assertEqual(info["sync_state"], "IDLE")
+                self.assertIsNone(info["last_sync_error"])
+
+    def test_refresh_failure_marks_unready_and_success_recovers(self) -> None:
+        from fastapi.testclient import TestClient
+
+        from stitch.servers.sglang import create_app
+
+        with tempfile.TemporaryDirectory() as tmp:
+            failing = {"value": False}
+
+            def refresh() -> None:
+                if failing["value"]:
+                    raise RuntimeError("mount hiccup")
+
+            board = FilesystemBulletinBoard(tmp, refresh=refresh)
+            manager = WeightSyncManager(board=board, engine=FakeEngine())
+            app = create_app(
+                manager,
+                upstream_url="http://127.0.0.1:9",
+                background_sync_interval=0.01,
+            )
+            with TestClient(app) as client:
+                failing["value"] = True
+                deadline = time.monotonic() + 2
+                while time.monotonic() < deadline and manager.last_refresh_error is None:
+                    time.sleep(0.01)
+
+                info = client.get("/server_info").json()
+                self.assertIn("mount hiccup", info["last_sync_error"])
+
+                failing["value"] = False
+                deadline = time.monotonic() + 2
+                while time.monotonic() < deadline and (
+                    manager.last_refresh_error is not None
+                    or manager.sync_state is not SyncState.IDLE
+                ):
+                    time.sleep(0.01)
+
+                info = client.get("/server_info").json()
+                self.assertIsNone(info["last_sync_error"])
+                self.assertEqual(info["sync_state"], "IDLE")
 
 
 class SidecarProxyTest(unittest.TestCase):

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -253,8 +253,10 @@ class WeightSyncManager(RolloutAdmissionGate):
         self.current_version = 0
         self.latest_seen_version = 0
         self.queued_target_version: int | None = None
+        self._wake_generation = 0
         self.sync_state = SyncState.IDLE
         self.last_sync_error: str | None = None
+        self.last_refresh_error: str | None = None
         # Per-stage wall-clock breakdown of the most recent sync pass (seconds),
         # exposed via server_info()["metrics"] so a scraper can attribute sync
         # latency to board refresh / host apply / drain / pause / reload without
@@ -273,6 +275,7 @@ class WeightSyncManager(RolloutAdmissionGate):
         await self.sync_to()
 
     async def server_info(self) -> dict[str, Any]:
+        effective_error = self.last_sync_error or self.last_refresh_error
         return {
             "run_id": self.run_id,
             "backend": self.engine.backend,
@@ -282,7 +285,8 @@ class WeightSyncManager(RolloutAdmissionGate):
             "latest_seen_version": self.latest_seen_version,
             "queued_target_version": self.queued_target_version,
             "sync_state": self.sync_state.value,
-            "last_sync_error": self.last_sync_error,
+            "last_sync_error": effective_error,
+            "last_refresh_error": self.last_refresh_error,
             "sync_task_active": self._sync_task is not None and not self._sync_task.done(),
             "active_requests": self._active_requests,
             "inflight_exact_versions": self.inflight_exact_versions,
@@ -293,6 +297,10 @@ class WeightSyncManager(RolloutAdmissionGate):
         if error["error"]["type"] == "WeightVersionNotReady":
             self.queue_sync(error["error"]["target_version"])
 
+    def set_background_refresh_error(self, error: str | None) -> None:
+        """Record health of the sidecar's periodic board refresh loop."""
+        self.last_refresh_error = error
+
     def queue_sync(self, target_version: int | None = None) -> None:
         run_id, latest = self.board.read_latest()
         self.latest_seen_version = max(self.latest_seen_version, latest)
@@ -301,10 +309,12 @@ class WeightSyncManager(RolloutAdmissionGate):
         # its version number is lower than what we serve); within a run it's work
         # only when the target exceeds what we've applied.
         needs_switch = run_id != self.current_run_id
-        if not needs_switch and max(latest, hint) <= self.current_version:
+        recovering = self.sync_state is SyncState.ERROR
+        if not recovering and not needs_switch and max(latest, hint) <= self.current_version:
             return
+        self._wake_generation += 1
         self.queued_target_version = max(latest, hint, self.queued_target_version or 0)
-        if self.sync_state is SyncState.IDLE:
+        if self.sync_state in (SyncState.IDLE, SyncState.ERROR):
             self.sync_state = SyncState.QUEUED
         if self._sync_task is None or self._sync_task.done():
             self._sync_task = asyncio.get_running_loop().create_task(self.sync_to())
@@ -314,9 +324,11 @@ class WeightSyncManager(RolloutAdmissionGate):
         # authoritative target is always the board's current (run_id, latest), so
         # we converge to it — and follow a run switch — regardless of the hint.
         if target_version is not None:
+            self._wake_generation += 1
             self.queued_target_version = max(int(target_version), self.queued_target_version or 0)
 
         while True:
+            pass_generation = self._wake_generation
             try:
                 reached = await self._sync_once()
                 if reached:
@@ -327,8 +339,12 @@ class WeightSyncManager(RolloutAdmissionGate):
                     run_id, latest = self.board.read_latest()
                     self.latest_seen_version = max(self.latest_seen_version, latest)
                     queued = self.queued_target_version or 0
-                    if run_id != self.current_run_id or max(latest, queued) > self.current_version:
+                    if run_id != self.current_run_id or latest > self.current_version:
                         reached = False
+                    elif self._wake_generation != pass_generation:
+                        reached = False
+                    elif queued > latest:
+                        self.queued_target_version = None
             except Exception as exc:  # noqa: BLE001
                 self.last_sync_error = str(exc)
                 self.sync_state = SyncState.ERROR
@@ -337,6 +353,7 @@ class WeightSyncManager(RolloutAdmissionGate):
 
             if reached:
                 self.queued_target_version = None
+                self.last_sync_error = None
                 self.sync_state = SyncState.IDLE
                 return
             await asyncio.sleep(1.0)
@@ -369,7 +386,6 @@ class WeightSyncManager(RolloutAdmissionGate):
             self.current_run_id = new_run_id
             self.current_version = 0
             self.latest_seen_version = 0
-            self.last_sync_error = None
 
         await self.commit_version(
             apply=_apply,
@@ -405,7 +421,6 @@ class WeightSyncManager(RolloutAdmissionGate):
             return True
 
         self.sync_state = SyncState.PREFETCHING
-        self.last_sync_error = None
 
         # Verify the whole tail is a contiguous chain before touching the
         # engine, so a broken chain fails before any pause/apply. apply_deltas

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -5,6 +5,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from stitch.bulletin import FilesystemBulletinBoard
 from stitch.protocol import SyncState, VersionManifest, WeightVersionPolicy
@@ -102,6 +103,75 @@ class StagedEngine(FakeEngine):
 
 
 class SyncManagerTest(unittest.TestCase):
+    def test_stale_wake_hint_does_not_pin_manager_queued(self) -> None:
+        async def run() -> None:
+            with tempfile.TemporaryDirectory() as tmp:
+                manager = WeightSyncManager(
+                    board=FilesystemBulletinBoard(tmp), engine=FakeEngine()
+                )
+
+                await manager.sync_to(99)
+
+                self.assertEqual(manager.current_version, 0)
+                self.assertEqual(manager.sync_state, SyncState.IDLE)
+                self.assertIsNone(manager.queued_target_version)
+
+        asyncio.run(run())
+
+    def test_wake_during_stale_recheck_forces_another_pass(self) -> None:
+        class RacingBoard:
+            def __init__(self) -> None:
+                self.latest = 0
+                self.refresh_started = asyncio.Event()
+                self.release_refresh = asyncio.Event()
+                self._first_refresh = True
+                self._stale_read = False
+
+            async def refresh(self) -> None:
+                if self._first_refresh:
+                    self._first_refresh = False
+                    self.refresh_started.set()
+                    await self.release_refresh.wait()
+                    self._stale_read = True
+
+            def read_latest(self) -> tuple[None, int]:
+                if self._stale_read:
+                    self._stale_read = False
+                    self.latest = 1
+                    return (None, 0)
+                return (None, self.latest)
+
+        async def run() -> None:
+            board = RacingBoard()
+            manager = WeightSyncManager(board=board, engine=FakeEngine())
+            passes = 0
+
+            async def sync_once() -> bool:
+                nonlocal passes
+                passes += 1
+                if passes > 1:
+                    manager.current_version = board.latest
+                return True
+
+            async def no_delay(_seconds: float) -> None:
+                return None
+
+            manager._sync_once = sync_once  # type: ignore[method-assign]
+            task = asyncio.create_task(manager.sync_to())
+            manager._sync_task = task
+            await board.refresh_started.wait()
+
+            manager.queue_sync(1)
+            board.release_refresh.set()
+            with mock.patch("stitch.sync.asyncio.sleep", new=no_delay):
+                await task
+
+            self.assertEqual(passes, 2)
+            self.assertEqual(manager.current_version, 1)
+            self.assertEqual(manager.sync_state, SyncState.IDLE)
+
+        asyncio.run(run())
+
     def test_cancelled_run_switch_drain_reopens_admission(self) -> None:
         async def run() -> None:
             with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Track wake generations through active reconciliation and keep background refresh failures observable and recoverable.

## Why

A publish arriving during an active sync must not be dropped when that sync transitions back to idle.

## Validation

- Focused coverage: `src/stitch/sync_test.py and src/stitch/servers/sglang_test.py`
- Stack tip: `uv run pytest` (170 passed)

## Stack

PR 4 of 14. Base: `rewrite-3-run-switch-atomicity`. Next: `rewrite-5-deployment-boundary`.