### PR TITLE
fix(standalone_rollouts): define a closed deployment boundary

### DIFF
--- a/cookbook/standalone_rollouts/auth.py
+++ b/cookbook/standalone_rollouts/auth.py
@@ -1,0 +1,27 @@
+"""Pure authorization policy for the public standalone front door."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def authorize(
+    headers: Mapping[str, str],
+    *,
+    api_key: str | None,
+    provider_model: str | None,
+    provider_deployment: str | None,
+) -> tuple[int, str] | None:
+    """Return an HTTP rejection or ``None`` when the request is authorized."""
+    if not api_key:
+        return (503, "provider auth is not configured")
+    if headers.get("authorization") != f"Bearer {api_key}":
+        return (401, "unauthorized")
+    if provider_model and headers.get("provider-model") != provider_model:
+        return (400, "Provider-Model header does not match this deployment")
+    if (
+        provider_deployment
+        and headers.get("provider-deployment") != provider_deployment
+    ):
+        return (400, "Provider-Deployment header does not match this deployment")
+    return None

--- a/cookbook/standalone_rollouts/auth_test.py
+++ b/cookbook/standalone_rollouts/auth_test.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import unittest
+
+from cookbook.standalone_rollouts.auth import authorize
+
+
+GOOD = {"authorization": "Bearer secret"}
+
+
+class AuthorizeTest(unittest.TestCase):
+    def test_unset_api_key_fails_closed(self) -> None:
+        for headers in ({}, GOOD, {"authorization": "Bearer anything"}):
+            rejection = authorize(
+                headers, api_key=None, provider_model=None, provider_deployment=None
+            )
+            self.assertIsNotNone(rejection)
+            self.assertEqual(rejection[0], 503)
+
+    def test_correct_bearer_is_allowed(self) -> None:
+        self.assertIsNone(
+            authorize(
+                GOOD, api_key="secret", provider_model=None, provider_deployment=None
+            )
+        )
+
+    def test_missing_or_wrong_bearer_is_401(self) -> None:
+        for headers in (
+            {},
+            {"authorization": "Bearer wrong"},
+            {"authorization": "secret"},
+        ):
+            rejection = authorize(
+                headers, api_key="secret", provider_model=None, provider_deployment=None
+            )
+            self.assertEqual(rejection, (401, "unauthorized"))
+
+    def test_optional_provider_headers_are_enforced_when_configured(self) -> None:
+        self.assertEqual(
+            authorize(
+                GOOD,
+                api_key="secret",
+                provider_model="moonlight",
+                provider_deployment=None,
+            )[0],
+            400,
+        )
+        self.assertIsNone(
+            authorize(
+                {**GOOD, "provider-model": "moonlight"},
+                api_key="secret",
+                provider_model="moonlight",
+                provider_deployment=None,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cookbook/standalone_rollouts/base_checkpoint.py
+++ b/cookbook/standalone_rollouts/base_checkpoint.py
@@ -1,0 +1,18 @@
+"""Resolve the checkpoint used by both the engine and delta materializer."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+
+def is_hf_repo_id(spec: str) -> bool:
+    """Return whether ``spec`` should be resolved through the Hugging Face cache."""
+    return not os.path.isabs(spec)
+
+
+def resolve_base_checkpoint(spec: str, *, snapshot_download: Callable[..., str]) -> str:
+    """Resolve an HF repo locally, or return an absolute checkpoint path."""
+    if is_hf_repo_id(spec):
+        return snapshot_download(spec, local_files_only=True)
+    return spec

--- a/cookbook/standalone_rollouts/base_checkpoint_test.py
+++ b/cookbook/standalone_rollouts/base_checkpoint_test.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import unittest
+
+from cookbook.standalone_rollouts.base_checkpoint import (
+    is_hf_repo_id,
+    resolve_base_checkpoint,
+)
+
+
+class BaseCheckpointTest(unittest.TestCase):
+    def test_absolute_dir_is_used_without_downloading(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_download(*args, **kwargs):
+            calls.append((args, kwargs))
+            return "/wrong"
+
+        resolved = resolve_base_checkpoint(
+            "/mnt/transport/customer-base", snapshot_download=fake_download
+        )
+        self.assertEqual(resolved, "/mnt/transport/customer-base")
+        self.assertEqual(calls, [])
+        self.assertFalse(is_hf_repo_id(resolved))
+
+    def test_repo_id_resolves_from_local_cache(self) -> None:
+        calls: list[tuple] = []
+
+        def fake_download(spec, **kwargs):
+            calls.append((spec, kwargs))
+            return "/hf-cache/snapshot"
+
+        resolved = resolve_base_checkpoint(
+            "moonshotai/Moonlight-16B-A3B-Instruct",
+            snapshot_download=fake_download,
+        )
+        self.assertEqual(resolved, "/hf-cache/snapshot")
+        self.assertEqual(
+            calls,
+            [("moonshotai/Moonlight-16B-A3B-Instruct", {"local_files_only": True})],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cookbook/standalone_rollouts/configs/moonlight_hot_load.py
+++ b/cookbook/standalone_rollouts/configs/moonlight_hot_load.py
@@ -12,6 +12,9 @@ from pathlib import Path
 
 APP_NAME = "stitch-moonlight-api-shim"
 MODEL_NAME = "moonshotai/Moonlight-16B-A3B-Instruct"
+# SGLang boots from, and the sidecar applies deltas onto, this exact checkpoint.
+# It may also be an absolute directory on a mounted volume or bucket.
+BASE_CHECKPOINT = MODEL_NAME
 
 HF_SECRET_NAME = "huggingface-secret"
 SHIM_SECRET_NAME = "stitch-api-shim-provider"

--- a/cookbook/standalone_rollouts/frontdoor.py
+++ b/cookbook/standalone_rollouts/frontdoor.py
@@ -37,6 +37,11 @@ from stitch.protocol import (
 
 
 HOT_LOAD_PATH = "/hot_load/v1/models/hot_load"
+INFERENCE_PATHS = (
+    "/generate",
+    "/v1/chat/completions",
+    "/v1/completions",
+)
 
 
 def advance_latest_decision(
@@ -111,11 +116,15 @@ def pool_state_from_server_infos(infos: list[dict[str, Any]]) -> RolloutPoolStat
         replicas.append(
             RolloutReplicaState(
                 readiness=ready,
-                current_version=current_version if isinstance(current_version, int) else None,
+                current_version=current_version
+                if isinstance(current_version, int)
+                else None,
                 current_snapshot_identity=identity,
                 replica_id=info.get("run_id") or info.get("replica_id"),
                 sync_state=sync_state,
-                readiness_reason=None if ready else (last_error or sync_state or "unreachable"),
+                readiness_reason=None
+                if ready
+                else (last_error or sync_state or "unreachable"),
             )
         )
     return RolloutPoolState(replicas=replicas)
@@ -127,7 +136,7 @@ def create_frontdoor_app(
     advance_to: Callable[[str | None, int], Awaitable[None]],
     list_server_infos: Callable[[], Awaitable[list[dict[str, Any]]]],
     proxy: Callable[..., Awaitable[Any]],
-    authorize: Callable[[Any], Any] | None = None,
+    authorize: Callable[[Any], Any],
     wake: Callable[[int], Awaitable[None]] | None = None,
 ):
     """Build the front-door FastAPI app from injected I/O.
@@ -149,7 +158,7 @@ def create_frontdoor_app(
     advance_lock = asyncio.Lock()
 
     def _auth(request: Request):
-        return authorize(request.headers) if authorize is not None else None
+        return authorize(request.headers)
 
     @app.post(HOT_LOAD_PATH, response_model=None)
     async def post_hot_load(request: Request) -> Response:
@@ -170,7 +179,9 @@ def create_frontdoor_app(
                 status = 400 if decision["error"]["type"] == "InvalidIdentity" else 409
                 return JSONResponse(decision, status_code=status)
             await advance_to(decision["run_id"], decision["version"])
-        snapshot_identity = format_snapshot_identity(decision["run_id"], decision["version"])
+        snapshot_identity = format_snapshot_identity(
+            decision["run_id"], decision["version"]
+        )
         if wake is not None:
             try:
                 await wake(decision["version"])
@@ -193,11 +204,13 @@ def create_frontdoor_app(
         infos = await list_server_infos()
         return JSONResponse(pool_state_from_server_infos(infos).to_dict())
 
-    @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
-    async def catch_all(path: str, request: Request) -> Response:
+    async def proxy_inference(request: Request) -> Response:
         rejected = _auth(request)
         if rejected is not None:
             return rejected
-        return await proxy(request, path)
+        return await proxy(request, request.url.path.lstrip("/"))
+
+    for path in INFERENCE_PATHS:
+        app.add_api_route(path, proxy_inference, methods=["POST"], response_model=None)
 
     return app

--- a/cookbook/standalone_rollouts/frontdoor_test.py
+++ b/cookbook/standalone_rollouts/frontdoor_test.py
@@ -47,7 +47,8 @@ class AdvanceDecisionTest(unittest.TestCase):
 
     def test_rejects_unparseable_identity(self) -> None:
         self.assertEqual(
-            advance_latest_decision(None, 0, "base", None)["error"]["type"], "InvalidIdentity"
+            advance_latest_decision(None, 0, "base", None)["error"]["type"],
+            "InvalidIdentity",
         )
 
 
@@ -55,9 +56,27 @@ class PoolStateTest(unittest.TestCase):
     def test_ready_only_when_idle_and_no_error(self) -> None:
         state = pool_state_from_server_infos(
             [
-                {"run_id": "a", "current_run_id": "run-x", "current_version": 5, "sync_state": "IDLE", "last_sync_error": None},
-                {"run_id": "b", "current_run_id": "run-x", "current_version": 4, "sync_state": "PREFETCHING", "last_sync_error": None},
-                {"run_id": "c", "current_run_id": "run-x", "current_version": 5, "sync_state": "ERROR", "last_sync_error": "boom"},
+                {
+                    "run_id": "a",
+                    "current_run_id": "run-x",
+                    "current_version": 5,
+                    "sync_state": "IDLE",
+                    "last_sync_error": None,
+                },
+                {
+                    "run_id": "b",
+                    "current_run_id": "run-x",
+                    "current_version": 4,
+                    "sync_state": "PREFETCHING",
+                    "last_sync_error": None,
+                },
+                {
+                    "run_id": "c",
+                    "current_run_id": "run-x",
+                    "current_version": 5,
+                    "sync_state": "ERROR",
+                    "last_sync_error": "boom",
+                },
             ]
         )
         by_id = {r.replica_id: r for r in state.replicas}
@@ -67,17 +86,32 @@ class PoolStateTest(unittest.TestCase):
         self.assertEqual(by_id["b"].readiness_reason, "PREFETCHING")
         self.assertFalse(by_id["c"].readiness)
         self.assertEqual(by_id["c"].readiness_reason, "boom")
-        self.assertEqual(state.ready_count(target_snapshot_identity="run-x/weight_v000005"), 1)
+        self.assertEqual(
+            state.ready_count(target_snapshot_identity="run-x/weight_v000005"), 1
+        )
 
     def test_identity_carries_run_id(self) -> None:
         # A replica on run-b advertises a run-scoped identity, so it is not
         # miscounted ready for a different run's same-numbered version.
         state = pool_state_from_server_infos(
-            [{"run_id": "a", "current_run_id": "run-b", "current_version": 1, "sync_state": "IDLE"}]
+            [
+                {
+                    "run_id": "a",
+                    "current_run_id": "run-b",
+                    "current_version": 1,
+                    "sync_state": "IDLE",
+                }
+            ]
         )
-        self.assertEqual(state.replicas[0].current_snapshot_identity, "run-b/weight_v000001")
-        self.assertEqual(state.ready_count(target_snapshot_identity="run-b/weight_v000001"), 1)
-        self.assertEqual(state.ready_count(target_snapshot_identity="run-a/weight_v000001"), 0)
+        self.assertEqual(
+            state.replicas[0].current_snapshot_identity, "run-b/weight_v000001"
+        )
+        self.assertEqual(
+            state.ready_count(target_snapshot_identity="run-b/weight_v000001"), 1
+        )
+        self.assertEqual(
+            state.ready_count(target_snapshot_identity="run-a/weight_v000001"), 0
+        )
 
 
 class FrontdoorAppTest(unittest.TestCase):
@@ -117,30 +151,40 @@ class FrontdoorAppTest(unittest.TestCase):
             advance_to=advance_to,
             list_server_infos=list_server_infos,
             proxy=proxy,
-            authorize=authorize,
+            authorize=authorize or (lambda _headers: None),
             wake=wake,
         )
         return TestClient(app), calls
 
     def test_post_advances_on_newer_identity_and_wakes(self) -> None:
         client, calls = self._client(run_id="run-a", version=4)
-        resp = client.post(HOT_LOAD_PATH, json={"identity": "weight_v000005", "run_id": "run-a"})
+        resp = client.post(
+            HOT_LOAD_PATH, json={"identity": "weight_v000005", "run_id": "run-a"}
+        )
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(resp.json()["accepted"])
-        self.assertEqual(resp.json()["current_snapshot_identity"], "run-a/weight_v000005")
+        self.assertEqual(
+            resp.json()["current_snapshot_identity"], "run-a/weight_v000005"
+        )
         self.assertEqual(calls["advanced"], [("run-a", 5)])
         self.assertEqual(calls["woke"], [5])
 
     def test_post_new_run_accepted_as_reset(self) -> None:
         client, calls = self._client(run_id="run-a", version=5)
-        resp = client.post(HOT_LOAD_PATH, json={"identity": "weight_v000001", "run_id": "run-b"})
+        resp = client.post(
+            HOT_LOAD_PATH, json={"identity": "weight_v000001", "run_id": "run-b"}
+        )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(calls["advanced"], [("run-b", 1)])
-        self.assertEqual(resp.json()["current_snapshot_identity"], "run-b/weight_v000001")
+        self.assertEqual(
+            resp.json()["current_snapshot_identity"], "run-b/weight_v000001"
+        )
 
     def test_post_rejects_rewind_without_advancing(self) -> None:
         client, calls = self._client(run_id="run-a", version=5)
-        resp = client.post(HOT_LOAD_PATH, json={"identity": "weight_v000005", "run_id": "run-a"})
+        resp = client.post(
+            HOT_LOAD_PATH, json={"identity": "weight_v000005", "run_id": "run-a"}
+        )
         self.assertEqual(resp.status_code, 409)
         self.assertEqual(resp.json()["error"]["type"], "WeightRewindRejected")
         self.assertEqual(calls["advanced"], [])
@@ -154,7 +198,9 @@ class FrontdoorAppTest(unittest.TestCase):
         client, _ = self._client(run_id="run-a", version=5)
         body = client.get(HOT_LOAD_PATH).json()
         self.assertEqual(len(body["replicas"]), 1)
-        self.assertEqual(body["replicas"][0]["current_snapshot_identity"], "run-a/weight_v000005")
+        self.assertEqual(
+            body["replicas"][0]["current_snapshot_identity"], "run-a/weight_v000005"
+        )
         self.assertTrue(body["replicas"][0]["readiness"])
 
     def test_catch_all_proxies(self) -> None:
@@ -162,6 +208,18 @@ class FrontdoorAppTest(unittest.TestCase):
         resp = client.post("/v1/chat/completions", json={"model": "m"})
         self.assertEqual(resp.json(), {"proxied": "v1/chat/completions"})
         self.assertEqual(calls["proxied"], ["v1/chat/completions"])
+
+    def test_only_explicit_inference_routes_are_proxied(self) -> None:
+        client, calls = self._client()
+        for path in (
+            "/health",
+            "/server_info",
+            "/v1/internal/control",
+            "/v1/%2e%2e/server_info",
+            "/v1/%252e%252e/server_info",
+        ):
+            self.assertEqual(client.get(path).status_code, 404, path)
+        self.assertEqual(calls["proxied"], [])
 
     def test_auth_rejection_blocks_every_route(self) -> None:
         from fastapi.responses import JSONResponse
@@ -171,7 +229,9 @@ class FrontdoorAppTest(unittest.TestCase):
 
         client, calls = self._client(authorize=deny)
         self.assertEqual(
-            client.post(HOT_LOAD_PATH, json={"identity": "weight_v000009", "run_id": "run-a"}).status_code,
+            client.post(
+                HOT_LOAD_PATH, json={"identity": "weight_v000009", "run_id": "run-a"}
+            ).status_code,
             401,
         )
         self.assertEqual(client.get(HOT_LOAD_PATH).status_code, 401)

--- a/cookbook/standalone_rollouts/modal_serve.py
+++ b/cookbook/standalone_rollouts/modal_serve.py
@@ -22,6 +22,8 @@ import modal
 import modal.experimental
 
 from cookbook.slime_disagg import helpers
+from cookbook.standalone_rollouts import auth as auth_mod
+from cookbook.standalone_rollouts import base_checkpoint
 from cookbook.standalone_rollouts import frontdoor as frontdoor_mod
 from stitch.bulletin import FilesystemBulletinBoard
 from stitch.providers.modal import (
@@ -36,6 +38,7 @@ exp = importlib.import_module(f"cookbook.standalone_rollouts.configs.{PROVIDER_C
 
 APP_NAME = exp.APP_NAME
 MODEL_NAME = exp.MODEL_NAME
+BASE_CHECKPOINT = exp.BASE_CHECKPOINT
 ROLLOUT_CONCURRENCY = exp.ROLLOUT_CONCURRENCY
 SIDECAR_PORT = 8000
 SGLANG_PORT = 8001
@@ -191,8 +194,13 @@ class Server:
 
     @modal.enter()
     def startup(self) -> None:
+        from huggingface_hub import snapshot_download
+
+        base_checkpoint_dir = base_checkpoint.resolve_base_checkpoint(
+            BASE_CHECKPOINT, snapshot_download=snapshot_download
+        )
         self.endpoint = SGLangEndpoint(
-            model_path=MODEL_NAME,
+            model_path=base_checkpoint_dir,
             worker_port=SGLANG_PORT,
             tp=exp.ROLLOUT_NUM_GPUS_PER_ENGINE,
             extra_server_args=SGLANG_SERVER_ARGS,
@@ -207,11 +215,6 @@ class Server:
             request_timeout=120.0,
             max_attempts_per_request=3,
         )
-        # Deltas are applied host-side onto a copy of the base checkpoint; the
-        # base resolves to the same HF cache snapshot the SGLang server loaded.
-        from huggingface_hub import snapshot_download
-
-        base_checkpoint_dir = snapshot_download(MODEL_NAME, local_files_only=True)
         self.sidecar = _start_provider_sidecar(base_checkpoint_dir=base_checkpoint_dir)
         helpers.wait_http(
             f"http://127.0.0.1:{SIDECAR_PORT}/health",
@@ -239,7 +242,8 @@ class Server:
 def download_model() -> None:
     from huggingface_hub import snapshot_download
 
-    snapshot_download(repo_id=MODEL_NAME)
+    if base_checkpoint.is_hf_repo_id(BASE_CHECKPOINT):
+        snapshot_download(repo_id=BASE_CHECKPOINT)
     hf_cache_volume.commit()
 
 
@@ -404,24 +408,15 @@ def _auth_error(headers):
     JSONResponse to reject, or None to allow."""
     from fastapi.responses import JSONResponse
 
-    api_key = os.environ.get("STITCH_SHIM_API_KEY")
-    if api_key and headers.get("authorization") != f"Bearer {api_key}":
-        return JSONResponse({"error": "unauthorized"}, status_code=401)
-    provider_model = os.environ.get("STITCH_SHIM_PROVIDER_MODEL")
-    if provider_model and headers.get("provider-model") != provider_model:
-        return JSONResponse(
-            {"error": "Provider-Model header does not match this deployment"},
-            status_code=400,
-        )
-    provider_deployment = os.environ.get("STITCH_SHIM_PROVIDER_DEPLOYMENT")
-    if (
-        provider_deployment
-        and headers.get("provider-deployment") != provider_deployment
-    ):
-        return JSONResponse(
-            {"error": "Provider-Deployment header does not match this deployment"},
-            status_code=400,
-        )
+    rejection = auth_mod.authorize(
+        headers,
+        api_key=os.environ.get("STITCH_SHIM_API_KEY"),
+        provider_model=os.environ.get("STITCH_SHIM_PROVIDER_MODEL"),
+        provider_deployment=os.environ.get("STITCH_SHIM_PROVIDER_DEPLOYMENT"),
+    )
+    if rejection is not None:
+        status, message = rejection
+        return JSONResponse({"error": message}, status_code=status)
     return None
 
 
@@ -462,6 +457,9 @@ class FrontDoor:
         import httpx
         import uvicorn
         from fastapi.responses import Response
+
+        if not os.environ.get("STITCH_SHIM_API_KEY"):
+            raise RuntimeError("STITCH_SHIM_API_KEY is required")
 
         board = FilesystemBulletinBoard(str(S3_TRANSPORT_MOUNT_PATH), layout="slime")
         gateway: dict[str, str | None] = {"url": None}


### PR DESCRIPTION
## Summary

Require fail-closed publisher authentication, proxy only explicit inference routes, and resolve one exact base checkpoint for both SGLang and delta application.

## Why

The fixed publisher contract requires a closed public surface and guarantees that every delta is applied to the exact bytes being served as version zero.

## Validation

- Focused coverage: `cookbook/standalone_rollouts/auth_test.py and cookbook/standalone_rollouts/base_checkpoint_test.py`
- Stack tip: `uv run pytest` (170 passed)

## Stack

PR 5 of 14. Base: `rewrite-4-wake-generation`. Next: `rewrite-6-identity-ledger`.