### PR TITLE
feat(standalone_rollouts): add an identity lineage ledger

### DIFF
--- a/cookbook/standalone_rollouts/ledger.py
+++ b/cookbook/standalone_rollouts/ledger.py
@@ -1,0 +1,279 @@
+"""Strict mapping from opaque customer identities to stitch versions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+LEDGER_FILENAME = "identities.json"
+LEDGER_SCHEMA_VERSION = 1
+MAX_IDENTITY_BYTES = 255
+RESERVED_IDENTITIES = frozenset({".", "..", ".stitch", "latest", LEDGER_FILENAME})
+
+
+class LedgerError(ValueError):
+    """Base class for invalid identity-ledger operations."""
+
+
+class LedgerCorruption(LedgerError):
+    """Persisted ledger data violates the schema or chain invariants."""
+
+
+class LedgerConflict(LedgerError):
+    """A new signal conflicts with the deployment's existing chain."""
+
+
+class LedgerRewind(LedgerConflict):
+    """A valid historical identity was signalled after the chain advanced."""
+
+
+def is_valid_identity(identity: object) -> bool:
+    """Return whether an opaque identity is safe as one filesystem component."""
+    if not isinstance(identity, str) or identity in RESERVED_IDENTITIES:
+        return False
+    try:
+        identity_bytes = identity.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    if not identity_bytes or len(identity_bytes) > MAX_IDENTITY_BYTES:
+        return False
+    if "/" in identity or "\\" in identity:
+        return False
+    return not any(
+        ord(character) < 0x20 or ord(character) == 0x7F for character in identity
+    )
+
+
+@dataclass(frozen=True)
+class DeltaFormats:
+    """Decoder-relevant formats that must stay stable across POST retries."""
+
+    delta_encoding: str
+    compression_format: str
+    checksum_format: str
+
+    def __post_init__(self) -> None:
+        supported = {
+            "delta_encoding": {"xor"},
+            "compression_format": {"zstd"},
+            "checksum_format": {"adler32", "xxh3-128", "blake3"},
+        }
+        for name, allowed in supported.items():
+            value = getattr(self, name)
+            if not isinstance(value, str) or value not in allowed:
+                raise ValueError(f"unsupported {name} {value!r}")
+
+    @classmethod
+    def defaults(cls) -> DeltaFormats:
+        return cls(
+            delta_encoding="xor",
+            compression_format="zstd",
+            checksum_format="adler32",
+        )
+
+    @classmethod
+    def from_dict(cls, data: object) -> DeltaFormats:
+        expected = {"delta_encoding", "compression_format", "checksum_format"}
+        _require_exact_keys(data, expected, "formats")
+        assert isinstance(data, dict)
+        return cls(**{name: data[name] for name in expected})
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "delta_encoding": self.delta_encoding,
+            "compression_format": self.compression_format,
+            "checksum_format": self.checksum_format,
+        }
+
+
+@dataclass(frozen=True)
+class LedgerEntry:
+    version: int
+    identity: str
+    previous_snapshot_identity: str | None = None
+    formats: DeltaFormats | None = None
+
+    @property
+    def is_base(self) -> bool:
+        return self.version == 0
+
+
+@dataclass(frozen=True)
+class RecordResult:
+    entry: LedgerEntry
+    is_new: bool
+
+
+class IdentityLedger:
+    """One configured base followed by a contiguous append-only delta chain."""
+
+    def __init__(self, entries: list[LedgerEntry]) -> None:
+        self._entries = list(entries)
+        self._by_identity = {entry.identity: entry for entry in entries}
+
+    @classmethod
+    def new(cls, base_identity: str) -> IdentityLedger:
+        if not is_valid_identity(base_identity):
+            raise ValueError("base identity must be one safe non-empty path component")
+        return cls([LedgerEntry(version=0, identity=base_identity)])
+
+    @classmethod
+    def from_dict(cls, data: object, *, expected_base_identity: str) -> IdentityLedger:
+        """Parse persisted state without coercion and validate every invariant."""
+        try:
+            _require_exact_keys(
+                data, {"schema_version", "base_identity", "deltas"}, "ledger"
+            )
+            assert isinstance(data, dict)
+            schema_version = data["schema_version"]
+            if (
+                type(schema_version) is not int
+                or schema_version != LEDGER_SCHEMA_VERSION
+            ):
+                raise ValueError(f"unsupported schema_version {schema_version!r}")
+            base_identity = data["base_identity"]
+            if not is_valid_identity(base_identity):
+                raise ValueError("base_identity is invalid")
+            if base_identity != expected_base_identity:
+                raise ValueError(
+                    f"persisted base {base_identity!r} does not match configured base "
+                    f"{expected_base_identity!r}"
+                )
+            raw_deltas = data["deltas"]
+            if not isinstance(raw_deltas, list):
+                raise ValueError("deltas must be a list")
+
+            entries = [LedgerEntry(version=0, identity=base_identity)]
+            identities = {base_identity}
+            for version, raw_delta in enumerate(raw_deltas, start=1):
+                label = f"deltas[{version - 1}]"
+                _require_exact_keys(raw_delta, {"identity", "formats"}, label)
+                assert isinstance(raw_delta, dict)
+                identity = raw_delta["identity"]
+                if not is_valid_identity(identity):
+                    raise ValueError(f"{label}.identity is invalid")
+                if identity in identities:
+                    raise ValueError(f"identity {identity!r} appears more than once")
+                entries.append(
+                    LedgerEntry(
+                        version=version,
+                        identity=identity,
+                        previous_snapshot_identity=entries[-1].identity,
+                        formats=DeltaFormats.from_dict(raw_delta["formats"]),
+                    )
+                )
+                identities.add(identity)
+        except (KeyError, TypeError, ValueError) as exc:
+            if isinstance(exc, LedgerCorruption):
+                raise
+            raise LedgerCorruption(f"invalid {LEDGER_FILENAME}: {exc}") from exc
+        return cls(entries)
+
+    @property
+    def base_identity(self) -> str:
+        return self._entries[0].identity
+
+    @property
+    def head(self) -> LedgerEntry:
+        return self._entries[-1]
+
+    @property
+    def head_version(self) -> int:
+        return self.head.version
+
+    @property
+    def delta_entries(self) -> tuple[LedgerEntry, ...]:
+        return tuple(self._entries[1:])
+
+    def version_for(self, identity: str) -> int | None:
+        entry = self._by_identity.get(identity)
+        return entry.version if entry is not None else None
+
+    def identity_for(self, version: int) -> str | None:
+        if type(version) is not int or version < 0 or version >= len(self._entries):
+            return None
+        return self._entries[version].identity
+
+    def confirm_base(self, identity: str) -> RecordResult:
+        """Accept the configured base only while it remains the current head."""
+        if identity != self.base_identity:
+            raise LedgerConflict(
+                f"this deployment serves base {self.base_identity!r}, not {identity!r}"
+            )
+        if self.head_version != 0:
+            raise LedgerRewind(
+                f"base {identity!r} is older than current identity {self.head.identity!r}"
+            )
+        return RecordResult(self._entries[0], is_new=False)
+
+    def append_delta(
+        self,
+        identity: str,
+        previous_snapshot_identity: str,
+        formats: DeltaFormats,
+    ) -> RecordResult:
+        """Append one delta or accept an exact retry of the current head."""
+        if not is_valid_identity(identity) or not is_valid_identity(
+            previous_snapshot_identity
+        ):
+            raise LedgerConflict(
+                "identity and previous identity must be safe path components"
+            )
+        if not isinstance(formats, DeltaFormats):
+            raise LedgerConflict("formats must be validated DeltaFormats")
+
+        existing = self._by_identity.get(identity)
+        if existing is not None:
+            if existing.is_base:
+                raise LedgerConflict("the configured base cannot also be a delta")
+            if (
+                existing.previous_snapshot_identity != previous_snapshot_identity
+                or existing.formats != formats
+            ):
+                raise LedgerConflict(
+                    f"retry for identity {identity!r} does not match its recorded lineage and formats"
+                )
+            if existing.version != self.head_version:
+                raise LedgerRewind(
+                    f"identity {identity!r} is older than current identity {self.head.identity!r}"
+                )
+            return RecordResult(existing, is_new=False)
+
+        if previous_snapshot_identity != self.head.identity:
+            raise LedgerConflict(
+                f"previous_snapshot_identity {previous_snapshot_identity!r} must equal "
+                f"current identity {self.head.identity!r}"
+            )
+        entry = LedgerEntry(
+            version=self.head_version + 1,
+            identity=identity,
+            previous_snapshot_identity=previous_snapshot_identity,
+            formats=formats,
+        )
+        self._entries.append(entry)
+        self._by_identity[identity] = entry
+        return RecordResult(entry, is_new=True)
+
+    def to_dict(self) -> dict[str, Any]:
+        deltas: list[dict[str, Any]] = []
+        for entry in self.delta_entries:
+            assert entry.formats is not None
+            deltas.append(
+                {"identity": entry.identity, "formats": entry.formats.to_dict()}
+            )
+        return {
+            "schema_version": LEDGER_SCHEMA_VERSION,
+            "base_identity": self.base_identity,
+            "deltas": deltas,
+        }
+
+
+def _require_exact_keys(data: object, expected: set[str], label: str) -> None:
+    if not isinstance(data, dict):
+        raise ValueError(f"{label} must be an object")
+    actual = set(data)
+    if actual != expected:
+        raise ValueError(
+            f"{label} fields must be {sorted(expected)!r}, got {sorted(actual)!r}"
+        )

--- a/cookbook/standalone_rollouts/ledger_test.py
+++ b/cookbook/standalone_rollouts/ledger_test.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import unittest
+
+from cookbook.standalone_rollouts.ledger import (
+    DeltaFormats,
+    IdentityLedger,
+    LedgerConflict,
+    LedgerCorruption,
+    LedgerRewind,
+    is_valid_identity,
+)
+
+
+FORMATS = DeltaFormats(
+    delta_encoding="xor",
+    compression_format="zstd",
+    checksum_format="xxh3-128",
+)
+
+
+class IdentityTest(unittest.TestCase):
+    def test_identity_is_opaque_but_must_be_one_safe_path_component(self) -> None:
+        self.assertTrue(is_valid_identity("customer-checkpoint:abc_123"))
+        for identity in (
+            "",
+            ".",
+            "..",
+            "latest",
+            "identities.json",
+            ".stitch",
+            "nested/checkpoint",
+            "nested\\checkpoint",
+            "contains\x00nul",
+            "unpaired-surrogate-\ud800",
+            "x" * 256,
+        ):
+            with self.subTest(identity=identity):
+                self.assertFalse(is_valid_identity(identity))
+
+
+class LineageTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ledger = IdentityLedger.new("base")
+
+    def test_new_ledger_is_seeded_with_configured_base(self) -> None:
+        self.assertEqual(self.ledger.head_version, 0)
+        self.assertEqual(self.ledger.identity_for(0), "base")
+        self.assertEqual(self.ledger.version_for("base"), 0)
+
+    def test_deltas_form_one_contiguous_chain(self) -> None:
+        first = self.ledger.append_delta("delta-a", "base", FORMATS)
+        second = self.ledger.append_delta("delta-b", "delta-a", FORMATS)
+        self.assertTrue(first.is_new)
+        self.assertEqual(first.entry.version, 1)
+        self.assertEqual(second.entry.version, 2)
+        self.assertEqual(second.entry.previous_snapshot_identity, "delta-a")
+
+    def test_exact_head_retry_is_idempotent(self) -> None:
+        first = self.ledger.append_delta("delta-a", "base", FORMATS)
+        retry = self.ledger.append_delta("delta-a", "base", FORMATS)
+        self.assertTrue(first.is_new)
+        self.assertFalse(retry.is_new)
+        self.assertEqual(retry.entry, first.entry)
+
+    def test_retry_must_preserve_parent_and_formats(self) -> None:
+        self.ledger.append_delta("delta-a", "base", FORMATS)
+        different_formats = DeltaFormats(
+            delta_encoding="xor",
+            compression_format="zstd",
+            checksum_format="blake3",
+        )
+        for parent, formats in (("other", FORMATS), ("base", different_formats)):
+            with self.subTest(parent=parent, formats=formats):
+                with self.assertRaises(LedgerConflict):
+                    self.ledger.append_delta("delta-a", parent, formats)
+
+    def test_old_identity_retry_is_a_rewind(self) -> None:
+        self.ledger.append_delta("delta-a", "base", FORMATS)
+        self.ledger.append_delta("delta-b", "delta-a", FORMATS)
+        with self.assertRaises(LedgerRewind):
+            self.ledger.append_delta("delta-a", "base", FORMATS)
+
+    def test_unknown_old_or_self_parent_is_rejected(self) -> None:
+        self.ledger.append_delta("delta-a", "base", FORMATS)
+        for identity, parent in (
+            ("unknown-parent", "missing"),
+            ("fork", "base"),
+            ("self-parent", "self-parent"),
+        ):
+            with self.subTest(identity=identity, parent=parent):
+                with self.assertRaises(LedgerConflict):
+                    self.ledger.append_delta(identity, parent, FORMATS)
+
+    def test_only_configured_base_can_be_confirmed(self) -> None:
+        retry = self.ledger.confirm_base("base")
+        self.assertFalse(retry.is_new)
+        with self.assertRaises(LedgerConflict):
+            self.ledger.confirm_base("other-full-snapshot")
+
+    def test_base_confirmation_after_a_delta_is_a_rewind(self) -> None:
+        self.ledger.append_delta("delta-a", "base", FORMATS)
+        with self.assertRaises(LedgerRewind):
+            self.ledger.confirm_base("base")
+        with self.assertRaises(LedgerConflict):
+            self.ledger.append_delta("base", "base", FORMATS)
+
+
+class FormatTest(unittest.TestCase):
+    def test_only_decoder_supported_formats_are_accepted(self) -> None:
+        self.assertEqual(DeltaFormats.defaults().checksum_format, "adler32")
+        for kwargs in (
+            {"delta_encoding": "overwrite"},
+            {"compression_format": "gzip"},
+            {"checksum_format": "sha256"},
+        ):
+            values = {
+                "delta_encoding": "xor",
+                "compression_format": "zstd",
+                "checksum_format": "adler32",
+                **kwargs,
+            }
+            with self.subTest(values=values):
+                with self.assertRaises(ValueError):
+                    DeltaFormats(**values)
+
+
+class SerializationTest(unittest.TestCase):
+    def test_round_trip_uses_an_ordered_versioned_schema(self) -> None:
+        ledger = IdentityLedger.new("base")
+        ledger.append_delta("delta-a", "base", FORMATS)
+        data = ledger.to_dict()
+        self.assertEqual(
+            data,
+            {
+                "schema_version": 1,
+                "base_identity": "base",
+                "deltas": [
+                    {
+                        "identity": "delta-a",
+                        "formats": {
+                            "delta_encoding": "xor",
+                            "compression_format": "zstd",
+                            "checksum_format": "xxh3-128",
+                        },
+                    },
+                ],
+            },
+        )
+        restored = IdentityLedger.from_dict(data, expected_base_identity="base")
+        self.assertEqual(restored.to_dict(), data)
+
+    def test_expected_base_must_match_persisted_base(self) -> None:
+        data = IdentityLedger.new("base-a").to_dict()
+        with self.assertRaises(LedgerCorruption):
+            IdentityLedger.from_dict(data, expected_base_identity="base-b")
+
+    def test_malformed_persisted_state_never_coerces_or_seeds(self) -> None:
+        corruptions = [
+            {},
+            {
+                "schema_version": True,
+                "base_identity": "base",
+                "deltas": [],
+            },
+            {
+                "schema_version": 2,
+                "base_identity": "base",
+                "deltas": [],
+            },
+            {
+                "schema_version": 1,
+                "base_identity": "base",
+                "deltas": {},
+            },
+            {
+                "schema_version": 1,
+                "base_identity": "base",
+                "deltas": [
+                    {
+                        "identity": "delta",
+                        "formats": FORMATS.to_dict(),
+                        "extra": True,
+                    },
+                ],
+            },
+            {
+                "schema_version": 1,
+                "base_identity": "base",
+                "deltas": [
+                    {
+                        "identity": "base",
+                        "formats": FORMATS.to_dict(),
+                    },
+                ],
+            },
+        ]
+        for data in corruptions:
+            with self.subTest(data=data):
+                with self.assertRaises(LedgerCorruption):
+                    IdentityLedger.from_dict(data, expected_base_identity="base")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a strict base-seeded append-only mapping from opaque publisher identities to contiguous Stitch versions, including exact-head retry validation.

## Why

Opaque identities cannot safely drive the integer core protocol without durable lineage, format, and retry state.

## Validation

- Focused coverage: `cookbook/standalone_rollouts/ledger_test.py`
- Stack tip: `uv run pytest` (170 passed)

## Stack

PR 6 of 14. Base: `rewrite-5-deployment-boundary`. Next: `rewrite-7-derived-delta-view`.