### PR TITLE
feat(standalone_rollouts): derive an immutable delta view

### DIFF
--- a/cookbook/standalone_rollouts/delta_view.py
+++ b/cookbook/standalone_rollouts/delta_view.py
@@ -1,0 +1,253 @@
+"""Provider-owned decoder indexes and an immutable local version view."""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import shutil
+import threading
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from cookbook.standalone_rollouts.ledger import (
+    IdentityLedger,
+    LedgerEntry,
+    is_valid_identity,
+)
+from stitch.protocol import atomic_write_text, weight_identity
+
+
+INDEX_FILENAME = "model.safetensors.index.json"
+DERIVED_INDEX_ROOT = Path(".stitch") / "deltas"
+
+
+class DeltaIndexError(ValueError):
+    """An uploaded or derived delta index is malformed."""
+
+
+class DerivedDeltaConflict(DeltaIndexError):
+    """A committed derived index differs from the current upload."""
+
+
+@dataclass(frozen=True)
+class DerivedDelta:
+    index_path: Path
+    shard_names: tuple[str, ...]
+
+
+def derive_delta_index(
+    transport_root: str | Path,
+    entry: LedgerEntry,
+    *,
+    committed: bool,
+) -> DerivedDelta:
+    """Validate a raw upload and publish its deterministic decoder index.
+
+    ``committed=False`` may replace an orphan left before a ledger save.
+    ``committed=True`` accepts the exact existing artifact or recreates it when
+    missing, but never changes one that belongs to a committed ledger entry.
+    """
+    _validate_delta_entry(entry)
+    root = Path(transport_root)
+    upload_dir = root / entry.identity
+    _, weight_map, shard_names = _load_index(
+        upload_dir / INDEX_FILENAME, shard_dir=upload_dir
+    )
+    derived_data = {
+        "metadata": _expected_metadata(entry),
+        "weight_map": weight_map,
+    }
+    contents = _canonical_json(derived_data)
+    index_path = root / DERIVED_INDEX_ROOT / entry.identity / INDEX_FILENAME
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if committed:
+        try:
+            existing = index_path.read_bytes()
+        except FileNotFoundError:
+            pass
+        else:
+            if existing != contents.encode("utf-8"):
+                raise DerivedDeltaConflict(
+                    f"committed derived index for {entry.identity!r} does not match the upload"
+                )
+            return DerivedDelta(index_path=index_path, shard_names=shard_names)
+
+    atomic_write_text(index_path, contents)
+    return DerivedDelta(index_path=index_path, shard_names=shard_names)
+
+
+class LocalDeltaView:
+    """Materialize immutable slime ``weight_vN`` dirs from opaque uploads."""
+
+    def __init__(self, root: str | Path, transport_root: str | Path) -> None:
+        self.root = Path(root)
+        self.transport_root = Path(transport_root)
+        self._lock = threading.Lock()
+
+    def rebuild(self, ledger: IdentityLedger) -> None:
+        """Install every missing delta version; completed dirs never change."""
+        with self._lock:
+            self.root.mkdir(parents=True, exist_ok=True)
+            self._ensure_latest_link()
+            for entry in ledger.delta_entries:
+                self._install(entry)
+
+    def _ensure_latest_link(self) -> None:
+        link = self.root / "latest"
+        target = (self.transport_root / "latest").absolute()
+        if os.path.lexists(link):
+            if link.is_symlink() and Path(os.readlink(link)) == target:
+                return
+            raise DeltaIndexError(
+                f"local view path {link} is not the transport pointer link"
+            )
+        link.symlink_to(target)
+
+    def _install(self, entry: LedgerEntry) -> None:
+        _validate_delta_entry(entry)
+        version_name = weight_identity(entry.version)
+        destination = self.root / version_name
+        if destination.is_symlink():
+            raise DeltaIndexError(
+                f"local view path {destination} must not be a symlink"
+            )
+        if destination.is_dir():
+            return
+        if os.path.lexists(destination):
+            raise DeltaIndexError(f"local view path {destination} is not a directory")
+
+        derived_path = (
+            self.transport_root / DERIVED_INDEX_ROOT / entry.identity / INDEX_FILENAME
+        )
+        _, _, shard_names = _load_index(
+            derived_path,
+            shard_dir=self.transport_root / entry.identity,
+            expected_metadata=_expected_metadata(entry),
+            exact_top_level=True,
+        )
+        temporary = self.root / f".{version_name}.tmp-{uuid.uuid4().hex}"
+        temporary.mkdir()
+        try:
+            shutil.copyfile(derived_path, temporary / INDEX_FILENAME)
+            upload_dir = (self.transport_root / entry.identity).absolute()
+            for shard_name in shard_names:
+                (temporary / shard_name).symlink_to(upload_dir / shard_name)
+            try:
+                os.rename(temporary, destination)
+            except OSError as exc:
+                if (
+                    exc.errno not in {errno.EEXIST, errno.ENOTEMPTY}
+                    or not destination.is_dir()
+                ):
+                    raise
+        finally:
+            shutil.rmtree(temporary, ignore_errors=True)
+
+
+def _expected_metadata(entry: LedgerEntry) -> dict[str, str]:
+    if entry.is_base or entry.formats is None:
+        raise ValueError("a derived delta index requires a non-base ledger entry")
+    return {
+        "version": f"{entry.version:06d}",
+        "base_version": f"{entry.version - 1:06d}",
+        **entry.formats.to_dict(),
+    }
+
+
+def _validate_delta_entry(entry: LedgerEntry) -> None:
+    if (
+        type(entry.version) is not int
+        or entry.version <= 0
+        or not is_valid_identity(entry.identity)
+        or entry.formats is None
+    ):
+        raise DeltaIndexError("a derived index requires a validated delta ledger entry")
+
+
+def _load_index(
+    path: Path,
+    *,
+    shard_dir: Path,
+    expected_metadata: dict[str, str] | None = None,
+    exact_top_level: bool = False,
+) -> tuple[dict[str, Any], dict[str, str], tuple[str, ...]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise DeltaIndexError(f"{path} is not valid UTF-8 JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise DeltaIndexError(f"{path} must contain a JSON object")
+    if exact_top_level and set(data) != {"metadata", "weight_map"}:
+        raise DeltaIndexError(f"{path} must contain only metadata and weight_map")
+    if "metadata" not in data or not isinstance(data["metadata"], dict):
+        raise DeltaIndexError(f"{path}.metadata must be an object")
+    if expected_metadata is not None and data["metadata"] != expected_metadata:
+        raise DeltaIndexError(f"{path}.metadata does not match the identity ledger")
+    if "weight_map" not in data or not isinstance(data["weight_map"], dict):
+        raise DeltaIndexError(f"{path}.weight_map must be an object")
+
+    weight_map: dict[str, str] = {}
+    for tensor_name, shard_name in data["weight_map"].items():
+        if not _is_valid_text(tensor_name):
+            raise DeltaIndexError(f"{path}.weight_map has an invalid tensor name")
+        if not _is_safe_shard_name(shard_name):
+            raise DeltaIndexError(
+                f"{path}.weight_map[{tensor_name!r}] has unsafe shard {shard_name!r}"
+            )
+        weight_map[tensor_name] = shard_name
+
+    shard_names = tuple(sorted(set(weight_map.values())))
+    for shard_name in shard_names:
+        shard_path = shard_dir / shard_name
+        if shard_path.is_symlink():
+            raise DeltaIndexError(
+                f"referenced shard {shard_path} must not be a symlink"
+            )
+        try:
+            with shard_path.open("rb"):
+                pass
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                f"referenced shard {shard_path} is missing"
+            ) from None
+        except IsADirectoryError:
+            raise DeltaIndexError(
+                f"referenced shard {shard_path} is not a regular file"
+            ) from None
+    return data, weight_map, shard_names
+
+
+def _is_valid_text(value: object) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return not any(
+        ord(character) < 0x20 or ord(character) == 0x7F for character in value
+    )
+
+
+def _is_safe_shard_name(value: object) -> bool:
+    if not _is_valid_text(value):
+        return False
+    assert isinstance(value, str)
+    return (
+        len(value.encode("utf-8")) <= 255
+        and "/" not in value
+        and "\\" not in value
+        and value not in {".", "..", INDEX_FILENAME}
+        and value.endswith(".safetensors")
+    )
+
+
+def _canonical_json(data: dict[str, Any]) -> str:
+    return (
+        json.dumps(data, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    )

--- a/cookbook/standalone_rollouts/delta_view_test.py
+++ b/cookbook/standalone_rollouts/delta_view_test.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from cookbook.standalone_rollouts.delta_view import (
+    INDEX_FILENAME,
+    DeltaIndexError,
+    DerivedDeltaConflict,
+    LocalDeltaView,
+    derive_delta_index,
+)
+from cookbook.standalone_rollouts.ledger import (
+    DeltaFormats,
+    IdentityLedger,
+    LedgerEntry,
+)
+
+
+FORMATS = DeltaFormats(
+    delta_encoding="xor",
+    compression_format="zstd",
+    checksum_format="xxh3-128",
+)
+
+
+def _entry(identity: str = "delta-a", *, version: int = 1) -> LedgerEntry:
+    return LedgerEntry(
+        version=version,
+        identity=identity,
+        previous_snapshot_identity="base" if version == 1 else "delta-a",
+        formats=FORMATS,
+    )
+
+
+def _write_upload(
+    root: Path,
+    identity: str,
+    *,
+    index: object | None = None,
+    shard_names: tuple[str, ...] = ("model-00001-of-00001.safetensors",),
+) -> Path:
+    upload = root / identity
+    upload.mkdir(parents=True)
+    if index is None:
+        index = {
+            "metadata": {"total_size": 3},
+            "weight_map": {"tensor": shard_names[0]} if shard_names else {},
+        }
+    (upload / INDEX_FILENAME).write_text(json.dumps(index), encoding="utf-8")
+    for name in shard_names:
+        (upload / name).write_bytes(f"bytes:{name}".encode())
+    return upload
+
+
+class DeriveIndexTest(unittest.TestCase):
+    def test_derives_metadata_without_touching_the_upload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            upload = _write_upload(root, "delta-a")
+            before = {path.name: path.read_bytes() for path in upload.iterdir()}
+
+            derived = derive_delta_index(root, _entry(), committed=False)
+
+            self.assertEqual(
+                {path.name: path.read_bytes() for path in upload.iterdir()}, before
+            )
+            body = json.loads(derived.index_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                body["metadata"],
+                {
+                    "version": "000001",
+                    "base_version": "000000",
+                    "delta_encoding": "xor",
+                    "compression_format": "zstd",
+                    "checksum_format": "xxh3-128",
+                },
+            )
+            self.assertEqual(
+                body["weight_map"], {"tensor": "model-00001-of-00001.safetensors"}
+            )
+            self.assertNotIn(".stitch", {path.name for path in upload.iterdir()})
+
+    def test_rejects_an_unvalidated_ledger_entry_before_path_access(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            unsafe = LedgerEntry(
+                version=1,
+                identity="../outside",
+                previous_snapshot_identity="base",
+                formats=FORMATS,
+            )
+            with self.assertRaises(DeltaIndexError):
+                derive_delta_index(Path(tmp), unsafe, committed=False)
+
+    def test_empty_weight_map_is_a_valid_no_op_delta(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_upload(
+                root,
+                "delta-a",
+                index={"metadata": {}, "weight_map": {}},
+                shard_names=(),
+            )
+            derived = derive_delta_index(root, _entry(), committed=False)
+            self.assertEqual(derived.shard_names, ())
+
+    def test_rejects_malformed_index_or_unsafe_shard_names(self) -> None:
+        invalid_indexes = (
+            [],
+            {"weight_map": {}},
+            {"metadata": [], "weight_map": {}},
+            {"metadata": {}, "weight_map": []},
+            {"metadata": {}, "weight_map": {"tensor": 7}},
+            {"metadata": {}, "weight_map": {"tensor": "../outside.safetensors"}},
+            {"metadata": {}, "weight_map": {"tensor": "/absolute.safetensors"}},
+            {"metadata": {}, "weight_map": {"tensor": "nested/shard.safetensors"}},
+            {"metadata": {}, "weight_map": {"tensor": "nested\\shard.safetensors"}},
+            {"metadata": {}, "weight_map": {"tensor": "weights.bin"}},
+        )
+        for index in invalid_indexes:
+            with self.subTest(index=index), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                _write_upload(root, "delta-a", index=index, shard_names=())
+                with self.assertRaises(DeltaIndexError):
+                    derive_delta_index(root, _entry(), committed=False)
+
+    def test_missing_referenced_shard_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_upload(
+                root,
+                "delta-a",
+                index={
+                    "metadata": {},
+                    "weight_map": {"tensor": "missing.safetensors"},
+                },
+                shard_names=(),
+            )
+            with self.assertRaises(FileNotFoundError):
+                derive_delta_index(root, _entry(), committed=False)
+
+    def test_referenced_shard_must_be_a_regular_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            upload = _write_upload(root, "delta-a", shard_names=())
+            (upload / "directory.safetensors").mkdir()
+            (upload / INDEX_FILENAME).write_text(
+                json.dumps(
+                    {
+                        "metadata": {},
+                        "weight_map": {"tensor": "directory.safetensors"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaises(DeltaIndexError):
+                derive_delta_index(root, _entry(), committed=False)
+
+    def test_retry_recreates_missing_but_rejects_different_committed_index(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_upload(root, "delta-a")
+            first = derive_delta_index(root, _entry(), committed=False)
+            original = first.index_path.read_bytes()
+
+            derive_delta_index(root, _entry(), committed=True)
+            first.index_path.unlink()
+            recreated = derive_delta_index(root, _entry(), committed=True)
+            self.assertEqual(recreated.index_path.read_bytes(), original)
+
+            recreated.index_path.write_text("{}", encoding="utf-8")
+            with self.assertRaises(DerivedDeltaConflict):
+                derive_delta_index(root, _entry(), committed=True)
+
+            recreated.index_path.write_bytes(b"\xff")
+            with self.assertRaises(DerivedDeltaConflict):
+                derive_delta_index(root, _entry(), committed=True)
+
+    def test_new_entry_overwrites_a_precommit_orphan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_upload(root, "delta-a")
+            orphan = root / ".stitch" / "deltas" / "delta-a" / INDEX_FILENAME
+            orphan.parent.mkdir(parents=True)
+            orphan.write_text("orphan", encoding="utf-8")
+            derived = derive_delta_index(root, _entry(), committed=False)
+            self.assertNotEqual(
+                derived.index_path.read_text(encoding="utf-8"), "orphan"
+            )
+
+
+class LocalDeltaViewTest(unittest.TestCase):
+    def _ledger_and_uploads(self, transport: Path) -> IdentityLedger:
+        ledger = IdentityLedger.new("base")
+        first = ledger.append_delta("delta-a", "base", FORMATS).entry
+        second = ledger.append_delta("delta-b", "delta-a", FORMATS).entry
+        _write_upload(
+            transport,
+            "delta-a",
+            shard_names=("a.safetensors", "unreferenced.safetensors"),
+        )
+        _write_upload(transport, "delta-b", shard_names=("b.safetensors",))
+        derive_delta_index(transport, first, committed=False)
+        derive_delta_index(transport, second, committed=False)
+        return ledger
+
+    def test_builds_only_derived_index_and_referenced_shards(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            transport, local = base / "transport", base / "local"
+            transport.mkdir()
+            ledger = self._ledger_and_uploads(transport)
+
+            LocalDeltaView(local, transport).rebuild(ledger)
+
+            self.assertFalse((local / "weight_v000000").exists())
+            version = local / "weight_v000001"
+            self.assertTrue((version / INDEX_FILENAME).is_file())
+            self.assertFalse((version / INDEX_FILENAME).is_symlink())
+            self.assertTrue((version / "a.safetensors").is_symlink())
+            self.assertFalse((version / "unreferenced.safetensors").exists())
+            self.assertTrue((local / "latest").is_symlink())
+
+    def test_missing_shard_never_installs_partial_version_and_can_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            transport, local = base / "transport", base / "local"
+            transport.mkdir()
+            ledger = IdentityLedger.new("base")
+            entry = ledger.append_delta("delta-a", "base", FORMATS).entry
+            upload = _write_upload(transport, "delta-a")
+            derive_delta_index(transport, entry, committed=False)
+            shard = upload / "model-00001-of-00001.safetensors"
+            contents = shard.read_bytes()
+            shard.unlink()
+
+            view = LocalDeltaView(local, transport)
+            with self.assertRaises(FileNotFoundError):
+                view.rebuild(ledger)
+            self.assertFalse((local / "weight_v000001").exists())
+            self.assertEqual(list(local.glob(".*.tmp-*")), [])
+
+            shard.write_bytes(contents)
+            view.rebuild(ledger)
+            self.assertTrue((local / "weight_v000001").is_dir())
+
+    def test_concurrent_rebuilds_leave_one_complete_immutable_view(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            transport, local = base / "transport", base / "local"
+            transport.mkdir()
+            ledger = self._ledger_and_uploads(transport)
+            view = LocalDeltaView(local, transport)
+
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                list(pool.map(lambda _unused: view.rebuild(ledger), range(2)))
+
+            version = local / "weight_v000002"
+            self.assertTrue((version / INDEX_FILENAME).is_file())
+            self.assertTrue((version / "b.safetensors").is_symlink())
+            self.assertEqual(list(local.glob(".*.tmp-*")), [])
+
+    def test_existing_version_must_be_an_owned_directory_not_a_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            transport, local, outside = (
+                base / "transport",
+                base / "local",
+                base / "outside",
+            )
+            transport.mkdir()
+            local.mkdir()
+            outside.mkdir()
+            ledger = self._ledger_and_uploads(transport)
+            (local / "weight_v000001").symlink_to(outside, target_is_directory=True)
+            with self.assertRaises(DeltaIndexError):
+                LocalDeltaView(local, transport).rebuild(ledger)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Validate raw publisher uploads, publish provider-owned decoder indexes, and materialize immutable local weight_vN views containing only referenced shards.

## Why

The decoder needs Stitch metadata, but accepted publisher indexes and shards must remain byte-for-byte unchanged.

## Validation

- Focused coverage: `cookbook/standalone_rollouts/delta_view_test.py`
- Stack tip: `uv run pytest` (170 passed)

## Stack

PR 7 of 14. Base: `rewrite-6-identity-ledger`. Next: `rewrite-8-opaque-contract`.