### PR TITLE
feat(standalone_rollouts): define the opaque hot-load contract

### DIFF
--- a/cookbook/standalone_rollouts/opaque_protocol.py
+++ b/cookbook/standalone_rollouts/opaque_protocol.py
@@ -1,0 +1,188 @@
+"""Pure rules for the fixed-base opaque-identity hot-load contract."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from cookbook.standalone_rollouts.ledger import (
+    DeltaFormats,
+    IdentityLedger,
+    LedgerCorruption,
+    is_valid_identity,
+)
+from stitch.protocol import RolloutPoolState, RolloutReplicaState
+
+
+class HotLoadRequestError(ValueError):
+    """The JSON body does not match the fixed customer contract."""
+
+
+@dataclass(frozen=True)
+class HotLoadSignal:
+    identity: str
+    previous_snapshot_identity: str | None
+    formats: DeltaFormats | None
+
+    @property
+    def is_delta(self) -> bool:
+        return self.previous_snapshot_identity is not None
+
+
+@dataclass(frozen=True)
+class FrontdoorRecovery:
+    ledger: IdentityLedger
+    save_ledger: bool
+    pointer_to_write: int | None
+
+
+def parse_hot_load_payload(payload: object) -> HotLoadSignal:
+    """Parse the customer body strictly; no string or number coercion."""
+    _require_fields(
+        payload,
+        required={"identity"},
+        optional={"incremental_snapshot_metadata", "reset_prompt_cache"},
+        label="body",
+    )
+    assert isinstance(payload, dict)
+    identity = payload["identity"]
+    if not is_valid_identity(identity):
+        raise HotLoadRequestError(
+            "body.identity must be one non-empty filesystem-safe string"
+        )
+
+    if (
+        "reset_prompt_cache" in payload
+        and payload["reset_prompt_cache"] != "new_session"
+    ):
+        raise HotLoadRequestError(
+            "body.reset_prompt_cache, when present, must be 'new_session'"
+        )
+
+    if "incremental_snapshot_metadata" not in payload:
+        return HotLoadSignal(identity, previous_snapshot_identity=None, formats=None)
+
+    incremental = payload["incremental_snapshot_metadata"]
+    _require_fields(
+        incremental,
+        required={"previous_snapshot_identity"},
+        optional={"compression_format", "checksum_format"},
+        label="body.incremental_snapshot_metadata",
+    )
+    assert isinstance(incremental, dict)
+    previous = incremental["previous_snapshot_identity"]
+    if not is_valid_identity(previous):
+        raise HotLoadRequestError(
+            "incremental_snapshot_metadata.previous_snapshot_identity must be "
+            "one non-empty filesystem-safe string"
+        )
+    values = {
+        "delta_encoding": "xor",
+        "compression_format": incremental.get("compression_format", "zstd"),
+        "checksum_format": incremental.get("checksum_format", "adler32"),
+    }
+    if not all(isinstance(value, str) for value in values.values()):
+        raise HotLoadRequestError("delta format fields must be strings")
+    try:
+        formats = DeltaFormats(**values)
+    except ValueError as exc:
+        raise HotLoadRequestError(str(exc)) from exc
+    return HotLoadSignal(identity, previous_snapshot_identity=previous, formats=formats)
+
+
+def recover_frontdoor_state(
+    *,
+    persisted_ledger: object | None,
+    expected_base_identity: str,
+    pointer: tuple[str | None, int],
+) -> FrontdoorRecovery:
+    """Validate durable state and describe the minimal startup repair.
+
+    The ledger is the commit point. A pointer behind it is repaired to the head;
+    a pointer ahead of it cannot be explained by the transaction ordering and is
+    corruption. A missing ledger is seeded only when the pool is still at v0.
+    """
+    run_id, pointer_version = pointer
+    if run_id is not None:
+        raise LedgerCorruption("standalone rollout pointers must not be run-scoped")
+    if type(pointer_version) is not int or pointer_version < 0:
+        raise LedgerCorruption(f"invalid latest pointer version {pointer_version!r}")
+
+    if persisted_ledger is None:
+        if pointer_version != 0:
+            raise LedgerCorruption(
+                "identity ledger is missing while latest points above the configured base"
+            )
+        return FrontdoorRecovery(
+            ledger=IdentityLedger.new(expected_base_identity),
+            save_ledger=True,
+            pointer_to_write=0,
+        )
+
+    ledger = IdentityLedger.from_dict(
+        persisted_ledger, expected_base_identity=expected_base_identity
+    )
+    if pointer_version > ledger.head_version:
+        raise LedgerCorruption(
+            f"latest points to v{pointer_version}, ahead of ledger head v{ledger.head_version}"
+        )
+    pointer_to_write = (
+        ledger.head_version if pointer_version < ledger.head_version else None
+    )
+    return FrontdoorRecovery(
+        ledger=ledger,
+        save_ledger=False,
+        pointer_to_write=pointer_to_write,
+    )
+
+
+def pool_state_from_server_infos(
+    infos: list[dict[str, Any]], ledger: IdentityLedger
+) -> RolloutPoolState:
+    """Translate replica integer versions back to opaque customer identities."""
+    replicas: list[RolloutReplicaState] = []
+    for info in infos:
+        raw_version = info.get("current_version")
+        version = raw_version if type(raw_version) is int and raw_version >= 0 else None
+        identity = ledger.identity_for(version) if version is not None else None
+        sync_state = info.get("sync_state")
+        last_error = info.get("last_sync_error")
+        current_run_id = info.get("current_run_id")
+
+        reason: str | None = None
+        if last_error:
+            reason = str(last_error)
+        elif sync_state != "IDLE":
+            reason = str(sync_state or "unreachable")
+        elif current_run_id is not None:
+            reason = "replica is serving an unexpected run-scoped chain"
+        elif identity is None:
+            reason = "replica version is absent from the identity ledger"
+
+        replicas.append(
+            RolloutReplicaState(
+                readiness=reason is None,
+                current_version=version,
+                current_snapshot_identity=identity,
+                replica_id=info.get("replica_id") or info.get("run_id"),
+                sync_state=sync_state,
+                readiness_reason=reason,
+            )
+        )
+    return RolloutPoolState(replicas=replicas)
+
+
+def _require_fields(
+    data: object,
+    *,
+    required: set[str],
+    optional: set[str],
+    label: str,
+) -> None:
+    if not isinstance(data, dict):
+        raise HotLoadRequestError(f"{label} must be a JSON object")
+    fields = set(data)
+    missing = required - fields
+    unknown = fields - required - optional
+    if missing:
+        raise HotLoadRequestError(f"{label} is missing fields {sorted(missing)!r}")
+    if unknown:
+        raise HotLoadRequestError(f"{label} has unknown fields {sorted(unknown)!r}")

--- a/cookbook/standalone_rollouts/opaque_protocol_test.py
+++ b/cookbook/standalone_rollouts/opaque_protocol_test.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import unittest
+
+from cookbook.standalone_rollouts.ledger import (
+    DeltaFormats,
+    IdentityLedger,
+    LedgerCorruption,
+)
+from cookbook.standalone_rollouts.opaque_protocol import (
+    HotLoadRequestError,
+    parse_hot_load_payload,
+    pool_state_from_server_infos,
+    recover_frontdoor_state,
+)
+
+
+FORMATS = DeltaFormats(
+    delta_encoding="xor",
+    compression_format="zstd",
+    checksum_format="xxh3-128",
+)
+
+
+class ParseHotLoadPayloadTest(unittest.TestCase):
+    def test_parses_base_assertion_and_delta_defaults_without_coercion(self) -> None:
+        base = parse_hot_load_payload({"identity": "base"})
+        self.assertEqual(base.identity, "base")
+        self.assertIsNone(base.previous_snapshot_identity)
+        self.assertIsNone(base.formats)
+
+        delta = parse_hot_load_payload(
+            {
+                "identity": "opaque-delta",
+                "incremental_snapshot_metadata": {"previous_snapshot_identity": "base"},
+                "reset_prompt_cache": "new_session",
+            }
+        )
+        self.assertEqual(delta.previous_snapshot_identity, "base")
+        self.assertEqual(delta.formats, DeltaFormats.defaults())
+
+    def test_accepts_only_the_fixed_wire_schema(self) -> None:
+        invalid_payloads = (
+            None,
+            [],
+            {},
+            {"identity": 123},
+            {"identity": "../escape"},
+            {"identity": "base", "run_id": "old-run"},
+            {"identity": "delta", "incremental_snapshot_metadata": None},
+            {"identity": "delta", "incremental_snapshot_metadata": []},
+            {"identity": "delta", "incremental_snapshot_metadata": {}},
+            {
+                "identity": "delta",
+                "incremental_snapshot_metadata": {"previous_snapshot_identity": 12},
+            },
+            {
+                "identity": "delta",
+                "incremental_snapshot_metadata": {
+                    "previous_snapshot_identity": "../base"
+                },
+            },
+            {
+                "identity": "delta",
+                "incremental_snapshot_metadata": {
+                    "previous_snapshot_identity": "base",
+                    "compression_format": None,
+                },
+            },
+            {
+                "identity": "delta",
+                "incremental_snapshot_metadata": {
+                    "previous_snapshot_identity": "base",
+                    "compression_format": "gzip",
+                },
+            },
+            {
+                "identity": "delta",
+                "incremental_snapshot_metadata": {
+                    "previous_snapshot_identity": "base",
+                    "delta_encoding": "xor",
+                },
+            },
+            {
+                "identity": "delta",
+                "incremental_snapshot_metadata": {
+                    "previous_snapshot_identity": "base",
+                    "unexpected": True,
+                },
+            },
+            {"identity": "base", "reset_prompt_cache": None},
+            {"identity": "base", "reset_prompt_cache": "reuse"},
+        )
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                with self.assertRaises(HotLoadRequestError):
+                    parse_hot_load_payload(payload)
+
+
+class RecoveryTest(unittest.TestCase):
+    def test_missing_ledger_seeds_only_at_base_pointer(self) -> None:
+        recovery = recover_frontdoor_state(
+            persisted_ledger=None,
+            expected_base_identity="base",
+            pointer=(None, 0),
+        )
+        self.assertEqual(
+            recovery.ledger.to_dict(), IdentityLedger.new("base").to_dict()
+        )
+        self.assertTrue(recovery.save_ledger)
+        self.assertEqual(recovery.pointer_to_write, 0)
+
+        with self.assertRaises(LedgerCorruption):
+            recover_frontdoor_state(
+                persisted_ledger=None,
+                expected_base_identity="base",
+                pointer=(None, 1),
+            )
+
+    def test_existing_ledger_repairs_only_a_pointer_behind_its_head(self) -> None:
+        ledger = IdentityLedger.new("base")
+        ledger.append_delta("delta-a", "base", FORMATS)
+        ledger.append_delta("delta-b", "delta-a", FORMATS)
+
+        recovery = recover_frontdoor_state(
+            persisted_ledger=ledger.to_dict(),
+            expected_base_identity="base",
+            pointer=(None, 1),
+        )
+        self.assertFalse(recovery.save_ledger)
+        self.assertEqual(recovery.pointer_to_write, 2)
+
+        current = recover_frontdoor_state(
+            persisted_ledger=ledger.to_dict(),
+            expected_base_identity="base",
+            pointer=(None, 2),
+        )
+        self.assertIsNone(current.pointer_to_write)
+
+    def test_run_scoped_or_ahead_pointer_is_corruption(self) -> None:
+        ledger = IdentityLedger.new("base")
+        for pointer in (("old-run", 0), (None, 1), (None, True), (None, -1)):
+            with self.subTest(pointer=pointer):
+                with self.assertRaises(LedgerCorruption):
+                    recover_frontdoor_state(
+                        persisted_ledger=ledger.to_dict(),
+                        expected_base_identity="base",
+                        pointer=pointer,
+                    )
+
+
+class PoolStateTest(unittest.TestCase):
+    def test_ready_requires_idle_runless_and_a_known_ledger_identity(self) -> None:
+        ledger = IdentityLedger.new("base")
+        ledger.append_delta("delta-a", "base", FORMATS)
+        state = pool_state_from_server_infos(
+            [
+                {"replica_id": "base", "current_version": 0, "sync_state": "IDLE"},
+                {"replica_id": "delta", "current_version": 1, "sync_state": "IDLE"},
+                {"replica_id": "bool", "current_version": True, "sync_state": "IDLE"},
+                {"replica_id": "unknown", "current_version": 9, "sync_state": "IDLE"},
+                {
+                    "replica_id": "scoped",
+                    "current_run_id": "old-run",
+                    "current_version": 1,
+                    "sync_state": "IDLE",
+                },
+                {
+                    "replica_id": "error",
+                    "current_version": 1,
+                    "sync_state": "ERROR",
+                    "last_sync_error": "boom",
+                },
+            ],
+            ledger,
+        )
+        replicas = {replica.replica_id: replica for replica in state.replicas}
+        self.assertEqual(replicas["base"].current_snapshot_identity, "base")
+        self.assertTrue(replicas["base"].readiness)
+        self.assertEqual(replicas["delta"].current_snapshot_identity, "delta-a")
+        self.assertTrue(replicas["delta"].readiness)
+        for replica_id in ("bool", "unknown", "scoped", "error"):
+            self.assertFalse(replicas[replica_id].readiness, replica_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add strict wire parsing, startup recovery rules, and translation from provider integer versions back to opaque publisher identities.

## Why

The fixed-base API must reject unknown fields, forks, invalid formats, and impossible durable state rather than infer intent.

## Validation

- Focused coverage: `cookbook/standalone_rollouts/opaque_protocol_test.py`
- Stack tip: `uv run pytest` (170 passed)

## Stack

PR 8 of 14. Base: `rewrite-7-derived-delta-view`. Next: `rewrite-9-opaque-transaction`.