### PR TITLE
feat(standalone_rollouts): make opaque POSTs transactional

### DIFF
--- a/cookbook/standalone_rollouts/opaque_frontdoor.py
+++ b/cookbook/standalone_rollouts/opaque_frontdoor.py
@@ -1,0 +1,166 @@
+"""Transactional FastAPI adapter for the opaque hot-load protocol.
+
+This factory is additive until the following deployment-wiring PR switches the
+Modal front door to it. Keeping the old factory live makes every stack tip
+runnable while the transaction can be reviewed independently.
+
+No ``from __future__ import annotations`` here. FastAPI must evaluate the route
+handlers' factory-local ``Request`` annotations eagerly.
+"""
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from cookbook.standalone_rollouts.delta_view import (
+    DeltaIndexError,
+    DerivedDeltaConflict,
+)
+from cookbook.standalone_rollouts.ledger import (
+    IdentityLedger,
+    LedgerConflict,
+    LedgerRewind,
+)
+from cookbook.standalone_rollouts.opaque_protocol import (
+    HotLoadRequestError,
+    parse_hot_load_payload,
+    pool_state_from_server_infos,
+)
+
+
+HOT_LOAD_PATH = "/hot_load/v1/models/hot_load"
+INFERENCE_PATHS = (
+    "/generate",
+    "/v1/chat/completions",
+    "/v1/completions",
+)
+
+
+def create_opaque_frontdoor_app(
+    *,
+    ledger: IdentityLedger,
+    save_ledger: Callable[[dict[str, Any]], Awaitable[None]],
+    derive_delta: Callable[..., Awaitable[None]],
+    advance_to: Callable[[int], Awaitable[None]],
+    list_server_infos: Callable[[], Awaitable[list[dict[str, Any]]]],
+    proxy: Callable[..., Awaitable[Any]],
+    authorize: Callable[[Any], Any],
+    wake: Callable[[int], Awaitable[None]] | None = None,
+):
+    """Build the authenticated singleton front door from injected I/O."""
+    from fastapi import FastAPI, Request
+    from fastapi.responses import JSONResponse, Response
+
+    app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+    advance_lock = asyncio.Lock()
+    current_ledger = ledger
+    ledger_write_blocked = False
+
+    def _auth(request: Request):
+        return authorize(request.headers)
+
+    def _error(status: int, error_type: str, message: str) -> Response:
+        return JSONResponse(
+            {"error": {"type": error_type, "message": message}}, status_code=status
+        )
+
+    @app.post(HOT_LOAD_PATH, response_model=None)
+    async def post_hot_load(request: Request) -> Response:
+        nonlocal current_ledger, ledger_write_blocked
+        rejected = _auth(request)
+        if rejected is not None:
+            return rejected
+        try:
+            payload = await request.json()
+        except Exception:  # noqa: BLE001 - malformed JSON is a customer error
+            return _error(400, "InvalidRequest", "request body must be a JSON object")
+        try:
+            signal = parse_hot_load_payload(payload)
+        except HotLoadRequestError as exc:
+            return _error(400, type(exc).__name__, str(exc))
+
+        async with advance_lock:
+            if ledger_write_blocked:
+                return _error(
+                    503,
+                    "LedgerStateUncertain",
+                    "a prior ledger save had an uncertain outcome; restart to recover durable state",
+                )
+            candidate = IdentityLedger.from_dict(
+                current_ledger.to_dict(),
+                expected_base_identity=current_ledger.base_identity,
+            )
+            try:
+                if signal.is_delta:
+                    assert signal.previous_snapshot_identity is not None
+                    assert signal.formats is not None
+                    result = candidate.append_delta(
+                        signal.identity,
+                        signal.previous_snapshot_identity,
+                        signal.formats,
+                    )
+                    await derive_delta(result.entry, committed=not result.is_new)
+                else:
+                    result = candidate.confirm_base(signal.identity)
+            except LedgerRewind as exc:
+                return _error(409, "WeightRewindRejected", str(exc))
+            except LedgerConflict as exc:
+                return _error(409, type(exc).__name__, str(exc))
+            except FileNotFoundError as exc:
+                return _error(409, "CheckpointNotFound", str(exc))
+            except DerivedDeltaConflict as exc:
+                return _error(409, type(exc).__name__, str(exc))
+            except DeltaIndexError as exc:
+                return _error(400, type(exc).__name__, str(exc))
+
+            if result.is_new:
+                # An exception can arrive after the backend durably publishes.
+                # Poison writes until startup recovery reloads the transport
+                # rather than guessing whether the candidate committed.
+                ledger_write_blocked = True
+                try:
+                    await save_ledger(candidate.to_dict())
+                except BaseException:
+                    raise
+                current_ledger = candidate
+                ledger_write_blocked = False
+
+            # Pointer failures are unambiguous: the ledger already committed, so
+            # memory stays advanced and an exact retry can repair latest.
+            await advance_to(result.entry.version)
+
+        if wake is not None:
+            try:
+                await wake(result.entry.version)
+            except Exception:  # noqa: BLE001 - wake is only a latency optimization
+                pass
+        return JSONResponse(
+            {
+                "accepted": True,
+                "identity": result.entry.identity,
+                "current_snapshot_identity": result.entry.identity,
+                "version": result.entry.version,
+                "already_current": not result.is_new,
+            }
+        )
+
+    @app.get(HOT_LOAD_PATH, response_model=None)
+    async def get_hot_load(request: Request) -> Response:
+        rejected = _auth(request)
+        if rejected is not None:
+            return rejected
+        infos = await list_server_infos()
+        return JSONResponse(
+            pool_state_from_server_infos(infos, current_ledger).to_dict()
+        )
+
+    async def proxy_inference(request: Request) -> Response:
+        rejected = _auth(request)
+        if rejected is not None:
+            return rejected
+        return await proxy(request, request.url.path.lstrip("/"))
+
+    for path in INFERENCE_PATHS:
+        app.add_api_route(path, proxy_inference, methods=["POST"], response_model=None)
+
+    return app

--- a/cookbook/standalone_rollouts/opaque_frontdoor_test.py
+++ b/cookbook/standalone_rollouts/opaque_frontdoor_test.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+
+from cookbook.standalone_rollouts.delta_view import (
+    DeltaIndexError,
+    DerivedDeltaConflict,
+)
+from cookbook.standalone_rollouts.ledger import IdentityLedger
+from cookbook.standalone_rollouts.opaque_frontdoor import (
+    HOT_LOAD_PATH,
+    create_opaque_frontdoor_app,
+)
+
+
+class FrontdoorHarness:
+    def __init__(self, *, authorize=None) -> None:
+        from fastapi.responses import JSONResponse
+        from fastapi.testclient import TestClient
+
+        self.events: list[tuple] = []
+        self.pointer = 0
+        self.fail_derive: Exception | None = None
+        self.fail_save: BaseException | None = None
+        self.fail_advance = False
+        self.fail_wake = False
+        self.infos = [{"replica_id": "r1", "current_version": 0, "sync_state": "IDLE"}]
+        ledger = IdentityLedger.new("base")
+        self.persisted_ledger = ledger.to_dict()
+
+        async def save_ledger(data) -> None:
+            self.events.append(("save", data))
+            self.persisted_ledger = data
+            if self.fail_save is not None:
+                error, self.fail_save = self.fail_save, None
+                raise error
+
+        async def derive_delta(entry, *, committed: bool) -> None:
+            self.events.append(("derive", entry.identity, committed))
+            if self.fail_derive is not None:
+                error, self.fail_derive = self.fail_derive, None
+                raise error
+
+        async def advance_to(version: int) -> None:
+            self.events.append(("advance", version))
+            if self.fail_advance:
+                self.fail_advance = False
+                raise OSError("advance failed")
+            self.pointer = version
+
+        async def list_server_infos():
+            return self.infos
+
+        async def proxy(_request, path):
+            self.events.append(("proxy", path))
+            return JSONResponse({"proxied": path})
+
+        async def wake(version: int) -> None:
+            self.events.append(("wake", version))
+            if self.fail_wake:
+                self.fail_wake = False
+                raise OSError("wake failed")
+
+        app = create_opaque_frontdoor_app(
+            ledger=ledger,
+            save_ledger=save_ledger,
+            derive_delta=derive_delta,
+            advance_to=advance_to,
+            list_server_infos=list_server_infos,
+            proxy=proxy,
+            authorize=authorize or (lambda _headers: None),
+            wake=wake,
+        )
+        self.client = TestClient(app, raise_server_exceptions=False)
+
+    def post_delta(
+        self,
+        identity: str = "delta-a",
+        previous: str = "base",
+        *,
+        checksum: str = "xxh3-128",
+    ):
+        return self.client.post(
+            HOT_LOAD_PATH,
+            json={
+                "identity": identity,
+                "incremental_snapshot_metadata": {
+                    "previous_snapshot_identity": previous,
+                    "compression_format": "zstd",
+                    "checksum_format": checksum,
+                },
+                "reset_prompt_cache": "new_session",
+            },
+        )
+
+
+class FrontdoorAppTest(unittest.TestCase):
+    def test_new_delta_orders_derive_save_advance_then_wake(self) -> None:
+        harness = FrontdoorHarness()
+        response = harness.post_delta()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["current_snapshot_identity"], "delta-a")
+        self.assertEqual(response.json()["version"], 1)
+        self.assertEqual(
+            [event[0] for event in harness.events],
+            ["derive", "save", "advance", "wake"],
+        )
+        self.assertEqual(harness.events[0], ("derive", "delta-a", False))
+
+    def test_exact_head_retry_revalidates_repairs_pointer_and_wakes(self) -> None:
+        harness = FrontdoorHarness()
+        self.assertEqual(harness.post_delta().status_code, 200)
+        harness.events.clear()
+        response = harness.post_delta()
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["already_current"])
+        self.assertEqual(
+            harness.events,
+            [("derive", "delta-a", True), ("advance", 1), ("wake", 1)],
+        )
+
+    def test_pointer_failure_converges_on_exact_retry(self) -> None:
+        harness = FrontdoorHarness()
+        harness.fail_advance = True
+        self.assertEqual(harness.post_delta().status_code, 500)
+        self.assertEqual(harness.pointer, 0)
+        harness.events.clear()
+
+        self.assertEqual(harness.post_delta().status_code, 200)
+        self.assertEqual(harness.pointer, 1)
+        self.assertEqual(
+            harness.events,
+            [("derive", "delta-a", True), ("advance", 1), ("wake", 1)],
+        )
+
+    def test_ambiguous_save_failure_blocks_writes_until_recovery(self) -> None:
+        harness = FrontdoorHarness()
+        harness.fail_save = OSError("save outcome unknown")
+        self.assertEqual(harness.post_delta().status_code, 500)
+        persisted = IdentityLedger.from_dict(
+            harness.persisted_ledger, expected_base_identity="base"
+        )
+        self.assertEqual(persisted.head.identity, "delta-a")
+        harness.events.clear()
+
+        response = harness.post_delta()
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["type"], "LedgerStateUncertain")
+        self.assertEqual(harness.events, [])
+
+    def test_cancelled_save_also_blocks_writes_until_recovery(self) -> None:
+        harness = FrontdoorHarness()
+        harness.fail_save = asyncio.CancelledError()
+        try:
+            harness.post_delta()
+        except BaseException:
+            pass
+        harness.events.clear()
+
+        response = harness.post_delta()
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["type"], "LedgerStateUncertain")
+        self.assertEqual(harness.events, [])
+
+    def test_customer_failures_do_not_advance_and_storage_failures_remain_5xx(
+        self,
+    ) -> None:
+        failures = (
+            (FileNotFoundError("upload missing"), 409),
+            (DeltaIndexError("bad index"), 400),
+            (DerivedDeltaConflict("changed upload"), 409),
+        )
+        for failure, expected in failures:
+            with self.subTest(failure=failure):
+                harness = FrontdoorHarness()
+                harness.fail_derive = failure
+                self.assertEqual(harness.post_delta().status_code, expected)
+                self.assertEqual(harness.pointer, 0)
+                self.assertNotIn("advance", [event[0] for event in harness.events])
+
+        harness = FrontdoorHarness()
+        harness.fail_save = FileNotFoundError("ledger mount unavailable")
+        self.assertEqual(harness.post_delta().status_code, 500)
+        self.assertEqual(harness.pointer, 0)
+
+    def test_base_forks_contradictory_retries_and_rewinds_are_rejected(self) -> None:
+        harness = FrontdoorHarness()
+        self.assertEqual(
+            harness.client.post(HOT_LOAD_PATH, json={"identity": "base"}).status_code,
+            200,
+        )
+        self.assertEqual(
+            harness.client.post(HOT_LOAD_PATH, json={"identity": "other"}).status_code,
+            409,
+        )
+        self.assertEqual(harness.post_delta().status_code, 200)
+        self.assertEqual(
+            harness.post_delta("delta-a", "base", checksum="blake3").status_code,
+            409,
+        )
+        self.assertEqual(harness.post_delta("delta-b", "base").status_code, 409)
+        self.assertEqual(harness.post_delta("delta-b", "delta-a").status_code, 200)
+        self.assertEqual(harness.post_delta("delta-a", "base").status_code, 409)
+        self.assertEqual(
+            harness.client.post(HOT_LOAD_PATH, json={"identity": "base"}).status_code,
+            409,
+        )
+
+    def test_wake_is_best_effort_and_get_uses_committed_ledger(self) -> None:
+        harness = FrontdoorHarness()
+        harness.fail_wake = True
+        self.assertEqual(harness.post_delta().status_code, 200)
+        harness.infos = [
+            {"replica_id": "r1", "current_version": 1, "sync_state": "IDLE"}
+        ]
+        body = harness.client.get(HOT_LOAD_PATH).json()
+        self.assertEqual(body["replicas"][0]["current_snapshot_identity"], "delta-a")
+        self.assertTrue(body["replicas"][0]["readiness"])
+
+    def test_closed_surface_and_auth(self) -> None:
+        from fastapi.responses import JSONResponse
+
+        harness = FrontdoorHarness()
+        response = harness.client.post("/v1/chat/completions", json={})
+        self.assertEqual(response.json(), {"proxied": "v1/chat/completions"})
+        for path in (
+            "/health",
+            "/server_info",
+            "/docs",
+            "/openapi.json",
+            "/v1/internal/control",
+            "/v1/%2e%2e/server_info",
+        ):
+            self.assertEqual(harness.client.get(path).status_code, 404, path)
+
+        denied = FrontdoorHarness(
+            authorize=lambda _headers: JSONResponse(
+                {"error": "unauthorized"}, status_code=401
+            )
+        )
+        self.assertEqual(denied.post_delta().status_code, 401)
+        self.assertEqual(denied.client.get(HOT_LOAD_PATH).status_code, 401)
+        self.assertEqual(
+            denied.client.post("/v1/chat/completions", json={}).status_code, 401
+        )
+        self.assertEqual(denied.events, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Order hot-load acceptance as derive, ledger commit, then pointer advance; repair pointer failures on exact retry and poison writes after an ambiguous ledger save.

## Why

Object storage offers no multi-object transaction, so the front door needs one explicit commit point and deterministic crash recovery.

## Validation

- Focused coverage: `cookbook/standalone_rollouts/opaque_frontdoor_test.py`
- Stack tip: `uv run pytest` (170 passed)

## Stack

PR 9 of 14. Base: `rewrite-8-opaque-contract`. Next: `rewrite-10-opaque-integration`.