### PR TITLE
sync: drain_all on run switches

### DIFF
--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -38,8 +38,11 @@ class AdmissionGate:
 
     ``quiesce`` drains all in-flight requests and flushes before applying; ``in_place``
     pauses the engine and lets non-exact requests keep decoding on stale KV (only exact
-    pins are drained). Either way the committer holds the lock across the apply and the
-    version flip, so no request is ever admitted seeing the stale version on new weights.
+    pins are drained) — but only across *compatible* commits: an incompatible transition
+    (a run switch's base reset) commits with ``drain_all=True``, which drains and gates
+    everything regardless of mode. Either way the committer holds the lock across the
+    apply and the version flip, so no request is ever admitted seeing the stale version
+    on new weights.
     """
 
     def __init__(self, *, commit_mode: CommitMode = "quiesce") -> None:
@@ -48,6 +51,7 @@ class AdmissionGate:
         self._cond = asyncio.Condition()
         self._active = 0
         self._committing = False
+        self._drain_all = False
         self._exact_inflight: dict[int, int] = defaultdict(int)
 
     @property
@@ -57,9 +61,12 @@ class AdmissionGate:
     def _gated(self, c: VersionConstraint) -> bool:
         if not self._committing:
             return False
-        # in_place lets non-exact requests cross a commit — they were stamped with the
-        # admission version, so a mislabel is only old-era impurity. Exact pins can't cross.
-        return c.exact_version is not None if self.commit_mode == "in_place" else True
+        # in_place lets non-exact requests cross a compatible commit — they were stamped
+        # with the admission version, so a mislabel is only old-era impurity. Exact pins
+        # can't cross, and nothing crosses an incompatible (drain_all) transition.
+        if self._drain_all or self.commit_mode != "in_place":
+            return True
+        return c.exact_version is not None
 
     def _rejection(self, c: VersionConstraint) -> dict[str, Any] | None:
         applied = self.applied.version if self.applied else None
@@ -77,7 +84,7 @@ class AdmissionGate:
         """Hook, run under the lock, when a request is rejected."""
 
     def _commit_ready(self) -> bool:
-        if self.commit_mode == "in_place":
+        if self.commit_mode == "in_place" and not self._drain_all:
             return not any(self._exact_inflight.values())
         return self._active == 0
 
@@ -114,15 +121,20 @@ class AdmissionGate:
         on_applied: Callable[[], None],
         pause: Callable[[], Awaitable[None]] | None = None,
         resume: Callable[[], Awaitable[None]] | None = None,
+        drain_all: bool = False,
     ) -> None:
         """Wait for the commit point, close the gate, apply, flip the served version
         (``on_applied``) while the gate is held, then reopen. ``on_applied`` runs only
-        after a successful apply; in ``in_place`` the flip happens before ``resume``."""
+        after a successful apply; in ``in_place`` the flip happens before ``resume``.
+        ``drain_all`` marks an incompatible transition (a base reset): drain and gate
+        every request regardless of mode — rolling requests may cross a compatible
+        weight update, never a change of lineage (stitch#32)."""
         # Close admission BEFORE draining (stitch#32): with the gate still open during
         # the drain, new requests keep being admitted and an in_place non-exact request
         # can straddle a base reset. Set _committing first, then wait for the drain.
         async with self._cond:
             self._committing = True
+            self._drain_all = drain_all
             self._cond.notify_all()
         try:
             async with self._cond:
@@ -141,6 +153,7 @@ class AdmissionGate:
         finally:
             async with self._cond:
                 self._committing = False
+                self._drain_all = False
                 self._cond.notify_all()
 
 
@@ -343,7 +356,9 @@ class Reconciler(AdmissionGate):
 
     async def _switch_run(self, new_run: str | None) -> None:
         """Rebase onto a new run: reset to base (the engine reseeds on the next stage).
-        Runs through the commit gate so no in-flight request decodes across the wipe."""
+        Commits with ``drain_all`` — a base reset is an incompatible transition, so even
+        in ``in_place`` mode no rolling request is admitted during, or decodes across,
+        the wipe."""
         old_run = self.applied.run_id if self.applied else None
         logger.info("run change %r -> %r: resetting to base", old_run, new_run)
         # Reset when the engine holds patched weights (v>0), or a prior pass errored and
@@ -365,4 +380,5 @@ class Reconciler(AdmissionGate):
             on_applied=on_applied,
             pause=self.engine.pause,
             resume=self.engine.resume,
+            drain_all=True,
         )

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -153,6 +153,66 @@ def test_run_switch_resets_in_place() -> None:
     _run(go())
 
 
+def test_run_switch_drains_rolling_requests() -> None:
+    # A base reset is an incompatible transition: even in in_place mode no rolling request
+    # is admitted during, or decodes across, the wipe (drain_all; stitch#32 / review P0-B).
+    async def go() -> None:
+        engine = FakeEngine()
+        r = Reconciler(store=FakeStore(VersionRef("r2", 1), _full("r2", 1)), engine=engine, commit_mode="in_place")
+        r.applied = VersionRef("r1", 5)
+        release = asyncio.Event()
+        late_served: list[VersionRef | None] = []
+
+        async def rolling() -> None:
+            async with r.admit(None):
+                await release.wait()
+
+        async def late() -> None:
+            async with r.admit(None) as served:
+                late_served.append(served)
+
+        req = asyncio.create_task(rolling())
+        await asyncio.sleep(0)  # admitted before the switch begins
+        sync = asyncio.create_task(r.reconcile())
+        for _ in range(1000):  # bounded: without drain_all the switch completes without draining
+            if r._committing:
+                break
+            await asyncio.sleep(0.001)
+        late_task = asyncio.create_task(late())
+        await asyncio.sleep(0.05)
+        assert "reset" not in engine.calls  # the wipe waits for the rolling request
+        assert not late_served  # and nothing is admitted while draining
+        release.set()
+        await asyncio.gather(req, sync, late_task)
+        assert "reset" in engine.calls
+        assert late_served[0] is not None and late_served[0].run_id == "r2"  # admitted post-wipe
+
+    _run(go())
+
+
+def test_rolling_requests_cross_in_place_commit() -> None:
+    # The counterpart: a *compatible* in_place commit never waits on rolling traffic —
+    # the update applies while the request keeps decoding; only a base reset drains.
+    async def go() -> None:
+        engine = FakeEngine()
+        r = Reconciler(store=FakeStore(VersionRef("r1", 4), _full("r1", 4)), engine=engine, commit_mode="in_place")
+        r.applied = VersionRef("r1", 3)
+        release = asyncio.Event()
+
+        async def rolling() -> None:
+            async with r.admit(None):
+                await release.wait()
+
+        req = asyncio.create_task(rolling())
+        await asyncio.sleep(0)
+        await r.reconcile()  # completes while the rolling request is still in flight
+        assert r.applied == VersionRef("r1", 4)
+        release.set()
+        await req
+
+    _run(go())
+
+
 def test_empty_delta_skips_reload() -> None:
     async def go() -> None:
         engine = FakeEngine()


### PR DESCRIPTION
Ports the `drain_all` half of stack PR #32 (`5db705e`) that `ac6bc3d` didn't carry. (A literal rebase wasn't viable — v1's `RolloutAdmissionGate`/`WeightSyncManager` don't exist here — so this is a fresh port, as discussed.)

## Problem
`in_place` deliberately lets rolling (non-exact) requests cross **compatible** weight commits. But `_switch_run` committed through the same mode-dependent gate, so in `in_place` mode a rolling request could be admitted during — and decode across — a **base reset** (an incompatible transition: different lineage, wiped weights). This is the external review's P0-B distinction, and `in_place` is the configured mode for the NVFP4 configs (kimi_k2_6, kimi_k25_2layer, moonlight) and glm45_air_bf16 — so it's the live path, not an edge case.

## Change
- `AdmissionGate.commit(..., drain_all=True)`: gates **all** admissions and waits for **all** in-flight requests regardless of `commit_mode`. Compatible commits are unchanged.
- `_switch_run` commits with `drain_all=True`.

Net: rolling requests may cross a compatible weight update, never a change of lineage.

## Tests
- `test_run_switch_drains_rolling_requests` (in_place): the wipe waits for an in-flight rolling request; nothing is admitted while draining; a late request is admitted post-wipe on the new run. **Verified red without the fix** (fails in ~1s on `'reset' not in engine.calls`) and green with it.
- `test_rolling_requests_cross_in_place_commit`: the counterpart — a compatible in_place commit completes while a rolling request is still in flight, pinning that drain_all didn't break in_place's raison d'être.

`uv run pytest`: 38 passed. Direct-run harness: `reconcile harness: 16 PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCAdJizffy3fwe4sQZL7So