### PR TITLE
cookbook: bump sglang fork pin to v0.5.15.post1

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -12,15 +12,15 @@ sglang release*.
 `python/` onto a stock sglang container:
 
 ```python
-SGLANG_IMAGE_TAG   = "lmsysorg/sglang:v0.5.15"          # base kernels/CUDA
-SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.15"            # modal-projects/sglang
-SGLANG_FORK_COMMIT = "13479b59cccd77459fb003d2f2e138e4cca8ed17"
+SGLANG_IMAGE_TAG   = "lmsysorg/sglang:v0.5.15.post1"    # base kernels/CUDA
+SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.15-post1"      # modal-projects/sglang
+SGLANG_FORK_COMMIT = "fd86c9155dfb651019a13f7229cd83bd0577752d"
 ```
 
-The branch is **`v0.5.15` + the patch stack below, nothing else** — every commit
-`git log v0.5.15..stitch-sglang-v0.5.15` is one of ours. Because only `python/` is
-overlaid, `SGLANG_IMAGE_TAG` **must** be the same sglang version the branch is based
-on (`v0.5.15`), or the baked C++/CUDA ops will be ABI-mismatched with the python.
+The branch is **`v0.5.15.post1` + the patch stack below, nothing else** — every commit
+`git log v0.5.15.post1..stitch-sglang-v0.5.15-post1` is one of ours. Because only `python/`
+is overlaid, `SGLANG_IMAGE_TAG` **must** be the same sglang version the branch is based on
+(`v0.5.15.post1`), or the baked C++/CUDA ops will be ABI-mismatched with the python.
 
 ## The patch stack
 
@@ -119,6 +119,11 @@ When bumping the base (e.g. to `v0.5.16`):
    same bytes via `/weights_checker` (per-tensor checksums) before shipping — this is
    how the NVFP4 partial pass is proven correct.
 5. Update the three constants in `cookbook/common/serving_image.py` and this file.
+
+_Most recent bump: `v0.5.15` → `v0.5.15.post1` — a clean cherry-pick of all seven commits.
+`git range-diff` was identical (post1's changes are disjoint from the patch surface except
+`scheduler.py` / `server_args.py`, which auto-merged). GPU byte-identical reload validation
+runs at the next e2e._
 
 ## Upstreaming
 

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -3,7 +3,7 @@
 Trainer-agnostic: no trainer package is installed (the delta apply lives in the engine
 behind ``/pull_weights``), so miles and slime serve on the identical image; precision
 comes from the served checkpoint, not a ``--quantization`` flag. The base image supplies
-kernels/CUDA; the fork pin (branch ``stitch-sglang-v0.5.15`` over base tag ``v0.5.15``)
+kernels/CUDA; the fork pin (branch ``stitch-sglang-v0.5.15-post1`` over base tag ``v0.5.15.post1``)
 carries ``/pull_weights``, the hardened local_checkpoint receiver, the quantized-reload
 restore protocol (reload == init), and the O(delta) partial-reload load plan. See
 ``SGLANG_FORK.md`` next to this file for the full patch stack, the upstreaming PRs, and
@@ -19,10 +19,10 @@ import modal
 # Fork = base sglang tag + the stitch weight-sync patch stack (see SGLANG_FORK.md).
 # The base tag MUST match the branch's base tag: the fork overlays python/ only, so the
 # baked kernels/CUDA come from this image and must be ABI-compatible with that python/.
-SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.15"
+SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.15.post1"
 SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
-SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.15"
-SGLANG_FORK_COMMIT = "13479b59cccd77459fb003d2f2e138e4cca8ed17"
+SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.15-post1"
+SGLANG_FORK_COMMIT = "fd86c9155dfb651019a13f7229cd83bd0577752d"
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent  # .../cookbook
 


### PR DESCRIPTION
Rebases the sglang weight-sync/reload patch stack from `v0.5.15` onto **`v0.5.15.post1`**.

- New fork branch: `stitch-sglang-v0.5.15-post1` @ `fd86c9155d` (modal-projects/sglang).
- Clean cherry-pick of all seven patches — `git range-diff` against the `v0.5.15` stack is **identical**. `post1`'s seven commits (DSA / eagle / disaggregation / deepseek attention) are disjoint from our patch surface except `scheduler.py` and `server_args.py`, which auto-merged; our additions there are byte-for-byte intact and every patched module compiles.
- Updates the three pins + prose in `cookbook/common/serving_image.py` and `SGLANG_FORK.md`.

Per `SGLANG_FORK.md`, GPU byte-identical reload validation (`/weights_checker`) runs at the next e2e — the reload patches themselves are unchanged and `post1` doesn't touch `model_runner` / `model_loader` / the quant layers.