### PR TITLE
sync: never skip a non-empty delta that lacks touched names (full-reload guard)

### DIFF
--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -292,11 +292,11 @@ class Reconciler(AdmissionGate):
         if applied is None or applied.run_id != ref.run_id or ref.version <= applied.version:
             return None
         names: set[str] = set()
-        # Walk back from the target toward the served version. The stage seeds from the newest
-        # FULL at or below the target, so a FULL above `applied` means a reseed => full reload.
         for v in range(ref.version, applied.version, -1):
             m = target if v == ref.version else self.store.read_manifest(VersionRef(ref.run_id, v))
-            if m.kind is not VersionKind.DELTA:
+            # full reload (None) for either: a FULL anchor in range (the stage reseeds from it), or a
+            # non-empty delta with no recorded touched names (an empty union would skip it → stale)
+            if m.kind is not VersionKind.DELTA or (m.files and not m.tensor_names):
                 return None
             names.update(m.tensor_names)
         return sorted(names)

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -252,6 +252,24 @@ def test_touched_names_union_reaches_commit() -> None:
     _run(go())
 
 
+def test_delta_without_touched_names_full_reloads_not_skips() -> None:
+    # A store that records a non-empty delta but NOT its touched tensor names must full-reload,
+    # never skip: an empty touched-set reads as "nothing changed" and would advance the version
+    # onto stale weights (the cognition DeltaStore regression). weight_names=None => full reload.
+    async def go() -> None:
+        engine = FakeEngine()
+        store = FakeStore(VersionRef("r1", 5), _delta("r1", 5, files=["f1"], tensor_names=[]))
+        r = Reconciler(store=store, engine=engine)
+        r.applied = VersionRef("r1", 4)
+        await r.reconcile()
+        assert r.applied == VersionRef("r1", 5)
+        assert engine.committed == [VersionRef("r1", 5)]  # reloaded, not skipped
+        assert engine.commit_weight_names == [None]       # full reload (touched names unknown)
+        assert r.metrics.get("skipped_reload") is not True
+
+    _run(go())
+
+
 def test_periodic_reconcile_recovers_missed_wake() -> None:
     async def go() -> None:
         engine = FakeEngine()


### PR DESCRIPTION
The reconciler decides skip / partial / full from the union of a delta's touched tensor names (VersionManifest.tensor_names). A Store that records a non-empty delta but not those names (building the manifest from a side chain rather than the HF index — the cognition DeltaStore does exactly this) produced an empty union, which read as "nothing changed" and SKIPPED the reload while still advancing the served version — silent staleness (weights stay at the old version behind a new label).

Guard: in _touched_names, a delta with a non-empty files marker but empty tensor_names falls back to a full reload (return None) instead of contributing an empty set. So the empty-union skip only triggers for a genuinely empty delta; a store missing tensor_names degrades to a correct full reload rather than a wrong skip. Adds a regression test.