### PR TITLE
cookbook: fastsafetensors on every disaggregated config

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -14,7 +14,7 @@ sglang release*.
 ```python
 SGLANG_IMAGE_TAG   = "lmsysorg/sglang:v0.5.15.post1"    # base kernels/CUDA
 SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.15-post1"      # modal-projects/sglang
-SGLANG_FORK_COMMIT = "1c132287b9a426251512653182dbd2df1b652885"
+SGLANG_FORK_COMMIT = "eed0b1dd02d5e7d167004eda51ed38d7be5291c8"
 ```
 
 The branch is **`v0.5.15.post1` + the patch stack below, nothing else** — every commit
@@ -38,7 +38,7 @@ commit bodies for the details — this is the map.
    volume mount (whole-file in-memory read + size-verify before the xor, one reload
    per host, reseed from the pristine boot checkpoint). The base-seed reseed copies shards
    in parallel with a 16 MiB streaming read (the /prep read is Volume-backend-fetch bound —
-   ~8 streams is the profiled knee, ~5x over one) and logs per-shard progress (GB/GB).
+   ~8 streams is the profiled knee, ~5x over one) and logs staging progress + throughput.
    *Upstreaming:* https://github.com/sgl-project/sglang/pull/30367
 
 2. **`[RL] update_weights_from_disk: load quantized checkpoints like initial loading`**

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -19,7 +19,7 @@ import modal
 SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.15.post1"
 SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
 SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.15-post1"
-SGLANG_FORK_COMMIT = "1c132287b9a426251512653182dbd2df1b652885"
+SGLANG_FORK_COMMIT = "eed0b1dd02d5e7d167004eda51ed38d7be5291c8"
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent
 

--- a/cookbook/miles_disagg/configs/glm45_air_bf16.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16.py
@@ -25,8 +25,8 @@ MEGATRON_RUNTIME_PATCHES = ["/root/cookbook/miles_disagg/patches/megatron-r3-dis
 
 
 SGLANG_SERVER_ARGS = {
-    "--weight-loader-prefetch-checkpoints": "",
-    "--weight-loader-prefetch-num-threads": "8",
+    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    "--load-format": "fastsafetensors",
     "--reasoning-parser": "glm45",
     "--tool-call-parser": "glm45",
     "--dist-timeout": "3600",

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -28,8 +28,8 @@ MEGATRON_RUNTIME_PATCHES = [
 
 
 SGLANG_SERVER_ARGS = {
-    "--weight-loader-prefetch-checkpoints": "",
-    "--weight-loader-prefetch-num-threads": "8",
+    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    "--load-format": "fastsafetensors",
     # v0.5.15 has no glm5.2 parser; glm45/glm47 are closest. TODO(glm5.2): confirm 5.2's format.
     "--reasoning-parser": "glm45",
     "--tool-call-parser": "glm47",

--- a/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
@@ -28,8 +28,8 @@ MEGATRON_RUNTIME_PATCHES = [
 
 
 SGLANG_SERVER_ARGS = {
-    "--weight-loader-prefetch-checkpoints": "",
-    "--weight-loader-prefetch-num-threads": "8",
+    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    "--load-format": "fastsafetensors",
     "--tool-call-parser": "kimi_k2",
     "--reasoning-parser": "kimi_k2",
     "--dist-timeout": "3600",

--- a/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
@@ -29,8 +29,8 @@ MEGATRON_RUNTIME_PATCHES = [
 
 # mem-fraction / context-length are starting points — measure on a warm B200:4.
 SGLANG_SERVER_ARGS = {
-    "--weight-loader-prefetch-checkpoints": "",
-    "--weight-loader-prefetch-num-threads": "8",
+    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    "--load-format": "fastsafetensors",
     "--tool-call-parser": "kimi_k2",
     "--reasoning-parser": "kimi_k2",
     "--dist-timeout": "3600",

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4.py
@@ -30,8 +30,8 @@ MEGATRON_RUNTIME_PATCHES = [
 # No --quantization flag — NVFP4 comes from the served checkpoint's quant config.
 # mem-fraction / context-length are starting points; measure.
 SGLANG_SERVER_ARGS = {
-    "--weight-loader-prefetch-checkpoints": "",
-    "--weight-loader-prefetch-num-threads": "8",
+    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    "--load-format": "fastsafetensors",
     "--attention-backend": "tokenspeed_mla",
     "--kv-cache-dtype": "fp8_e4m3",  # tokenspeed_mla requires this
     "--context-length": "8192",  # Moonlight's max_position_embeddings

--- a/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
+++ b/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
@@ -22,8 +22,8 @@ SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 
 SGLANG_SERVER_ARGS = {
-    "--weight-loader-prefetch-checkpoints": "",
-    "--weight-loader-prefetch-num-threads": "8",
+    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    "--load-format": "fastsafetensors",
     "--tool-call-parser": "kimi_k2",
     "--reasoning-parser": "kimi_k2",
     "--dist-timeout": "3600",

--- a/cookbook/slime_disagg/configs/moonlight.py
+++ b/cookbook/slime_disagg/configs/moonlight.py
@@ -21,8 +21,8 @@ SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 
 # mem-fraction-static is a starting point -- measure on a warm container.
 SGLANG_SERVER_ARGS = {
-    "--weight-loader-prefetch-checkpoints": "",
-    "--weight-loader-prefetch-num-threads": "8",
+    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    "--load-format": "fastsafetensors",
     "--context-length": "8192",
     "--mem-fraction-static": "0.85",
     # routing replay: set here since slime launches no engine in publish-only mode.

--- a/cookbook/slime_disagg/configs/moonlight_int4.py
+++ b/cookbook/slime_disagg/configs/moonlight_int4.py
@@ -24,8 +24,8 @@ SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 
 # The pool reuses the trainer image (its SGLang serves native INT4; no Blackwell fork).
 SGLANG_SERVER_ARGS = {
-    "--weight-loader-prefetch-checkpoints": "",
-    "--weight-loader-prefetch-num-threads": "8",
+    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    "--load-format": "fastsafetensors",
     "--context-length": "16384",
     "--mem-fraction-static": "0.85",
     "--enable-return-routed-experts": "",  # routing replay

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
@@ -17,8 +17,8 @@ SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 
 SGLANG_SERVER_ARGS = {
-    "--weight-loader-prefetch-checkpoints": "",
-    "--weight-loader-prefetch-num-threads": "8",
+    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    "--load-format": "fastsafetensors",
     "--reasoning-parser": "qwen3",
     "--context-length": "16384",
     "--mem-fraction-static": "0.84",


### PR DESCRIPTION
Standardizes every serving config on `--load-format fastsafetensors`, replacing the `--weight-loader-prefetch-*` + mmap read path.

## Why
Under gVisor, mmap'd safetensors reads fault at ~0.35 GB/s even from a warm page cache. fastsafetensors does a per-rank **O_DIRECT** read — each rank reads `1/tp` of the shard files, no page-cache dependency. This is the read path the GLM-4.5-Air-FP8 e2e validated (full reload ~130s → ~23s), and both `glm45_air_fp8` configs already used it; this brings the rest into line.

## Scope / correctness
- Governs the **full/initial load** only. The disk reload inherits it — `tokenizer_manager` resolves `load_format=None` → `server_args.load_format` — so no plumbing needed through `commit()`.
- The serving image (`cookbook/common/serving_image.py`, shared by miles_disagg **and** slime_disagg) unconditionally installs `fastsafetensors` and forces `SGLANG_FASTSAFETENSORS_NOGDS=1` (GDS/nvidia-fs is absent under gVisor), so no config can hit the GDS-open crash.
- **Partial (O-delta) reload is unaffected** — it has its own targeted reader (`partial_weights_iterator`) over just the touched tensors and never consults `--load-format`.
- Drops the now-dead `--weight-loader-prefetch-*` flags: prefetch only warms the page cache for the mmap path, which fastsafetensors bypasses.

## Configs touched
miles_disagg: `glm45_air_bf16`, `glm5_2_nvfp4`, `kimi_k25_2layer_nvfp4`, `kimi_k2_6_nvfp4`, `moonlight_nvfp4`
slime_disagg: `kimi_k2_6_int4`, `moonlight_int4`, `moonlight`, `qwen3_4b_delta_flash` (`qwen3_4b_delta_flash_hillclimb` inherits its base)

`glm45_air_fp8` (both repos) already on fastsafetensors — unchanged.