### PR TITLE
cookbook: separate prep into its own app; parallelize + log the masters copy

### DIFF
--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -4,6 +4,9 @@
 Server (sglang + stitch sidecar) is the shared common one; the Trainer runs miles on Ray
 and publishes XOR deltas through a Modal Volume the pool syncs from.
 
+Prepare the checkpoints once first (a separate app, so prep never spins up the rollout Server
+floor — see ``cookbook.miles_disagg.prep_app``), then deploy this rollout + trainer app:
+
     EXPERIMENT_CONFIG=glm45_air_fp8 uv run --extra modal modal deploy -m cookbook.miles_disagg.app
 
 Config access is uniform: the experiment module ``exp`` is the single source of truth —
@@ -32,7 +35,7 @@ from cookbook.common.constants import (
     CHECKPOINTS_PATH, DATA_PATH, HF_CACHE_PATH, MINUTES, PREP_PATH, RAY_PORT,
     SERVER_STARTUP_TIMEOUT, SGLANG_CACHE_PATH, SIDECAR_PORT,
 )
-from cookbook.miles_disagg import prep, trainer_image
+from cookbook.miles_disagg import trainer_image
 from cookbook.miles_disagg.config import MilesConfig, YAML_CONFIG_FIELDS
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
 
@@ -227,44 +230,7 @@ def _materialize_node_local_yaml(cfg: Any, field: str, dest_dir: str = "/root/.m
         setattr(cfg, field, path)
 
 
-# ── Preparation + entrypoints ──────────────────────────────────────────────────
-@app.function(
-    image=image, gpu=f"{modal_cfg.gpu}:1",
-    volumes={str(HF_CACHE_PATH): hf_cache_volume, str(PREP_PATH): prep_volume},
-    timeout=6 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
-)
-def prepare_checkpoints() -> None:
-    prep.prepare_checkpoints(exp, prep_volume)
-
-
-# torch_dist conversion is clustered across nodes (a large MoE won't fit an 8-way split).
-_TORCH_DIST_MULTINODE = modal_cfg.torch_dist_prep_nodes > 1
-
-
-@app.function(
-    image=image, gpu=f"{modal_cfg.gpu}:{modal_cfg.torch_dist_prep_gpus_per_node}",
-    volumes={str(HF_CACHE_PATH): hf_cache_volume, str(PREP_PATH): prep_volume},
-    timeout=6 * 60 * MINUTES,
-    ephemeral_disk=(modal_cfg.torch_dist_prep_ephemeral_disk_mib or modal_cfg.rollout_ephemeral_disk_mib),
-    secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
-    **({"experimental_options": {"efa_enabled": True}} if _TORCH_DIST_MULTINODE else {}),
-)
-@(modal.experimental.clustered(modal_cfg.torch_dist_prep_nodes, rdma=True) if _TORCH_DIST_MULTINODE else lambda fn: fn)
-def prepare_torch_dist() -> None:
-    rank, master_addr, _ = ray_cluster.get_modal_cluster_context(modal_cfg.torch_dist_prep_nodes)
-    prep.prepare_torch_dist(exp, prep_volume, rank=rank, master_addr=master_addr)
-
-
-@app.function(
-    image=image, volumes={str(DATA_PATH): data_volume},
-    timeout=2 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
-)
-def prepare_dataset() -> None:
-    data_volume.reload()
-    miles_cfg.prepare_data()
-    data_volume.commit()
-
-
+# ── Entrypoints (preparation lives in a separate app: cookbook.miles_disagg.prep_app) ──
 @app.local_entrypoint()
 def launch_train() -> None:
     """Spawn training on the deployed app. Config ships as data, so edits run without a

--- a/cookbook/miles_disagg/prep.py
+++ b/cookbook/miles_disagg/prep.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 from cookbook.common.constants import PREP_PATH
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT, TORCH_DIST_CONVERT_WRAPPER
@@ -40,9 +44,10 @@ def prepare_checkpoints(exp, prep_volume) -> None:
 
     def _build_bf16(out: str) -> None:
         if is_int4:
+            print("dequantizing INT4 source -> bf16 masters (GPU)...", flush=True)
             subprocess.run(["python", f"{tools}/convert_kimi_int4_to_bf16.py", "--model-dir", src, "--output-dir", out], check=True)
         else:
-            subprocess.run(f"cp -aL {src}/. {out}/", shell=True, check=True)  # -L: real files, not cache symlinks
+            _copy_tree("bf16 masters", src, out)
         _strip_stale_quant_config(os.path.join(out, "config.json"))
 
     _staged(bf16_dir, _build_bf16)
@@ -56,7 +61,7 @@ def prepare_checkpoints(exp, prep_volume) -> None:
         fp8_source = getattr(exp, "ROLLOUT_SOURCE_MODEL", None)
         if not fp8_source:
             raise SystemExit("SERVED_CHECKPOINT_FORMAT='fp8' requires ROLLOUT_SOURCE_MODEL")
-        _staged(fp8_dir, lambda out: subprocess.run(f"cp -aL {snapshot_download(fp8_source)}/. {out}/", shell=True, check=True))
+        _staged(fp8_dir, lambda out: _copy_tree("fp8 served base", snapshot_download(fp8_source), out))
         prep_volume.commit()
         print(f"Prepared masters={bf16_dir} served_base={fp8_dir}")
         return
@@ -68,8 +73,11 @@ def prepare_checkpoints(exp, prep_volume) -> None:
         carveouts += ["--num-layers-at-start-in-bf16", str(n)]
     if (n := getattr(exp.miles, "num_layers_at_end_in_bf16", None)) is not None:
         carveouts += ["--num-layers-at-end-in-bf16", str(n)]
-    _staged(nvfp4_dir, lambda out: subprocess.run(
-        ["python", f"{tools}/convert_hf_to_nvfp4.py", "--model-dir", bf16_dir, "--save-dir", out, *carveouts], check=True))
+    def _build_nvfp4(out: str) -> None:
+        print("building nvfp4 served base from bf16 masters (GPU conversion)...", flush=True)
+        subprocess.run(["python", f"{tools}/convert_hf_to_nvfp4.py", "--model-dir", bf16_dir, "--save-dir", out, *carveouts], check=True)
+
+    _staged(nvfp4_dir, _build_nvfp4)
     prep_volume.commit()
     print(f"Prepared masters={bf16_dir} served_base={nvfp4_dir}")
 
@@ -100,12 +108,49 @@ def prepare_torch_dist(exp, prep_volume, *, rank: int, master_addr: str) -> None
     env = {**os.environ}
     if use_wrapper:
         env["SKIP_RELEASE_RENAME"] = "1"
+    print(f"converting bf16 masters -> torch_dist ref_load ({nodes}-node torchrun, rank {rank})...", flush=True)
     subprocess.run(["bash", "-c", inner], check=True, env=env)
     # Every node commits its own distcp shards (disjoint files merge on the Volume);
     # a rank-0-only commit would drop the other nodes' shards.
     prep_volume.commit()
     if rank == 0:
         print(f"Prepared torch_dist={torch_dist_dir}")
+
+
+# A single Volume->Volume stream is backend-fetch bound; ~8 parallel streams recover ~5x (the
+# sglang base-seed's profiled knee). 16 MiB reads run at full mount speed while bounding memory.
+_COPY_WORKERS = int(os.environ.get("PREP_COPY_WORKERS", "8"))
+_COPY_CHUNK = 16 << 20
+_COPY_LOG_STEP_GB = 50  # one progress line per this many GB, so a multi-TB copy isn't a silent stall
+
+
+def _copy_tree(label: str, src: str, dst: str) -> None:
+    """Copy a checkpoint dir, dereferencing the HF cache's blob symlinks into real files (the old
+    ``cp -aL``), but across a thread pool for the ~5x and with throttled GB/GB + rate progress."""
+    src_files = [p for p in Path(src).rglob("*") if p.is_file()]  # is_file() follows symlinks
+    total_gb = sum(p.stat().st_size for p in src_files) / 1e9
+    progress = {"done_gb": 0.0, "next_log_gb": _COPY_LOG_STEP_GB}
+    lock = threading.Lock()
+    start = time.monotonic()
+
+    def copy_one(p: Path) -> None:
+        out = Path(dst) / p.relative_to(src)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "rb") as fsrc, open(out, "wb") as fdst:  # open() follows the symlink to the real blob
+            while chunk := fsrc.read(_COPY_CHUNK):
+                fdst.write(chunk)
+        with lock:
+            progress["done_gb"] += p.stat().st_size / 1e9
+            done = progress["done_gb"]
+            if done >= progress["next_log_gb"] or done >= total_gb:
+                rate = done / max(time.monotonic() - start, 1e-3)
+                print(f"copying {label}: {done:.0f}/{total_gb:.0f} GB ({100 * done / max(total_gb, 1e-9):.0f}%), {rate:.1f} GB/s", flush=True)
+                progress["next_log_gb"] += _COPY_LOG_STEP_GB
+
+    os.makedirs(dst, exist_ok=True)
+    with ThreadPoolExecutor(max_workers=min(_COPY_WORKERS, len(src_files) or 1)) as pool:
+        list(pool.map(copy_one, src_files))
+    print(f"copied {label}: {total_gb:.0f} GB", flush=True)
 
 
 def _staged(final_dir: str, build) -> None:

--- a/cookbook/miles_disagg/prep_app.py
+++ b/cookbook/miles_disagg/prep_app.py
@@ -1,0 +1,76 @@
+"""Preparation stage for the miles cookbook — a separate Modal app from the rollout app.
+
+Prep builds the served base, the torch_dist ref_load, and the dataset: a one-shot stage that
+runs once before serving. It lives in its own app so invoking it never instantiates the
+``Server`` in ``app.py`` — and therefore never brings up the rollout autoscaler floor
+(``rollout_min_containers``), a serving concern with no place in preparation. Run prep first,
+then deploy the rollout app:
+
+    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -m cookbook.miles_disagg.prep_app::prepare_checkpoints
+    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -m cookbook.miles_disagg.prep_app::prepare_torch_dist
+    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -m cookbook.miles_disagg.prep_app::prepare_dataset
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import modal
+import modal.experimental
+
+from cookbook.common import ray_cluster
+from cookbook.common.constants import DATA_PATH, HF_CACHE_PATH, MINUTES, PREP_PATH
+from cookbook.miles_disagg import prep, trainer_image
+
+EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]  # required; a default would silently prep the wrong experiment
+MILES_LOCAL_DIR = os.environ.get("MILES_LOCAL_DIR")  # optional dev overlay of a local miles checkout
+
+exp = importlib.import_module(f"cookbook.miles_disagg.configs.{EXPERIMENT}")
+modal_cfg = exp.modal
+miles_cfg = exp.miles
+
+image = trainer_image.build_trainer_image(hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, miles_local=MILES_LOCAL_DIR)
+
+hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=True, version=2)
+data_volume = modal.Volume.from_name("miles-data", create_if_missing=True, version=2)
+prep_volume = modal.Volume.from_name("miles-prep-checkpoints", create_if_missing=True, version=2)
+
+app = modal.App(f"{exp.APP_NAME}-prep")
+
+
+@app.function(
+    image=image, gpu=f"{modal_cfg.gpu}:1",
+    volumes={str(HF_CACHE_PATH): hf_cache_volume, str(PREP_PATH): prep_volume},
+    timeout=6 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+)
+def prepare_checkpoints() -> None:
+    prep.prepare_checkpoints(exp, prep_volume)
+
+
+# torch_dist conversion is clustered across nodes (a large MoE won't fit an 8-way split).
+_TORCH_DIST_MULTINODE = modal_cfg.torch_dist_prep_nodes > 1
+
+
+@app.function(
+    image=image, gpu=f"{modal_cfg.gpu}:{modal_cfg.torch_dist_prep_gpus_per_node}",
+    volumes={str(HF_CACHE_PATH): hf_cache_volume, str(PREP_PATH): prep_volume},
+    timeout=6 * 60 * MINUTES,
+    ephemeral_disk=(modal_cfg.torch_dist_prep_ephemeral_disk_mib or modal_cfg.rollout_ephemeral_disk_mib),
+    secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+    **({"experimental_options": {"efa_enabled": True}} if _TORCH_DIST_MULTINODE else {}),
+)
+@(modal.experimental.clustered(modal_cfg.torch_dist_prep_nodes, rdma=True) if _TORCH_DIST_MULTINODE else lambda fn: fn)
+def prepare_torch_dist() -> None:
+    rank, master_addr, _ = ray_cluster.get_modal_cluster_context(modal_cfg.torch_dist_prep_nodes)
+    prep.prepare_torch_dist(exp, prep_volume, rank=rank, master_addr=master_addr)
+
+
+@app.function(
+    image=image, volumes={str(DATA_PATH): data_volume},
+    timeout=2 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+)
+def prepare_dataset() -> None:
+    data_volume.reload()
+    miles_cfg.prepare_data()
+    data_volume.commit()

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -4,6 +4,9 @@
 Server (sglang + stitch sidecar) is the shared common one; the Trainer runs slime on Ray
 and publishes XOR deltas through a Modal Volume the pool syncs from.
 
+Prepare the model + dataset once first (a separate app, so prep never spins up the rollout
+Server floor — see ``cookbook.slime_disagg.prep_app``), then deploy this rollout + trainer app:
+
     EXPERIMENT_CONFIG=kimi_k2_6_int4 uv run --extra modal modal deploy -m cookbook.slime_disagg.app
 
 Config access is uniform: the experiment module ``exp`` is the single source of truth —
@@ -182,29 +185,7 @@ class Trainer:
         subprocess.run(["bash", "-lc", cmd], check=True)
 
 
-# ── Preparation + entrypoints ──────────────────────────────────────────────────
-@app.function(
-    image=image, volumes={str(HF_CACHE_PATH): hf_cache_volume},
-    timeout=2 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
-)
-def download_model() -> None:
-    """Snapshot the served model into the HF cache (sglang serves it by repo id)."""
-    from huggingface_hub import snapshot_download
-
-    snapshot_download(repo_id=slime_cfg.hf_checkpoint)
-    hf_cache_volume.commit()
-
-
-@app.function(
-    image=image, volumes={str(DATA_PATH): data_volume},
-    timeout=2 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
-)
-def prepare_dataset() -> None:
-    data_volume.reload()
-    slime_cfg.prepare_data()
-    data_volume.commit()
-
-
+# ── Entrypoints (preparation lives in a separate app: cookbook.slime_disagg.prep_app) ──
 @app.local_entrypoint()
 def launch_train() -> None:
     """Spawn training on the deployed app. Config ships as data, so edits run without a

--- a/cookbook/slime_disagg/prep_app.py
+++ b/cookbook/slime_disagg/prep_app.py
@@ -1,0 +1,56 @@
+"""Preparation stage for the slime cookbook — a separate Modal app from the rollout app.
+
+Prep snapshots the served model into the HF cache and builds the dataset: a one-shot stage that
+runs once before serving. It lives in its own app so invoking it never instantiates the ``Server``
+in ``app.py`` — and therefore never brings up the rollout autoscaler floor
+(``rollout_min_containers``), a serving concern with no place in preparation. Run prep first, then
+deploy the rollout app:
+
+    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -m cookbook.slime_disagg.prep_app::download_model
+    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -m cookbook.slime_disagg.prep_app::prepare_dataset
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+import modal
+
+from cookbook.common.constants import DATA_PATH, HF_CACHE_PATH, MINUTES
+from cookbook.slime_disagg import trainer_image
+
+EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]  # required; a default would silently prep the wrong experiment
+SLIME_LOCAL_DIR = os.environ.get("SLIME_LOCAL_DIR")  # optional dev overlay of a local slime checkout
+
+exp = importlib.import_module(f"cookbook.slime_disagg.configs.{EXPERIMENT}")
+slime_cfg = exp.slime
+
+image = trainer_image.build_trainer_image(hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, slime_local=SLIME_LOCAL_DIR)
+
+hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=True, version=2)
+data_volume = modal.Volume.from_name("slime-data", create_if_missing=True, version=2)
+
+app = modal.App(f"{exp.APP_NAME}-prep")
+
+
+@app.function(
+    image=image, volumes={str(HF_CACHE_PATH): hf_cache_volume},
+    timeout=2 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+)
+def download_model() -> None:
+    """Snapshot the served model into the HF cache (sglang serves it by repo id)."""
+    from huggingface_hub import snapshot_download
+
+    snapshot_download(repo_id=slime_cfg.hf_checkpoint)
+    hf_cache_volume.commit()
+
+
+@app.function(
+    image=image, volumes={str(DATA_PATH): data_volume},
+    timeout=2 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+)
+def prepare_dataset() -> None:
+    data_volume.reload()
+    slime_cfg.prepare_data()
+    data_volume.commit()


### PR DESCRIPTION
## Prep/serve separation
Preparation (build the served base, the torch_dist `ref_load`, the dataset) now lives in its own Modal app — `cookbook/miles_disagg/prep_app.py` and `cookbook/slime_disagg/prep_app.py` — separate from the rollout `app.py`.

**Why:** prep and serve are distinct lifecycle stages, but they shared one `modal.App`. Running `modal run ...app::prepare_checkpoints` instantiated the whole app, so Modal brought up the `Server`'s `min_containers=rollout_min_containers` floor — spinning up crash-looping GPU replicas against a checkpoint prep hadn't written yet. A serving autoscaler knob has no place in the preparation stage. `prep_app` imports only what prep needs (config, trainer image, prep volumes) and never the `Server`, so the floor can't come up. Serving config is untouched.

```bash
EXPERIMENT_CONFIG=<cfg> modal run    -m cookbook.miles_disagg.prep_app::prepare_checkpoints
EXPERIMENT_CONFIG=<cfg> modal run    -m cookbook.miles_disagg.prep_app::prepare_torch_dist
EXPERIMENT_CONFIG=<cfg> modal deploy -m cookbook.miles_disagg.app     # serve + train
```

Validated e2e: `prepare_checkpoints` for GLM-4.5-Air-FP8 ran through `prep_app` with **1 prep container and no `Server`** (vs. 8 crash-looping replicas before).

## Parallel + progress-logged masters copy
`prep.py`'s masters/base copy (HF-cache volume → prep volume, dereferencing the cache's blob symlinks) was a single `cp -aL` — silent and single-threaded. A single Volume→Volume stream is backend-fetch bound under gVisor; it's now a **thread-pool copy (~8 streams, the sglang base-seed's profiled knee, ~5×)** and logs `GB/GB (%) + GB/s`, so a multi-TB copy shows progress instead of reading as a hang. `PREP_COPY_WORKERS` overrides the width.

Applied to both `miles_disagg` and `slime_disagg`.