### PR TITLE
cookbook: use 'modal run -d' for the prep commands in docstrings

### DIFF
--- a/cookbook/miles_disagg/prep_app.py
+++ b/cookbook/miles_disagg/prep_app.py
@@ -6,9 +6,9 @@ runs once before serving. It lives in its own app so invoking it never instantia
 (``rollout_min_containers``), a serving concern with no place in preparation. Run prep first,
 then deploy the rollout app:
 
-    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -m cookbook.miles_disagg.prep_app::prepare_checkpoints
-    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -m cookbook.miles_disagg.prep_app::prepare_torch_dist
-    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -m cookbook.miles_disagg.prep_app::prepare_dataset
+    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -d -m cookbook.miles_disagg.prep_app::prepare_checkpoints
+    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -d -m cookbook.miles_disagg.prep_app::prepare_torch_dist
+    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -d -m cookbook.miles_disagg.prep_app::prepare_dataset
 """
 
 from __future__ import annotations

--- a/cookbook/slime_disagg/prep_app.py
+++ b/cookbook/slime_disagg/prep_app.py
@@ -6,8 +6,8 @@ in ``app.py`` — and therefore never brings up the rollout autoscaler floor
 (``rollout_min_containers``), a serving concern with no place in preparation. Run prep first, then
 deploy the rollout app:
 
-    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -m cookbook.slime_disagg.prep_app::download_model
-    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -m cookbook.slime_disagg.prep_app::prepare_dataset
+    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -d -m cookbook.slime_disagg.prep_app::download_model
+    EXPERIMENT_CONFIG=<cfg> uv run --extra modal modal run -d -m cookbook.slime_disagg.prep_app::prepare_dataset
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Prep (download + convert) is long-running; a foreground `modal run` ties the app's lifetime to the CLI connection, so a dropped terminal / network blip kills it mid-prep. Detached (`-d`) runs on Modal independently — watch via `modal app logs`. Updates the prep_app docstrings for miles_disagg + slime_disagg.