### PR TITLE
reconciler: per-version flush_cache from the manifest

### DIFF
--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -398,12 +398,12 @@ class Reconciler(AdmissionGate):
                 "all tensors" if weight_names is None else f"{len(weight_names)} tensors",
             )
 
+            flush = target.flush_cache if target.flush_cache is not None else self.flush_cache_on_commit
+
             async def apply() -> None:
                 self.sync_state = SyncState.COMMITTING
                 with _timed(m, "commit_s"):
-                    await self.engine.commit(
-                        pointer, flush_cache=self.flush_cache_on_commit, weight_names=weight_names
-                    )
+                    await self.engine.commit(pointer, flush_cache=flush, weight_names=weight_names)
 
             await self.commit(
                 apply=apply,

--- a/src/stitch/types.py
+++ b/src/stitch/types.py
@@ -68,6 +68,7 @@ class VersionManifest:
     kind: VersionKind
     files: list[str]
     tensor_names: list[str] = field(default_factory=list)
+    flush_cache: bool | None = None
 
     @classmethod
     def from_hf_index(cls, version_dir: str | Path, *, run_id: str | None = None) -> "VersionManifest":


### PR DESCRIPTION
Adds a per-version prompt-cache flush so a publisher can reset the prefix cache on a specific weight version, rather than the all-or-nothing static `flush_cache_on_commit` fixed at `serve()`.

- `VersionManifest.flush_cache: bool | None` (`None` = defer to the static default)
- the reconciler applies the target version's `flush_cache` on its commit

Backward compatible: `VersionManifest.from_hf_index` leaves it `None`, so existing users (miles/slime) keep the static policy unchanged.

Motivation: lets the Cognition RL-rollout provider honor the spec's per-signal `reset_prompt_cache`. The provider-side consumer (map `reset_prompt_cache` → the version's `flush_cache`) + its pin bump land separately once this merges.