### PR TITLE
service: add sync_in_progress, dedupe engine-health across deployments

### DIFF
--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from stitch.service import sync_in_progress
+
 from . import process
 from .constants import SGLANG_PORT, SIDECAR_PORT
 
@@ -68,31 +70,14 @@ def serve_startup(
     process.wait_http(f"http://127.0.0.1:{SIDECAR_PORT}/health", replica.sidecar, startup_timeout)
 
     def engine_health() -> str | None:
-        # The base seed (engine.prefetch) and every delta apply drive the fork's /pull_weights,
-        # which starves sglang's event loop enough that its detokenizer heartbeat goes stale and
-        # /health 503s. That stall is EXPECTED while the sidecar is seeding or mid-sync — report
-        # failures only when it is genuinely idle, or replicas crash-cycle through every sync (the
-        # base seed runs with sync_state=IDLE, so it needs the prefetch_done check, not just sync_state).
-        # A dead engine process still raises once the seed/sync is done (or errored).
+        # The base seed and every delta apply drive the fork's /pull_weights, which starves
+        # sglang's event loop enough that its detokenizer heartbeat goes stale and /health 503s.
+        # That stall is EXPECTED mid-sync — suppress it unless the reconciler is idle (a dead
+        # engine process still raises once the sync is done or errored).
         error = replica.endpoint.health_check()
         if error is None:
             return None
-        try:
-            import json
-            import urllib.request
-
-            with urllib.request.urlopen(
-                f"http://127.0.0.1:{SIDECAR_PORT}/server_info", timeout=5
-            ) as response:
-                info = json.loads(response.read())
-                seeding = not info.get("prefetch_done", True) and not info.get("prefetch_error")
-                if seeding or info.get("sync_state") in (
-                    "QUEUED", "PREFETCHING", "PREPARING", "COMMITTING",
-                ):
-                    return None
-        except Exception:  # noqa: BLE001 — sidecar unreachable: report the engine error
-            pass
-        return error
+        return None if sync_in_progress(f"http://127.0.0.1:{SIDECAR_PORT}/server_info") else error
 
     import modal.experimental
 

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -12,7 +12,9 @@ demotes ``request`` to a required query param, 422-ing every call.
 
 import asyncio
 import contextlib
+import json
 import logging
+import urllib.request
 import uuid
 from collections.abc import Iterable
 from contextlib import asynccontextmanager
@@ -22,7 +24,7 @@ from stitch.engines.base import Engine
 from stitch.pools.base import Pool
 from stitch.stores.base import Store
 from stitch.sync import CommitMode, ConstraintUnmet, Reconciler
-from stitch.types import PoolState, ReplicaState, VersionConstraint
+from stitch.types import PoolState, ReplicaState, SyncState, VersionConstraint
 
 logger = logging.getLogger(__name__)
 
@@ -212,3 +214,24 @@ async def readiness(pool: Pool, *, timeout: float = 15.0) -> PoolState:
     async with httpx.AsyncClient(trust_env=False) as c:
         states = await asyncio.gather(*(probe(c, url) for url in pool.discover_replicas()))
     return PoolState(list(states))
+
+
+# The reconciler states in which the engine is legitimately unresponsive: it is pulling or
+# reloading weights, which starves its event loop, so a stale health heartbeat is EXPECTED.
+_SYNCING_STATES = {SyncState.QUEUED.value, SyncState.PREFETCHING.value,
+                   SyncState.PREPARING.value, SyncState.COMMITTING.value}
+
+
+def sync_in_progress(server_info_url: str, *, timeout: float = 5.0) -> bool:
+    """Whether the replica's reconciler is mid weight-sync (seeding the base or reloading a
+    version). A deployment's engine-health probe calls this to SUPPRESS a health blip during a
+    sync: the reload starves the engine's event loop, so an unresponsive detokenizer is expected,
+    not a crash. A boot base-seed runs with sync_state IDLE, so ``prefetch_done`` is its separate
+    signal. Best-effort: an unreachable sidecar returns False, so the caller reports the error."""
+    try:
+        with urllib.request.urlopen(server_info_url, timeout=timeout) as resp:
+            info = json.loads(resp.read())
+    except Exception:  # noqa: BLE001
+        return False
+    seeding = not info.get("prefetch_done", True) and not info.get("prefetch_error")
+    return bool(seeding or info.get("sync_state") in _SYNCING_STATES)

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -1,0 +1,53 @@
+"""``sync_in_progress`` — the shared /server_info interpretation a deployment's engine-health
+probe uses to suppress health blips while the reconciler is reloading weights."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from stitch.service import sync_in_progress
+
+
+@contextlib.contextmanager
+def _server_info(payload):
+    """Serve ``payload`` as JSON at /server_info on a throwaway localhost port."""
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps(payload).encode())
+
+        def log_message(self, *_):  # silence
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/server_info"
+    finally:
+        server.shutdown()
+
+
+@pytest.mark.parametrize(
+    "info,expected",
+    [
+        ({"prefetch_done": True, "sync_state": "COMMITTING"}, True),   # reloading
+        ({"prefetch_done": True, "sync_state": "PREFETCHING"}, True),  # staging deltas
+        ({"prefetch_done": False, "prefetch_error": None}, True),      # boot base-seed (IDLE)
+        ({"prefetch_done": True, "sync_state": "IDLE"}, False),        # settled: a blip is real
+        ({"prefetch_done": False, "prefetch_error": "boom"}, False),   # seed failed: report it
+    ],
+)
+def test_sync_in_progress(info, expected):
+    with _server_info(info) as url:
+        assert sync_in_progress(url) is expected
+
+
+def test_unreachable_sidecar_reports_error():
+    # Nothing listening: best-effort False so the caller surfaces the engine error.
+    assert sync_in_progress("http://127.0.0.1:1/server_info", timeout=0.2) is False


### PR DESCRIPTION
## What

A deployment's engine-health probe must suppress health blips *while the reconciler is reloading weights* — the reload starves sglang's event loop, so its detokenizer heartbeat goes stale and `/health` 503s, and that stall is expected, not a crash.

That interpretation of a replica's `/server_info` sync-state was **copy-pasted into each deployment's engine-health probe**, with the sync-state strings (`"QUEUED"`, `"PREFETCHING"`, …) hardcoded — and the copies had begun to drift (one dropped the base-seed `prefetch_done` guard).

This moves it into stitch as `service.sync_in_progress(server_info_url)`, so the contract lives with the `SyncState` enum it reads, and collapses `cookbook/common/server.py` onto it.

## Changes

- `service.py`: `sync_in_progress()` — reads `/server_info`, returns whether the reconciler is seeding the base or mid-reload (best-effort; unreachable sidecar → `False` so the caller reports the real error). The busy-state set is derived from `SyncState`, not string literals.
- `service_test.py`: covers each state, the boot base-seed (IDLE + `prefetch_done=False`), a failed seed, and an unreachable sidecar.
- `cookbook/common/server.py`: `engine_health` now delegates (−17 lines).

## Test

`uv run pytest` → 50 passed (6 new).