### PR TITLE
cookbook: hoist shared trainer-launch helpers into common

### DIFF
--- a/cookbook/common/launch.py
+++ b/cookbook/common/launch.py
@@ -39,3 +39,18 @@ def resolve_config(cfg: Any, tmpdir: str, yaml_fields: tuple[str, ...]) -> None:
             with open(path, "w") as f:
                 yaml.dump(val, f)
             setattr(cfg, field, path)
+
+
+def materialize_node_local_yaml(cfg: Any, field: str, dest_dir: str = "/root/.node_yaml") -> None:
+    """Write an inline-dict config field to a deterministic node-local YAML path, so every Ray
+    actor across nodes re-reads identical content at an identical path — unlike ``resolve_config``'s
+    per-launch tmpdir. Call on every node (before the rank gate). No-op unless the field is a dict;
+    mutates ``cfg`` in place. (e.g. miles' ``te_precision_config_file``.)"""
+    import yaml
+
+    if isinstance(val := getattr(cfg, field, None), dict):
+        os.makedirs(dest_dir, exist_ok=True)
+        path = os.path.join(dest_dir, f"{field}.yaml")
+        with open(path, "w") as f:
+            yaml.dump(val, f)
+        setattr(cfg, field, path)

--- a/cookbook/common/trainer_image.py
+++ b/cookbook/common/trainer_image.py
@@ -1,0 +1,27 @@
+"""Shared trainer-image layers. The framework-specific base image, fork clone, and any extra
+build steps stay in each recipe's ``trainer_image.py``; the layers every framework needs — the
+delta-encoder codecs, the HF-download env, and the stitch + cookbook source mounts — live here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import modal
+
+_COOKBOOK_DIR = Path(__file__).resolve().parent.parent  # .../cookbook
+
+
+def add_common_layers(image: modal.Image, *, experiment: str, run_id: str | None = None) -> modal.Image:
+    """Append the framework-agnostic trainer layers: the trainer-side delta ENCODER's codecs
+    (needed even under --no-deps), the HF-download env (``EXPERIMENT_CONFIG``/``RUN_ID`` so a
+    container's re-import selects the same experiment/run as the deploy), and the stitch + cookbook
+    source mounts so the trainer, Ray actors, and the sidecar subprocess resolve their imports."""
+    return (
+        image
+        .pip_install("fastapi", "httpx", "uvicorn", "zstandard", "xxhash", "blake3")
+        .env({"HF_XET_HIGH_PERFORMANCE": "1", "HF_HUB_ENABLE_HF_TRANSFER": "1",
+              "EXPERIMENT_CONFIG": experiment, **({"RUN_ID": run_id} if run_id else {})})
+        .add_local_python_source("stitch")
+        .add_local_dir(str(_COOKBOOK_DIR), remote_path="/root/cookbook", ignore=["**/__pycache__"])
+    )

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -180,7 +180,7 @@ class Trainer:
             volume.reload()
 
         cfg = MilesConfig.from_payload(payload)
-        _materialize_node_local_yaml(cfg, "te_precision_config_file")
+        launch.materialize_node_local_yaml(cfg, "te_precision_config_file")
         if self.rank != 0:
             return
 
@@ -221,21 +221,6 @@ class Trainer:
                 print(f"Train log committed to miles-checkpoints at {run_id}/train.log")
             except Exception as exc:  # noqa: BLE001
                 print(f"WARNING: could not commit train log: {exc}")
-
-
-# ── miles launch helper (te_precision_config_file is miles-only) ──────────────────
-def _materialize_node_local_yaml(cfg: Any, field: str, dest_dir: str = "/root/.miles_node_yaml") -> None:
-    """Write an inline YAML config to a deterministic node-local path on EVERY node.
-    Fields like te_precision_config_file are re-read on each Ray actor, so they must
-    resolve to identical content at an identical path on all nodes."""
-    import yaml
-
-    if isinstance(val := getattr(cfg, field, None), dict):
-        os.makedirs(dest_dir, exist_ok=True)
-        path = os.path.join(dest_dir, f"{field}.yaml")
-        with open(path, "w") as f:
-            yaml.dump(val, f)
-        setattr(cfg, field, path)
 
 
 # ── Entrypoints (preparation lives in a separate app: cookbook.miles_disagg.prep_app) ──

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import modal
 
+from cookbook.common import trainer_image as common_trainer_image
+
 # Dated tag, never `latest`: Modal caches from_registry per tag string and won't re-pull
 # a moved mutable tag, so `latest` silently serves whatever was first pulled.
 MILES_IMAGE_TAG = "radixark/miles:dev-202607182122"  # base Megatron/TE; match the upstream main stitch-miles is on
@@ -24,7 +26,6 @@ MILES_ROOT = "/root/miles"
 MEGATRON_PATH = "/root/Megatron-LM"  # source-only megatron.training must be on PYTHONPATH
 TORCH_DIST_CONVERT_WRAPPER = "/root/convert_hf_to_torch_dist_modal.py"
 
-_COOKBOOK_DIR = Path(__file__).resolve().parent.parent  # .../cookbook
 _TORCH_DIST_WRAPPER_SRC = Path(__file__).resolve().parent / "convert_hf_to_torch_dist_modal.py"
 
 
@@ -44,14 +45,9 @@ def build_trainer_image(*, hf_cache_path: str, experiment: str, run_id: str | No
             f" && cd {MILES_ROOT} && git fetch origin {MILES_REPO_REF} && git checkout FETCH_HEAD"
             f" && python3 -m pip install --no-deps -e {MILES_ROOT}"
         )
-        # The trainer-side delta ENCODER (miles delta.py) needs the codecs even under --no-deps.
-        .pip_install("fastapi", "httpx", "uvicorn", "zstandard", "xxhash", "blake3")
-        .env({"HF_XET_HIGH_PERFORMANCE": "1", "HF_HUB_ENABLE_HF_TRANSFER": "1", "EXPERIMENT_CONFIG": experiment,
-              **({"RUN_ID": run_id} if run_id else {})})
         .add_local_file(str(_TORCH_DIST_WRAPPER_SRC), TORCH_DIST_CONVERT_WRAPPER, copy=True)
-        .add_local_python_source("stitch")
-        .add_local_dir(str(_COOKBOOK_DIR), remote_path="/root/cookbook", ignore=["**/__pycache__"])
     )
+    image = common_trainer_image.add_common_layers(image, experiment=experiment, run_id=run_id)
     if miles_local:  # dev overlay: replace the cloned fork with a local checkout (no rebuild)
         image = image.add_local_dir(miles_local, remote_path=MILES_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])
     return image

--- a/cookbook/slime_disagg/trainer_image.py
+++ b/cookbook/slime_disagg/trainer_image.py
@@ -6,17 +6,15 @@ trainer package, so slime and miles serve on the identical weight-sync sglang im
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import modal
+
+from cookbook.common import trainer_image as common_trainer_image
 
 SLIME_IMAGE_TAG = "slimerl/slime:nightly-dev-20260527a"
 SLIME_REPO_URL = "https://github.com/modal-projects/slime.git"
 # Pin to an exact commit, not the branch tip (the fetch+checkout is a cached layer).
 SLIME_REPO_REF = "11bb0fa48aa37d5c54fe297143c6bc1d40f311bf"
 SLIME_ROOT = "/root/slime"
-
-_COOKBOOK_DIR = Path(__file__).resolve().parent.parent  # .../cookbook
 
 
 def build_trainer_image(*, hf_cache_path: str, experiment: str, run_id: str | None = None, slime_local: str | None = None) -> modal.Image:
@@ -36,13 +34,8 @@ def build_trainer_image(*, hf_cache_path: str, experiment: str, run_id: str | No
         # The base installs megatron-core as a strict editable that hides
         # megatron.training; reinstall in compat mode so the whole source tree is importable.
         .run_commands("cd /root/Megatron-LM && python3 -m pip install --no-deps -e . --config-settings editable_mode=compat")
-        # The trainer-side delta ENCODER (slime.utils.disk_delta) needs the codecs even under --no-deps.
-        .pip_install("fastapi", "httpx", "uvicorn", "zstandard", "xxhash", "blake3")
-        .env({"HF_XET_HIGH_PERFORMANCE": "1", "HF_HUB_ENABLE_HF_TRANSFER": "1", "EXPERIMENT_CONFIG": experiment,
-              **({"RUN_ID": run_id} if run_id else {})})
-        .add_local_python_source("stitch")
-        .add_local_dir(str(_COOKBOOK_DIR), remote_path="/root/cookbook", ignore=["**/__pycache__"])
     )
+    image = common_trainer_image.add_common_layers(image, experiment=experiment, run_id=run_id)
     if slime_local:  # dev overlay: replace the cloned fork with a local checkout (no rebuild)
         image = image.add_local_dir(slime_local, remote_path=SLIME_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])
     return image


### PR DESCRIPTION
## What

Two things every framework recipe needs were duplicated across `miles_disagg` / `slime_disagg` (and the cog `examples/miles` reference trainer). Move them into `common/`. **No behavior change** — pure dedup.

1. **`materialize_node_local_yaml`** (inline-dict config field → a node-local YAML on every node, so each Ray actor reads identical content at an identical path) lived only in `miles_disagg/app.py`. Moved to `common.launch`. The copy had already been *omitted* once downstream, which passed `te_precision_config_file` to the trainer as a giant string (`open()` → "File name too long") — exactly the drift this removes.
2. **The trainer-image tail** (delta-encoder codecs `pip_install`, HF-download env, `stitch` + `cookbook` source mounts) was byte-identical in `miles/slime trainer_image.py`. Extracted `common.trainer_image.add_common_layers(...)` so a codec can't drift between them.

Framework-specific pieces stay per-recipe: base image, fork clone, build quirks (miles EFA/torch-dist wrapper; slime Megatron compat reinstall), `Trainer` bring-up, and `config.py` (each framework's arg surface is its own contract).

Deliberately **not** touched: the rollout `Server` (engine-specific — a recipe may serve on vLLM, not sglang), and the config classes.

## Test

`uv run pytest` → 44 passed. Both refactored trainer images construct cleanly (`add_common_layers` wiring verified).