### PR TITLE
stitch + cookbook: hoist shared serving/launch helpers, dedupe deployments

### DIFF
--- a/cookbook/common/hooks.py
+++ b/cookbook/common/hooks.py
@@ -22,6 +22,8 @@ from stitch.publish import claim_run, constrain_request, publish_version
 from stitch.stores.modal_volume import ModalVolumeStore
 from stitch.types import PointerRewind
 
+from . import process
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,7 +37,7 @@ def commit_and_wake(args: Any, published_dir: str, rollout_engines: Any = None) 
     del rollout_engines
     store = _store(args)
     store.commit()
-    if _rank() not in (None, 0) or not Path(published_dir).name.startswith("weight_v"):
+    if process.dist_rank() not in (None, 0) or not Path(published_dir).name.startswith("weight_v"):
         return
     try:
         publish_version(store, _pool(args), published_dir, run_id=_run_id(args))
@@ -47,7 +49,7 @@ def commit_and_wake(args: Any, published_dir: str, rollout_engines: Any = None) 
 def claim_pool(args: Any) -> None:
     """Launch hook (rank 0): reset every replica to base before the first publish, so a
     cold or finished-run-warm pool starts this run clean."""
-    if _rank() not in (None, 0):
+    if process.dist_rank() not in (None, 0):
         return
     claim_run(_store(args), _pool(args), _run_id(args))
 
@@ -134,12 +136,3 @@ def _run_id(args: Any) -> str:
     return str(run_id)
 
 
-def _rank() -> int | None:
-    try:
-        import torch.distributed as dist
-
-        if dist.is_available() and dist.is_initialized():
-            return int(dist.get_rank())
-    except Exception:  # noqa: BLE001
-        return None
-    return None

--- a/cookbook/common/launch.py
+++ b/cookbook/common/launch.py
@@ -54,3 +54,16 @@ def materialize_node_local_yaml(cfg: Any, field: str, dest_dir: str = "/root/.no
         with open(path, "w") as f:
             yaml.dump(val, f)
         setattr(cfg, field, path)
+
+
+def deploy_pool_and_spawn(run: Any) -> None:
+    """The shared body of a recipe's ``launch`` entrypoint: deploy this run's pool, block until its
+    gateway is healthy, then spawn training. ``run`` is the recipe's ``app`` module (its ``app`` /
+    ``APP_NAME`` / ``spawn_train``)."""
+    from stitch.pools.modal_flash import ModalFlashPool
+    from stitch.service import await_pool_ready
+
+    run.app.deploy()
+    await_pool_ready(ModalFlashPool(run.APP_NAME, "Server"))
+    run.spawn_train()
+    print(f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; stop it with: modal app stop {run.APP_NAME}")

--- a/cookbook/common/launch.py
+++ b/cookbook/common/launch.py
@@ -39,3 +39,18 @@ def resolve_config(cfg: Any, tmpdir: str, yaml_fields: tuple[str, ...]) -> None:
             with open(path, "w") as f:
                 yaml.dump(val, f)
             setattr(cfg, field, path)
+
+
+def materialize_node_local_yaml(cfg: Any, field: str, dest_dir: str = "/root/.node_yaml") -> None:
+    """Write an inline-dict config field to a deterministic node-local YAML path, so every Ray
+    actor across nodes re-reads identical content at an identical path — unlike ``resolve_config``'s
+    per-launch tmpdir. Call on every node (before the rank gate). No-op unless the field is a dict;
+    mutates ``cfg`` in place. (e.g. miles' ``te_precision_config_file``.)"""
+    import yaml
+
+    if isinstance(val := getattr(cfg, field, None), dict):
+        os.makedirs(dest_dir, exist_ok=True)
+        path = os.path.join(dest_dir, f"{field}.yaml")
+        with open(path, "w") as f:
+            yaml.dump(val, f)
+        setattr(cfg, field, path)

--- a/cookbook/common/process.py
+++ b/cookbook/common/process.py
@@ -119,3 +119,23 @@ def start_host_mem_monitor(interval_s: int = 20) -> None:
             time.sleep(interval_s)
 
     threading.Thread(target=_loop, daemon=True, name="host-mem-monitor").start()
+
+
+def dist_rank() -> int | None:
+    """This process's torch.distributed rank, or None off the distributed path (single-process dev)."""
+    try:
+        import torch.distributed as dist
+
+        if dist.is_available() and dist.is_initialized():
+            return int(dist.get_rank())
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def dist_barrier() -> None:
+    """Wait for all ranks; a no-op off the distributed path."""
+    import torch.distributed as dist
+
+    if dist.is_available() and dist.is_initialized():
+        dist.barrier()

--- a/cookbook/common/ray_cluster.py
+++ b/cookbook/common/ray_cluster.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import socket
 import subprocess
 import time
@@ -81,6 +82,23 @@ def start_ray_worker(my_ip: str, master_addr: str, *, ray_port: int) -> None:
          "--disable-usage-stats"],
         check=True, timeout=RAY_START_TIMEOUT,
     )
+
+
+def start_ray_node(rank: int, master_addr: str, my_ip: str, *, n_nodes: int, ray_port: int,
+                   extra_env: dict[str, str] | None = None) -> None:
+    """Set this node's Ray/NCCL env, then bring Ray up (head on rank 0, worker otherwise).
+    ``extra_env`` overlays the framework-specific vars a recipe adds — its own HOST_IP alias, a
+    PYTHONPATH, its training ``environment``."""
+    os.environ.update({
+        "SGLANG_HOST_IP": my_ip, "HOST_IP": my_ip,
+        "MASTER_ADDR": master_addr, "RAY_ADDRESS": f"{master_addr}:{ray_port}",
+        "no_proxy": f"127.0.0.1,{master_addr},{my_ip}", "NO_PROXY": f"127.0.0.1,{master_addr},{my_ip}",
+        **(extra_env or {}),
+    })
+    if rank == 0:
+        start_ray_head(my_ip, n_nodes, ray_port=ray_port)
+    else:
+        start_ray_worker(my_ip, master_addr, ray_port=ray_port)
 
 
 def _print_ray_logs() -> None:

--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import os
 from typing import Any
 
+from stitch.service import sync_in_progress
+
 from . import process
 from .constants import SGLANG_PORT, SIDECAR_PORT
 
@@ -68,31 +70,14 @@ def serve_startup(
     process.wait_http(f"http://127.0.0.1:{SIDECAR_PORT}/health", replica.sidecar, startup_timeout)
 
     def engine_health() -> str | None:
-        # The base seed (engine.prefetch) and every delta apply drive the fork's /pull_weights,
-        # which starves sglang's event loop enough that its detokenizer heartbeat goes stale and
-        # /health 503s. That stall is EXPECTED while the sidecar is seeding or mid-sync — report
-        # failures only when it is genuinely idle, or replicas crash-cycle through every sync (the
-        # base seed runs with sync_state=IDLE, so it needs the prefetch_done check, not just sync_state).
-        # A dead engine process still raises once the seed/sync is done (or errored).
+        # The base seed and every delta apply drive the fork's /pull_weights, which starves
+        # sglang's event loop enough that its detokenizer heartbeat goes stale and /health 503s.
+        # That stall is EXPECTED mid-sync — suppress it unless the reconciler is idle (a dead
+        # engine process still raises once the sync is done or errored).
         error = replica.endpoint.health_check()
         if error is None:
             return None
-        try:
-            import json
-            import urllib.request
-
-            with urllib.request.urlopen(
-                f"http://127.0.0.1:{SIDECAR_PORT}/server_info", timeout=5
-            ) as response:
-                info = json.loads(response.read())
-                seeding = not info.get("prefetch_done", True) and not info.get("prefetch_error")
-                if seeding or info.get("sync_state") in (
-                    "QUEUED", "PREFETCHING", "PREPARING", "COMMITTING",
-                ):
-                    return None
-        except Exception:  # noqa: BLE001 — sidecar unreachable: report the engine error
-            pass
-        return error
+        return None if sync_in_progress(f"http://127.0.0.1:{SIDECAR_PORT}/server_info") else error
 
     import modal.experimental
 

--- a/cookbook/common/trainer_image.py
+++ b/cookbook/common/trainer_image.py
@@ -1,0 +1,27 @@
+"""Shared trainer-image layers. The framework-specific base image, fork clone, and any extra
+build steps stay in each recipe's ``trainer_image.py``; the layers every framework needs — the
+delta-encoder codecs, the HF-download env, and the stitch + cookbook source mounts — live here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import modal
+
+_COOKBOOK_DIR = Path(__file__).resolve().parent.parent  # .../cookbook
+
+
+def add_common_layers(image: modal.Image, *, experiment: str, run_id: str | None = None) -> modal.Image:
+    """Append the framework-agnostic trainer layers: the trainer-side delta ENCODER's codecs
+    (needed even under --no-deps), the HF-download env (``EXPERIMENT_CONFIG``/``RUN_ID`` so a
+    container's re-import selects the same experiment/run as the deploy), and the stitch + cookbook
+    source mounts so the trainer, Ray actors, and the sidecar subprocess resolve their imports."""
+    return (
+        image
+        .pip_install("fastapi", "httpx", "uvicorn", "zstandard", "xxhash", "blake3")
+        .env({"HF_XET_HIGH_PERFORMANCE": "1", "HF_HUB_ENABLE_HF_TRANSFER": "1",
+              "EXPERIMENT_CONFIG": experiment, **({"RUN_ID": run_id} if run_id else {})})
+        .add_local_python_source("stitch")
+        .add_local_dir(str(_COOKBOOK_DIR), remote_path="/root/cookbook", ignore=["**/__pycache__"])
+    )

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -180,7 +180,7 @@ class Trainer:
             volume.reload()
 
         cfg = MilesConfig.from_payload(payload)
-        _materialize_node_local_yaml(cfg, "te_precision_config_file")
+        launch.materialize_node_local_yaml(cfg, "te_precision_config_file")
         if self.rank != 0:
             return
 
@@ -221,21 +221,6 @@ class Trainer:
                 print(f"Train log committed to miles-checkpoints at {run_id}/train.log")
             except Exception as exc:  # noqa: BLE001
                 print(f"WARNING: could not commit train log: {exc}")
-
-
-# ── miles launch helper (te_precision_config_file is miles-only) ──────────────────
-def _materialize_node_local_yaml(cfg: Any, field: str, dest_dir: str = "/root/.miles_node_yaml") -> None:
-    """Write an inline YAML config to a deterministic node-local path on EVERY node.
-    Fields like te_precision_config_file are re-read on each Ray actor, so they must
-    resolve to identical content at an identical path on all nodes."""
-    import yaml
-
-    if isinstance(val := getattr(cfg, field, None), dict):
-        os.makedirs(dest_dir, exist_ok=True)
-        path = os.path.join(dest_dir, f"{field}.yaml")
-        with open(path, "w") as f:
-            yaml.dump(val, f)
-        setattr(cfg, field, path)
 
 
 # ── Entrypoints (preparation lives in a separate app: cookbook.miles_disagg.prep_app) ──

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -161,17 +161,14 @@ class Trainer:
         process.apply_git_patches(list(getattr(exp, "MEGATRON_RUNTIME_PATCHES", [])), MEGATRON_PATH, "Megatron patch")
         self.rank = rank
         process.start_host_mem_monitor()  # per-node host-RAM trace
-        os.environ.update({
-            "MILES_HOST_IP": my_ip, "SGLANG_HOST_IP": my_ip, "HOST_IP": my_ip,
-            "MASTER_ADDR": master_addr, "RAY_ADDRESS": f"{master_addr}:{RAY_PORT}",
-            "no_proxy": f"127.0.0.1,{master_addr},{my_ip}", "NO_PROXY": f"127.0.0.1,{master_addr},{my_ip}",
-            "PYTHONPATH": f"{MEGATRON_PATH}:{os.environ.get('PYTHONPATH', '')}",  # source-only megatron.training
-            **miles_cfg.environment,
-        })
-        if rank == 0:
-            ray_cluster.start_ray_head(my_ip, miles_cfg.n_train_nodes, ray_port=RAY_PORT)
-        else:
-            ray_cluster.start_ray_worker(my_ip, master_addr, ray_port=RAY_PORT)
+        ray_cluster.start_ray_node(
+            rank, master_addr, my_ip, n_nodes=miles_cfg.n_train_nodes, ray_port=RAY_PORT,
+            extra_env={
+                "MILES_HOST_IP": my_ip,
+                "PYTHONPATH": f"{MEGATRON_PATH}:{os.environ.get('PYTHONPATH', '')}",  # source-only megatron.training
+                **miles_cfg.environment,
+            },
+        )
 
     @modal.method()
     def train(self, payload: dict) -> None:

--- a/cookbook/miles_disagg/launch.py
+++ b/cookbook/miles_disagg/launch.py
@@ -21,31 +21,10 @@ import uuid
 
 def main() -> None:
     os.environ["RUN_ID"] = uuid.uuid4().hex[:8]
+    from cookbook.common import launch
     from cookbook.miles_disagg import app as run
 
-    run.app.deploy()
-    _await_pool_ready(run)
-    run.spawn_train()
-    print(f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; stop it with: modal app stop {run.APP_NAME}")
-
-
-def _await_pool_ready(run, timeout: float = 20 * 60) -> None:
-    """Block until the pool answers /health, so the trainer's first rollout hits a ready pool rather
-    than a 5xx storm while the engines are still loading. Spawn anyway on timeout (the trainer retries)."""
-    import time
-
-    import httpx
-
-    gateway = run.ModalFlashPool(run.APP_NAME, "Server").gateway_url()
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            if httpx.get(f"{gateway}/health", timeout=10).status_code == 200:
-                return
-        except Exception:  # noqa: BLE001
-            pass
-        time.sleep(30)
-    print(f"WARNING: {run.APP_NAME} pool not ready after {timeout:.0f}s; spawning trainer anyway")
+    launch.deploy_pool_and_spawn(run)
 
 
 if __name__ == "__main__":

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import modal
 
+from cookbook.common import trainer_image as common_trainer_image
+
 # Dated tag, never `latest`: Modal caches from_registry per tag string and won't re-pull
 # a moved mutable tag, so `latest` silently serves whatever was first pulled.
 MILES_IMAGE_TAG = "radixark/miles:dev-202607182122"  # base Megatron/TE; match the upstream main stitch-miles is on
@@ -24,7 +26,6 @@ MILES_ROOT = "/root/miles"
 MEGATRON_PATH = "/root/Megatron-LM"  # source-only megatron.training must be on PYTHONPATH
 TORCH_DIST_CONVERT_WRAPPER = "/root/convert_hf_to_torch_dist_modal.py"
 
-_COOKBOOK_DIR = Path(__file__).resolve().parent.parent  # .../cookbook
 _TORCH_DIST_WRAPPER_SRC = Path(__file__).resolve().parent / "convert_hf_to_torch_dist_modal.py"
 
 
@@ -44,14 +45,9 @@ def build_trainer_image(*, hf_cache_path: str, experiment: str, run_id: str | No
             f" && cd {MILES_ROOT} && git fetch origin {MILES_REPO_REF} && git checkout FETCH_HEAD"
             f" && python3 -m pip install --no-deps -e {MILES_ROOT}"
         )
-        # The trainer-side delta ENCODER (miles delta.py) needs the codecs even under --no-deps.
-        .pip_install("fastapi", "httpx", "uvicorn", "zstandard", "xxhash", "blake3")
-        .env({"HF_XET_HIGH_PERFORMANCE": "1", "HF_HUB_ENABLE_HF_TRANSFER": "1", "EXPERIMENT_CONFIG": experiment,
-              **({"RUN_ID": run_id} if run_id else {})})
         .add_local_file(str(_TORCH_DIST_WRAPPER_SRC), TORCH_DIST_CONVERT_WRAPPER, copy=True)
-        .add_local_python_source("stitch")
-        .add_local_dir(str(_COOKBOOK_DIR), remote_path="/root/cookbook", ignore=["**/__pycache__"])
     )
+    image = common_trainer_image.add_common_layers(image, experiment=experiment, run_id=run_id)
     if miles_local:  # dev overlay: replace the cloned fork with a local checkout (no rebuild)
         image = image.add_local_dir(miles_local, remote_path=MILES_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])
     return image

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -151,16 +151,10 @@ class Trainer:
         rank, master_addr, my_ip = ray_cluster.get_modal_cluster_context(slime_cfg.n_train_nodes)
         self.rank = rank
         process.start_host_mem_monitor()  # per-node host-RAM trace
-        os.environ.update({
-            "SLIME_HOST_IP": my_ip, "SGLANG_HOST_IP": my_ip, "HOST_IP": my_ip,
-            "MASTER_ADDR": master_addr, "RAY_ADDRESS": f"{master_addr}:{RAY_PORT}",
-            "no_proxy": f"127.0.0.1,{master_addr},{my_ip}", "NO_PROXY": f"127.0.0.1,{master_addr},{my_ip}",
-            **slime_cfg.environment,
-        })
-        if rank == 0:
-            ray_cluster.start_ray_head(my_ip, slime_cfg.n_train_nodes, ray_port=RAY_PORT)
-        else:
-            ray_cluster.start_ray_worker(my_ip, master_addr, ray_port=RAY_PORT)
+        ray_cluster.start_ray_node(
+            rank, master_addr, my_ip, n_nodes=slime_cfg.n_train_nodes, ray_port=RAY_PORT,
+            extra_env={"SLIME_HOST_IP": my_ip, **slime_cfg.environment},
+        )
 
     @modal.method()
     def train(self, payload: dict) -> None:

--- a/cookbook/slime_disagg/launch.py
+++ b/cookbook/slime_disagg/launch.py
@@ -21,31 +21,10 @@ import uuid
 
 def main() -> None:
     os.environ["RUN_ID"] = uuid.uuid4().hex[:8]
+    from cookbook.common import launch
     from cookbook.slime_disagg import app as run
 
-    run.app.deploy()
-    _await_pool_ready(run)
-    run.spawn_train()
-    print(f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; stop it with: modal app stop {run.APP_NAME}")
-
-
-def _await_pool_ready(run, timeout: float = 20 * 60) -> None:
-    """Block until the pool answers /health, so the trainer's first rollout hits a ready pool rather
-    than a 5xx storm while the engines are still loading. Spawn anyway on timeout (the trainer retries)."""
-    import time
-
-    import httpx
-
-    gateway = run.ModalFlashPool(run.APP_NAME, "Server").gateway_url()
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            if httpx.get(f"{gateway}/health", timeout=10).status_code == 200:
-                return
-        except Exception:  # noqa: BLE001
-            pass
-        time.sleep(30)
-    print(f"WARNING: {run.APP_NAME} pool not ready after {timeout:.0f}s; spawning trainer anyway")
+    launch.deploy_pool_and_spawn(run)
 
 
 if __name__ == "__main__":

--- a/cookbook/slime_disagg/trainer_image.py
+++ b/cookbook/slime_disagg/trainer_image.py
@@ -6,17 +6,15 @@ trainer package, so slime and miles serve on the identical weight-sync sglang im
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import modal
+
+from cookbook.common import trainer_image as common_trainer_image
 
 SLIME_IMAGE_TAG = "slimerl/slime:nightly-dev-20260527a"
 SLIME_REPO_URL = "https://github.com/modal-projects/slime.git"
 # Pin to an exact commit, not the branch tip (the fetch+checkout is a cached layer).
 SLIME_REPO_REF = "11bb0fa48aa37d5c54fe297143c6bc1d40f311bf"
 SLIME_ROOT = "/root/slime"
-
-_COOKBOOK_DIR = Path(__file__).resolve().parent.parent  # .../cookbook
 
 
 def build_trainer_image(*, hf_cache_path: str, experiment: str, run_id: str | None = None, slime_local: str | None = None) -> modal.Image:
@@ -36,13 +34,8 @@ def build_trainer_image(*, hf_cache_path: str, experiment: str, run_id: str | No
         # The base installs megatron-core as a strict editable that hides
         # megatron.training; reinstall in compat mode so the whole source tree is importable.
         .run_commands("cd /root/Megatron-LM && python3 -m pip install --no-deps -e . --config-settings editable_mode=compat")
-        # The trainer-side delta ENCODER (slime.utils.disk_delta) needs the codecs even under --no-deps.
-        .pip_install("fastapi", "httpx", "uvicorn", "zstandard", "xxhash", "blake3")
-        .env({"HF_XET_HIGH_PERFORMANCE": "1", "HF_HUB_ENABLE_HF_TRANSFER": "1", "EXPERIMENT_CONFIG": experiment,
-              **({"RUN_ID": run_id} if run_id else {})})
-        .add_local_python_source("stitch")
-        .add_local_dir(str(_COOKBOOK_DIR), remote_path="/root/cookbook", ignore=["**/__pycache__"])
     )
+    image = common_trainer_image.add_common_layers(image, experiment=experiment, run_id=run_id)
     if slime_local:  # dev overlay: replace the cloned fork with a local checkout (no rebuild)
         image = image.add_local_dir(slime_local, remote_path=SLIME_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])
     return image

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -12,7 +12,9 @@ demotes ``request`` to a required query param, 422-ing every call.
 
 import asyncio
 import contextlib
+import json
 import logging
+import urllib.request
 import uuid
 from collections.abc import Iterable
 from contextlib import asynccontextmanager
@@ -22,7 +24,7 @@ from stitch.engines.base import Engine
 from stitch.pools.base import Pool
 from stitch.stores.base import Store
 from stitch.sync import CommitMode, ConstraintUnmet, Reconciler
-from stitch.types import PoolState, ReplicaState, VersionConstraint
+from stitch.types import PoolState, ReplicaState, SyncState, VersionConstraint
 
 logger = logging.getLogger(__name__)
 
@@ -212,3 +214,24 @@ async def readiness(pool: Pool, *, timeout: float = 15.0) -> PoolState:
     async with httpx.AsyncClient(trust_env=False) as c:
         states = await asyncio.gather(*(probe(c, url) for url in pool.discover_replicas()))
     return PoolState(list(states))
+
+
+# The reconciler states in which the engine is legitimately unresponsive: it is pulling or
+# reloading weights, which starves its event loop, so a stale health heartbeat is EXPECTED.
+_SYNCING_STATES = {SyncState.QUEUED.value, SyncState.PREFETCHING.value,
+                   SyncState.PREPARING.value, SyncState.COMMITTING.value}
+
+
+def sync_in_progress(server_info_url: str, *, timeout: float = 5.0) -> bool:
+    """Whether the replica's reconciler is mid weight-sync (seeding the base or reloading a
+    version). A deployment's engine-health probe calls this to SUPPRESS a health blip during a
+    sync: the reload starves the engine's event loop, so an unresponsive detokenizer is expected,
+    not a crash. A boot base-seed runs with sync_state IDLE, so ``prefetch_done`` is its separate
+    signal. Best-effort: an unreachable sidecar returns False, so the caller reports the error."""
+    try:
+        with urllib.request.urlopen(server_info_url, timeout=timeout) as resp:
+            info = json.loads(resp.read())
+    except Exception:  # noqa: BLE001
+        return False
+    seeding = not info.get("prefetch_done", True) and not info.get("prefetch_error")
+    return bool(seeding or info.get("sync_state") in _SYNCING_STATES)

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -14,6 +14,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import time
 import urllib.request
 import uuid
 from collections.abc import Iterable
@@ -235,3 +236,23 @@ def sync_in_progress(server_info_url: str, *, timeout: float = 5.0) -> bool:
         return False
     seeding = not info.get("prefetch_done", True) and not info.get("prefetch_error")
     return bool(seeding or info.get("sync_state") in _SYNCING_STATES)
+
+
+def await_pool_ready(pool: Pool, *, timeout: float = 20 * 60, interval: float = 30.0) -> bool:
+    """Block until the pool's gateway answers /health 200 — Flash holds requests through a
+    cold-starting pool, so the first rollout/hot-load meets a ready pool instead of a 5xx storm
+    while engines load. Returns True when ready; on timeout, warns and returns False (the caller
+    proceeds anyway — the trainer retries). A launch-script helper: synchronous, unlike ``readiness``."""
+    import httpx
+
+    gateway = pool.gateway_url().rstrip("/")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if httpx.get(f"{gateway}/health", timeout=10).status_code == 200:
+                return True
+        except Exception:  # noqa: BLE001
+            pass
+        time.sleep(interval)
+    print(f"WARNING: pool at {gateway} not ready after {timeout:.0f}s; proceeding (the trainer retries)")
+    return False

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -1,0 +1,53 @@
+"""``sync_in_progress`` — the shared /server_info interpretation a deployment's engine-health
+probe uses to suppress health blips while the reconciler is reloading weights."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from stitch.service import sync_in_progress
+
+
+@contextlib.contextmanager
+def _server_info(payload):
+    """Serve ``payload`` as JSON at /server_info on a throwaway localhost port."""
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps(payload).encode())
+
+        def log_message(self, *_):  # silence
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/server_info"
+    finally:
+        server.shutdown()
+
+
+@pytest.mark.parametrize(
+    "info,expected",
+    [
+        ({"prefetch_done": True, "sync_state": "COMMITTING"}, True),   # reloading
+        ({"prefetch_done": True, "sync_state": "PREFETCHING"}, True),  # staging deltas
+        ({"prefetch_done": False, "prefetch_error": None}, True),      # boot base-seed (IDLE)
+        ({"prefetch_done": True, "sync_state": "IDLE"}, False),        # settled: a blip is real
+        ({"prefetch_done": False, "prefetch_error": "boom"}, False),   # seed failed: report it
+    ],
+)
+def test_sync_in_progress(info, expected):
+    with _server_info(info) as url:
+        assert sync_in_progress(url) is expected
+
+
+def test_unreachable_sidecar_reports_error():
+    # Nothing listening: best-effort False so the caller surfaces the engine error.
+    assert sync_in_progress("http://127.0.0.1:1/server_info", timeout=0.2) is False


### PR DESCRIPTION
Consolidates the disaggregated-rollout dedup pass (supersedes #65 and #66, which this replaces so their overlapping edits to `service.py` / `common/launch.py` don't conflict). Pure dedup — no behavior change; `uv run pytest` → 50 passed.

The rule applied: anything **framework- and customer-agnostic** that was copy-pasted across recipes (miles / slime / the cognition provider) moves into stitch or `cookbook/common`; framework-specific pieces (base image, fork clone, `Trainer` bring-up, `config.py`, and the engine-specific `Server`) stay per-recipe.

## stitch (`src/stitch/service.py`) — shared serving/readiness primitives
- **`sync_in_progress(server_info_url)`** — the `/server_info` sync-state interpretation an engine-health probe uses to suppress health blips during a reload. Was copy-pasted (with the state strings hardcoded, and already drifting) into `common/server.py` and the cognition provider.
- **`await_pool_ready(pool)`** — poll the pool gateway `/health` until it serves. Was copy-pasted as `_await_pool_ready` in **both** cookbook launch scripts and again as `await_ready` in the provider.
- `service_test.py` covers `sync_in_progress`.

## cookbook/common — shared deployment helpers
- **`launch.materialize_node_local_yaml`** — inline-dict config field → a node-local YAML on every node (was miles-only; the omitted copy is what crashed a downstream nvfp4 run by passing the dict as a giant string).
- **`launch.deploy_pool_and_spawn`** — the whole `mint → deploy → await → spawn` launch body (miles/slime `launch.py` were ~90% identical).
- **`trainer_image.add_common_layers`** — the delta-encoder codecs + HF env + stitch/cookbook mounts (byte-identical across miles/slime trainer images; a codec can no longer drift between them).

## Deliberately NOT merged
- The rollout **`Server`** — engine-specific (a recipe may serve on vLLM, not sglang); serving stays framework-agnostic but per-recipe.
- The **config classes** — each framework's arg surface is its own contract.
- Per-recipe `@app.local_entrypoint` CLI stubs (`spawn_train` / `launch_train` / `smoke_flash_pool`).