### PR TITLE
Harden rollout serving and catch-up reliability

### DIFF
--- a/cookbook/common/trainer_image.py
+++ b/cookbook/common/trainer_image.py
@@ -12,16 +12,39 @@ import modal
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent  # .../cookbook
 
 
-def add_common_layers(image: modal.Image, *, experiment: str, run_id: str | None = None) -> modal.Image:
+def add_common_layers(
+    image: modal.Image,
+    *,
+    experiment: str,
+    run_id: str | None = None,
+    copy_source: bool = False,
+) -> modal.Image:
     """Append the framework-agnostic trainer layers: the trainer-side delta ENCODER's codecs
     (needed even under --no-deps), the HF-download env (``EXPERIMENT_CONFIG``/``RUN_ID`` so a
     container's re-import selects the same experiment/run as the deploy), and the stitch + cookbook
-    source mounts so the trainer, Ray actors, and the sidecar subprocess resolve their imports."""
+    source so the trainer, Ray actors, and the sidecar subprocess resolve their imports.
+
+    ``copy_source=True`` bakes those sources into image layers.  Callers that need to append
+    build steps must opt into that mode because Modal intentionally rejects build steps after a
+    runtime ``add_local_*`` mount.
+    """
     return (
-        image
-        .pip_install("fastapi", "httpx", "uvicorn", "zstandard", "xxhash", "blake3")
-        .env({"HF_XET_HIGH_PERFORMANCE": "1", "HF_HUB_ENABLE_HF_TRANSFER": "1",
-              "EXPERIMENT_CONFIG": experiment, **({"RUN_ID": run_id} if run_id else {})})
-        .add_local_python_source("stitch")
-        .add_local_dir(str(_COOKBOOK_DIR), remote_path="/root/cookbook", ignore=["**/__pycache__"])
+        image.pip_install(
+            "fastapi", "httpx", "uvicorn", "zstandard", "xxhash", "blake3"
+        )
+        .env(
+            {
+                "HF_XET_HIGH_PERFORMANCE": "1",
+                "HF_HUB_ENABLE_HF_TRANSFER": "1",
+                "EXPERIMENT_CONFIG": experiment,
+                **({"RUN_ID": run_id} if run_id else {}),
+            }
+        )
+        .add_local_python_source("stitch", copy=copy_source)
+        .add_local_dir(
+            str(_COOKBOOK_DIR),
+            remote_path="/root/cookbook",
+            ignore=["**/__pycache__"],
+            copy=copy_source,
+        )
     )

--- a/cookbook/common/trainer_image_test.py
+++ b/cookbook/common/trainer_image_test.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cookbook.miles_disagg import trainer_image as miles_trainer_image
+from cookbook.slime_disagg import trainer_image as slime_trainer_image
+
+
+class _OrderingImage:
+    """Small Modal Image ordering model: build layers may not follow runtime mounts."""
+
+    def __init__(self) -> None:
+        self.has_runtime_mount = False
+
+    def _build(self, *_args, **_kwargs) -> _OrderingImage:
+        assert not self.has_runtime_mount, (
+            "build layer added after a runtime source mount"
+        )
+        return self
+
+    entrypoint = apt_install = run_commands = pip_install = env = _build
+
+    def add_local_file(self, *_args, copy: bool = False, **_kwargs) -> _OrderingImage:
+        if copy:
+            return self._build()
+        self.has_runtime_mount = True
+        return self
+
+    add_local_dir = add_local_python_source = add_local_file
+
+
+def _build(
+    monkeypatch,
+    trainer_image: Any,
+    local_source_arg: str,
+    *,
+    copy_source: bool,
+    local_source: str | None = None,
+) -> _OrderingImage:
+    image = _OrderingImage()
+    monkeypatch.setattr(
+        trainer_image.modal.Image, "from_registry", lambda *_args, **_kwargs: image
+    )
+    return trainer_image.build_trainer_image(
+        hf_cache_path="/cache",
+        experiment="test",
+        copy_source=copy_source,
+        **({local_source_arg: local_source} if local_source else {}),
+    )
+
+
+@pytest.mark.parametrize(
+    ("trainer_image", "local_source_arg"),
+    [
+        (miles_trainer_image, "miles_local"),
+        (slime_trainer_image, "slime_local"),
+    ],
+    ids=["miles", "slime"],
+)
+def test_sources_remain_fast_runtime_mounts_by_default(
+    monkeypatch,
+    trainer_image: Any,
+    local_source_arg: str,
+) -> None:
+    image = _build(
+        monkeypatch,
+        trainer_image,
+        local_source_arg,
+        copy_source=False,
+    )
+
+    assert image.has_runtime_mount
+
+
+@pytest.mark.parametrize(
+    ("trainer_image", "local_source_arg", "local_source"),
+    [
+        (miles_trainer_image, "miles_local", "/local/miles"),
+        (slime_trainer_image, "slime_local", "/local/slime"),
+    ],
+    ids=["miles", "slime"],
+)
+def test_copy_source_image_can_be_extended_after_local_fork_overlay(
+    monkeypatch,
+    trainer_image: Any,
+    local_source_arg: str,
+    local_source: str,
+) -> None:
+    image = _build(
+        monkeypatch,
+        trainer_image,
+        local_source_arg,
+        copy_source=True,
+        local_source=local_source,
+    )
+
+    assert not image.has_runtime_mount
+    image.env({"TRAINER_GPU": "B300"})
+    image.add_local_file("patch", "/root/patch", copy=True)
+    image.run_commands("cd /root/miles && git apply /root/patch")

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -23,13 +23,23 @@ MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
 MILES_REPO_REF = "d814b87c32d3de528ec1536700e79406ee40bf20"  # stitch-weight-sync-v0516
 
 MILES_ROOT = "/root/miles"
-MEGATRON_PATH = "/root/Megatron-LM"  # source-only megatron.training must be on PYTHONPATH
+# Source-only megatron.training must be on PYTHONPATH.
+MEGATRON_PATH = "/root/Megatron-LM"
 TORCH_DIST_CONVERT_WRAPPER = "/root/convert_hf_to_torch_dist_modal.py"
 
-_TORCH_DIST_WRAPPER_SRC = Path(__file__).resolve().parent / "convert_hf_to_torch_dist_modal.py"
+_TORCH_DIST_WRAPPER_SRC = (
+    Path(__file__).resolve().parent / "convert_hf_to_torch_dist_modal.py"
+)
 
 
-def build_trainer_image(*, hf_cache_path: str, experiment: str, run_id: str | None = None, miles_local: str | None = None) -> modal.Image:
+def build_trainer_image(
+    *,
+    hf_cache_path: str,
+    experiment: str,
+    run_id: str | None = None,
+    miles_local: str | None = None,
+    copy_source: bool = False,
+) -> modal.Image:
     """The miles trainer image: RDMA/EFA userspace + the pinned miles fork + the
     trainer-side delta encoder's codecs. stitch + the cookbook package are mounted so the
     trainer, Ray actors, and the sidecar subprocess resolve their imports."""
@@ -40,17 +50,33 @@ def build_trainer_image(*, hf_cache_path: str, experiment: str, run_id: str | No
         # image installs its TE wheels with --no-deps.
         .pip_install("onnxscript==0.7.1")
         # RDMA/EFA userspace so multi-node NCCL binds EFA under rdma=True instead of TCP.
-        .apt_install("libibverbs-dev", "libibverbs1", "libhwloc-dev", "libnl-route-3-200")
-        .run_commands(f"rm -rf {hf_cache_path}")  # baked HF cache must not shadow the mounted volume
+        .apt_install(
+            "libibverbs-dev", "libibverbs1", "libhwloc-dev", "libnl-route-3-200"
+        )
+        # A baked HF cache must not shadow the mounted volume.
+        .run_commands(f"rm -rf {hf_cache_path}")
         .run_commands(
             f"rm -rf {MILES_ROOT}"
             f" && git clone {MILES_REPO_URL} {MILES_ROOT}"
             f" && cd {MILES_ROOT} && git fetch origin {MILES_REPO_REF} && git checkout FETCH_HEAD"
             f" && python3 -m pip install --no-deps -e {MILES_ROOT}"
         )
-        .add_local_file(str(_TORCH_DIST_WRAPPER_SRC), TORCH_DIST_CONVERT_WRAPPER, copy=True)
+        .add_local_file(
+            str(_TORCH_DIST_WRAPPER_SRC), TORCH_DIST_CONVERT_WRAPPER, copy=True
+        )
     )
-    image = common_trainer_image.add_common_layers(image, experiment=experiment, run_id=run_id)
-    if miles_local:  # dev overlay: replace the cloned fork with a local checkout (no rebuild)
-        image = image.add_local_dir(miles_local, remote_path=MILES_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])
+    image = common_trainer_image.add_common_layers(
+        image,
+        experiment=experiment,
+        run_id=run_id,
+        copy_source=copy_source,
+    )
+    # Dev overlay: replace the cloned fork with a local checkout.
+    if miles_local:
+        image = image.add_local_dir(
+            miles_local,
+            remote_path=MILES_ROOT,
+            ignore=[".git", "**/__pycache__", "**/*.pyc"],
+            copy=copy_source,
+        )
     return image

--- a/cookbook/slime_disagg/trainer_image.py
+++ b/cookbook/slime_disagg/trainer_image.py
@@ -17,14 +17,22 @@ SLIME_REPO_REF = "11bb0fa48aa37d5c54fe297143c6bc1d40f311bf"
 SLIME_ROOT = "/root/slime"
 
 
-def build_trainer_image(*, hf_cache_path: str, experiment: str, run_id: str | None = None, slime_local: str | None = None) -> modal.Image:
+def build_trainer_image(
+    *,
+    hf_cache_path: str,
+    experiment: str,
+    run_id: str | None = None,
+    slime_local: str | None = None,
+    copy_source: bool = False,
+) -> modal.Image:
     """The slime trainer image: the pinned slime fork over the slime base, Megatron-LM
     reinstalled so ``megatron.training`` is importable, + the delta encoder's codecs.
     stitch + the cookbook package are mounted for the trainer, Ray actors, and sidecar."""
     image = (
         modal.Image.from_registry(SLIME_IMAGE_TAG)
         .entrypoint([])
-        .run_commands(f"rm -rf {hf_cache_path}")  # baked HF cache must not shadow the mounted volume
+        # A baked HF cache must not shadow the mounted volume.
+        .run_commands(f"rm -rf {hf_cache_path}")
         .run_commands(
             f"rm -rf {SLIME_ROOT}"
             f" && git clone --depth 1 {SLIME_REPO_URL} {SLIME_ROOT}"
@@ -33,9 +41,22 @@ def build_trainer_image(*, hf_cache_path: str, experiment: str, run_id: str | No
         )
         # The base installs megatron-core as a strict editable that hides
         # megatron.training; reinstall in compat mode so the whole source tree is importable.
-        .run_commands("cd /root/Megatron-LM && python3 -m pip install --no-deps -e . --config-settings editable_mode=compat")
+        .run_commands(
+            "cd /root/Megatron-LM && python3 -m pip install --no-deps -e . --config-settings editable_mode=compat"
+        )
     )
-    image = common_trainer_image.add_common_layers(image, experiment=experiment, run_id=run_id)
-    if slime_local:  # dev overlay: replace the cloned fork with a local checkout (no rebuild)
-        image = image.add_local_dir(slime_local, remote_path=SLIME_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])
+    image = common_trainer_image.add_common_layers(
+        image,
+        experiment=experiment,
+        run_id=run_id,
+        copy_source=copy_source,
+    )
+    # Dev overlay: replace the cloned fork with a local checkout.
+    if slime_local:
+        image = image.add_local_dir(
+            slime_local,
+            remote_path=SLIME_ROOT,
+            ignore=[".git", "**/__pycache__", "**/*.pyc"],
+            copy=copy_source,
+        )
     return image

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,13 @@ modal = ["modal>=1.5.1.dev9", "httpx"]
 sglang = ["fastapi", "httpx"]
 
 [dependency-groups]
-dev = ["pytest", "ruff==0.15.1", "modal>=1.5.1.dev9"]
+dev = [
+    "pytest",
+    "ruff==0.15.1",
+    "modal>=1.5.1.dev9",
+    "fastapi",
+    "httpx",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ modal = ["modal>=1.5.1.dev9", "httpx"]
 sglang = ["fastapi", "httpx"]
 
 [dependency-groups]
-dev = ["pytest", "ruff==0.15.1"]
+dev = ["pytest", "ruff==0.15.1", "modal>=1.5.1.dev9"]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -45,7 +45,8 @@ def create_app(
     """The versioned rollout proxy. Versioned routes are admitted through the gate
     (constraint enforced, serving version captured), stamped by the engine, forwarded,
     and the response stamped with the served version. A rejected constraint returns a
-    retryable 409; a client disconnect aborts the upstream generation."""
+    retryable 409; a client disconnect aborts the upstream generation. A local-engine
+    transport failure returns a retryable 503 instead of escaping as a sidecar 500."""
     import httpx
     from fastapi import FastAPI, Request
     from fastapi.responses import JSONResponse, Response
@@ -153,7 +154,30 @@ def create_app(
                     with contextlib.suppress(BaseException):
                         await disconnect_task
 
-                resp = upstream_task.result()
+                try:
+                    resp = upstream_task.result()
+                except httpx.RequestError as exc:
+                    # The sidecar is still healthy when its colocated engine exits, wedges, or
+                    # drops a connection. Surface that distinction to the pool so another replica
+                    # can take the retry. A failed read can leave generation alive upstream, so
+                    # retain the admission lease until the best-effort abort has completed.
+                    logger.warning(
+                        "local engine request failed method=%s route=/%s rid=%s error=%s: %s",
+                        request.method, route, rid, type(exc).__name__, exc,
+                    )
+                    if rid is not None:
+                        await _abort(client(), engine_url, rid)
+                    return JSONResponse(
+                        {
+                            "error": {
+                                "type": "EngineUnavailable",
+                                "message": "the local inference engine is unavailable",
+                                "retryable": True,
+                            }
+                        },
+                        status_code=503,
+                        headers={"Retry-After": "1"},
+                    )
                 if "application/json" not in resp.headers.get("content-type", ""):
                     return Response(content=resp.content, status_code=resp.status_code,
                                     media_type=resp.headers.get("content-type") or None)
@@ -172,8 +196,10 @@ def create_app(
 async def _abort(client: Any, engine_url: str, rid: str) -> None:
     try:
         await client.request("POST", f"{engine_url}/abort_request", json={"rid": rid}, timeout=10.0)
-    except Exception:  # noqa: BLE001
-        logger.warning("failed to abort upstream rid=%s", rid, exc_info=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "failed to abort upstream rid=%s error=%s: %s", rid, type(exc).__name__, exc,
+        )
 
 
 def serve(

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -3,14 +3,169 @@ probe uses to suppress health blips while the reconciler commits staged weights.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
+import logging
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
 
+import httpx
 import pytest
 
-from stitch.service import sync_in_progress
+from stitch.engines.base import Engine
+from stitch.service import create_app, sync_in_progress
+from stitch.sync import AdmissionGate
+from stitch.types import VersionRef
+
+
+class _ProxyEngine(Engine):
+    def base_url(self) -> str:
+        return "http://local-engine:8001"
+
+    def blocked_routes(self) -> frozenset[str]:
+        return frozenset()
+
+    def stamp_request(self, request: dict[str, Any], served: VersionRef) -> None:
+        request["served_version"] = served.version
+
+    def stamp_response(self, response: dict[str, Any], served: VersionRef, current: VersionRef) -> None:
+        response["served_version"] = served.version
+
+
+class _FailingUpstream:
+    """Let a test observe admission, then fail the engine request at a controlled point."""
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.fail = asyncio.Event()
+        self.abort_rids: list[str] = []
+
+    async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if url.endswith("/abort_request"):
+            self.abort_rids.append(kwargs["json"]["rid"])
+            return httpx.Response(200)
+        self.started.set()
+        await self.fail.wait()
+        raise httpx.ConnectError("all connection attempts failed", request=httpx.Request(method, url))
+
+
+class _HangingUpstream:
+    """An engine request which runs until the proxy cancels it on client disconnect."""
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.cancelled = asyncio.Event()
+        self.abort_rids: list[str] = []
+
+    async def request(self, _method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if url.endswith("/abort_request"):
+            self.abort_rids.append(kwargs["json"]["rid"])
+            return httpx.Response(200)
+        self.started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+
+
+async def _asgi_post(app: Any, payload: dict[str, Any], *, disconnect_on: asyncio.Event | None = None):
+    """Issue one request directly to the ASGI app, optionally disconnecting after its body."""
+    body = json.dumps(payload).encode()
+    body_sent = False
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        nonlocal body_sent
+        if not body_sent:
+            body_sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        if disconnect_on is not None:
+            await disconnect_on.wait()
+            return {"type": "http.disconnect"}
+        await asyncio.Future()
+        raise AssertionError("unreachable")
+
+    async def send(message: dict[str, Any]) -> None:
+        sent.append(message)
+
+    await app(
+        {
+            "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
+            "method": "POST", "scheme": "http", "path": "/generate",
+            "raw_path": b"/generate", "query_string": b"",
+            "headers": [(b"content-type", b"application/json")],
+            "client": ("127.0.0.1", 1234), "server": ("sidecar", 8000),
+        },
+        receive,
+        send,
+    )
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    response_body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+    headers = {k.decode().lower(): v.decode() for k, v in start["headers"]}
+    return start["status"], headers, response_body
+
+
+def test_upstream_transport_failure_is_retryable_and_releases_admission(monkeypatch, caplog):
+    async def go():
+        upstream = _FailingUpstream()
+        gate = AdmissionGate()
+        gate.applied = VersionRef("run", 3)
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: upstream)
+        app = create_app(gate, _ProxyEngine())  # type: ignore[arg-type]
+
+        request = asyncio.create_task(_asgi_post(app, {"rid": "rollout-1"}))
+        await upstream.started.wait()
+        assert gate.active_requests == 1
+        upstream.fail.set()
+        status, headers, body = await request
+
+        assert gate.active_requests == 0
+        assert upstream.abort_rids == ["rollout-1"]
+        return status, headers, json.loads(body)
+
+    with caplog.at_level(logging.WARNING, logger="stitch.service"):
+        status, headers, data = asyncio.run(go())
+
+    assert status == 503
+    assert headers["retry-after"] == "1"
+    assert data == {
+        "error": {
+            "type": "EngineUnavailable",
+            "message": "the local inference engine is unavailable",
+            "retryable": True,
+        }
+    }
+    records = [r for r in caplog.records if "local engine request failed" in r.message]
+    assert len(records) == 1
+    assert records[0].exc_info is None  # concise per-request signal, not a traceback storm
+
+
+def test_client_disconnect_cancels_aborts_and_releases_admission(monkeypatch):
+    async def go():
+        upstream = _HangingUpstream()
+        allow_disconnect = asyncio.Event()
+        gate = AdmissionGate()
+        gate.applied = VersionRef("run", 3)
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: upstream)
+        app = create_app(gate, _ProxyEngine())  # type: ignore[arg-type]
+
+        request = asyncio.create_task(
+            _asgi_post(app, {"rid": "rollout-2"}, disconnect_on=allow_disconnect)
+        )
+        await upstream.started.wait()
+        assert gate.active_requests == 1
+        allow_disconnect.set()
+        status, _headers, _body = await request
+
+        assert upstream.cancelled.is_set()
+        assert upstream.abort_rids == ["rollout-2"]
+        assert gate.active_requests == 0
+        assert status == 499
+
+    asyncio.run(go())
 
 
 @contextlib.contextmanager

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -278,7 +278,8 @@ class Reconciler(AdmissionGate):
                 if caught_up:
                     # A publish can land mid-commit; re-check before idling.
                     await asyncio.to_thread(self.store.refresh)
-                    if self._behind(self.store.read_pointer()):
+                    pointer = await asyncio.to_thread(self.store.read_pointer)
+                    if self._behind(pointer):
                         caught_up = False
             except Exception as exc:  # noqa: BLE001
                 self.last_error = str(exc)
@@ -356,7 +357,7 @@ class Reconciler(AdmissionGate):
 
     async def _reconcile_once_measured(self, m: dict[str, Any]) -> bool:
         await asyncio.to_thread(self.store.refresh)
-        pointer = self.store.read_pointer()
+        pointer = await asyncio.to_thread(self.store.read_pointer)
         if pointer is None:
             return True
         if self.applied is None or pointer.run_id != self.applied.run_id:
@@ -368,7 +369,7 @@ class Reconciler(AdmissionGate):
         self.last_error = None
         m["target_version"] = pointer.version
         m["applied_version"] = self.applied.version if self.applied else -1
-        target = self.store.read_manifest(pointer)
+        target = await asyncio.to_thread(self.store.read_manifest, pointer)
         source_dir = await asyncio.to_thread(self.store.materialize, pointer)
         logger.info(
             "catch-up: %s -> v%d, preparing weight update",
@@ -401,10 +402,55 @@ class Reconciler(AdmissionGate):
             await self.commit(apply=self._commit_noop, on_applied=on_applied)
             m["skipped_weight_update"] = True
         else:
-            # Preparation runs while serving; the gate covers only the load.
+            # Preparation runs while serving. Re-read the head once before the
+            # commit so a slow stage does not force an avoidable GPU update to an
+            # already-obsolete version. One re-check bounds the work when the
+            # trainer publishes continuously.
             self.sync_state = SyncState.STAGING
+            initial_pointer = pointer
             with _timed(m, "stage_s"):
                 await self.engine.stage(target, source_dir)
+                try:
+                    await asyncio.to_thread(self.store.refresh)
+                    latest = await asyncio.to_thread(self.store.read_pointer)
+                    if (
+                        latest is not None
+                        and latest.run_id == pointer.run_id
+                        and latest.version > pointer.version
+                    ):
+                        latest_target = await asyncio.to_thread(
+                            self.store.read_manifest, latest
+                        )
+                        latest_source_dir = await asyncio.to_thread(
+                            self.store.materialize, latest
+                        )
+                    else:
+                        latest = None
+                except Exception as exc:  # noqa: BLE001
+                    latest = None
+                    m["coalesce_error"] = str(exc)
+                    logger.warning(
+                        "could not inspect a newer target; committing staged v%d",
+                        pointer.version,
+                        exc_info=True,
+                    )
+
+                if latest is not None:
+                    logger.info(
+                        "catch-up: staging advanced head v%d -> v%d before commit",
+                        pointer.version,
+                        latest.version,
+                    )
+                    await self.engine.stage(latest_target, latest_source_dir)
+                    pointer = latest
+                    target = latest_target
+
+            if pointer != initial_pointer:
+                m["initial_target_version"] = initial_pointer.version
+                m["target_version"] = pointer.version
+                m["coalesced_versions"] = (
+                    pointer.version - initial_pointer.version
+                )
             logger.info("catch-up: loading v%d into the engine", pointer.version)
 
             async def apply() -> None:
@@ -422,9 +468,8 @@ class Reconciler(AdmissionGate):
                 resume=self.engine.resume,
             )
         self.sync_state = SyncState.FETCHING
-        return not self._behind(
-            self.store.read_pointer()
-        )  # a mid-pass publish is next tick's work
+        pointer = await asyncio.to_thread(self.store.read_pointer)
+        return not self._behind(pointer)  # a mid-pass publish is next tick's work
 
     async def _commit_noop(self) -> None:
         self.sync_state = SyncState.COMMITTING

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -153,7 +153,7 @@ def test_catch_up() -> None:
     _run(go())
 
 
-def test_latest_advance_during_stage_folds_next_pass() -> None:
+def test_latest_advance_during_stage_coalesces_before_commit() -> None:
     async def go() -> None:
         manifests = [_delta("r1", version, files=[f"v{version}"]) for version in range(7, 11)]
         store = FakeStore(VersionRef("r1", 7), *manifests)
@@ -179,8 +179,102 @@ def test_latest_advance_during_stage_folds_next_pass() -> None:
         await syncing
 
         assert engine.staged == [VersionRef("r1", 7), VersionRef("r1", 10)]
-        assert engine.committed == [VersionRef("r1", 7), VersionRef("r1", 10)]
+        assert engine.committed == [VersionRef("r1", 10)]
         assert r.applied == VersionRef("r1", 10)
+        assert r.metrics["initial_target_version"] == 7
+        assert r.metrics["target_version"] == 10
+        assert r.metrics["coalesced_versions"] == 3
+
+    _run(go())
+
+
+def test_continuous_publishing_cannot_starve_commit() -> None:
+    async def go() -> None:
+        store = FakeStore(
+            VersionRef("r1", 1),
+            *(
+                _delta("r1", version, files=[f"v{version}"])
+                for version in range(1, 4)
+            ),
+        )
+        engine = FakeEngine()
+        stage = engine.stage
+
+        async def advancing_stage(
+            manifest: VersionManifest,
+            source_dir: str,
+        ) -> None:
+            await stage(manifest, source_dir)
+            if manifest.ref.version < 3:
+                store.advance_pointer(
+                    VersionRef("r1", manifest.ref.version + 1)
+                )
+
+        engine.stage = advancing_stage  # type: ignore[method-assign]
+        r = Reconciler(store=store, engine=engine)
+        r.applied = VersionRef("r1", 0)
+
+        caught_up = await r._reconcile_once()
+
+        assert not caught_up
+        assert engine.staged == [VersionRef("r1", 1), VersionRef("r1", 2)]
+        assert engine.committed == [VersionRef("r1", 2)]
+        assert r.applied == VersionRef("r1", 2)
+        assert store.read_pointer() == VersionRef("r1", 3)
+
+    _run(go())
+
+
+def test_coalesce_does_not_cross_run_lineage() -> None:
+    async def go() -> None:
+        store = FakeStore(
+            VersionRef("r1", 1),
+            _delta("r1", 1, files=["old"]),
+            _delta("r2", 1, files=["new"]),
+        )
+        engine = FakeEngine()
+        stage = engine.stage
+
+        async def switching_stage(
+            manifest: VersionManifest,
+            source_dir: str,
+        ) -> None:
+            await stage(manifest, source_dir)
+            store.advance_pointer(VersionRef("r2", 1))
+
+        engine.stage = switching_stage  # type: ignore[method-assign]
+        r = Reconciler(store=store, engine=engine)
+        r.applied = VersionRef("r1", 0)
+
+        assert not await r._reconcile_once()
+        assert engine.staged == [VersionRef("r1", 1)]
+        assert engine.committed == [VersionRef("r1", 1)]
+        assert r.applied == VersionRef("r1", 1)
+
+    _run(go())
+
+
+def test_coalesce_observation_failure_commits_staged_target() -> None:
+    class FailSecondRefreshStore(FakeStore):
+        def refresh(self) -> None:
+            super().refresh()
+            if self.refreshed == 2:
+                raise RuntimeError("transient store error")
+
+    async def go() -> None:
+        store = FailSecondRefreshStore(
+            VersionRef("r1", 1),
+            _delta("r1", 1, files=["v1"]),
+        )
+        engine = FakeEngine()
+        r = Reconciler(store=store, engine=engine)
+        r.applied = VersionRef("r1", 0)
+
+        assert await r._reconcile_once()
+        assert engine.staged == [VersionRef("r1", 1)]
+        assert engine.committed == [VersionRef("r1", 1)]
+        assert r.applied == VersionRef("r1", 1)
+        assert r.metrics["coalesce_error"] == "transient store error"
 
     _run(go())
 

--- a/uv.lock
+++ b/uv.lock
@@ -1000,6 +1000,8 @@ sglang = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "fastapi" },
+    { name = "httpx" },
     { name = "modal" },
     { name = "pytest" },
     { name = "ruff" },
@@ -1016,6 +1018,8 @@ provides-extras = ["modal", "sglang"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "fastapi" },
+    { name = "httpx" },
     { name = "modal", specifier = ">=1.5.1.dev9" },
     { name = "pytest" },
     { name = "ruff", specifier = "==0.15.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -1000,6 +1000,7 @@ sglang = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "modal" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -1015,6 +1016,7 @@ provides-extras = ["modal", "sglang"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "modal", specifier = ">=1.5.1.dev9" },
     { name = "pytest" },
     { name = "ruff", specifier = "==0.15.1" },
 ]


### PR DESCRIPTION
## Summary

- let Miles and Slime callers bake trainer source trees when they need to append later Modal image build steps
- return explicit retryable `503` responses when a colocated inference engine has a transport failure, while preserving request abort and admission cleanup
- if `latest` advances during checkpoint staging, stage once more to the newest target in the same run before performing a single engine commit

## Design

The catch-up change targets Stitch's current staged checkpoint protocol. It is independent of disk versus CPU preparation and does not rely on tensor-level sparsity or partial reloads. The reconciler checks the head once after staging: this avoids an unnecessary commit to an already-obsolete version while ensuring a continuously publishing trainer cannot starve GPU progress. Run boundaries are never coalesced.

The original pre-v0.5.16 branch is preserved as `rollout-reliability-pre-v0516-refactor`.

## Testing

- `uv run ruff check .`
- `uv run pytest -q` — 79 passed
- `uv run ruff format --check cookbook/common/trainer_image.py cookbook/common/trainer_image_test.py cookbook/miles_disagg/trainer_image.py cookbook/slime_disagg/trainer_image.py`
