### PR TITLE
Weight sync 1/6: staged disk and CPU core

### DIFF
--- a/src/stitch/engines/base.py
+++ b/src/stitch/engines/base.py
@@ -1,8 +1,8 @@
 """The ``Engine`` port — a client to one inference engine.
 
 ``engines/sglang.py`` is the working instance; ``engines/vllm.py`` sketches the vLLM
-shape. Subclasses override the methods they use — ``prefetch`` and ``blocked_routes``
-have safe defaults.
+shape. Subclasses override the methods they use —
+``initialize_update_destination`` and ``blocked_routes`` have safe defaults.
 """
 
 from __future__ import annotations
@@ -18,23 +18,20 @@ class Engine:
 
     async def stage(self, manifest: VersionManifest, source_dir: str) -> None:
         """Bring the local checkpoint to ``manifest.ref``: seed from the nearest FULL
-        anchor, then replay deltas forward. May run while the engine serves."""
+        anchor, then apply deltas forward. May run while the engine serves."""
         raise NotImplementedError
 
     async def commit(
-        self, ref: VersionRef, *, flush_cache: bool = False, weight_names: list[str] | None = None
+        self, manifest: VersionManifest, *, flush_cache: bool = False
     ) -> None:
-        """Reload the staged checkpoint into the serving weights — the gate covers only this.
+        """Apply the staged checkpoint to the serving weights; the gate covers only this.
         ``flush_cache`` (a commit-policy decision the reconciler passes) evicts the engine's
-        prefix/KV cache as part of the reload. ``weight_names`` are the tensors the staged
-        deltas touched (union across the applied→target range); an engine that supports it
-        reloads only those (+ their fused/expert closures) instead of the full checkpoint.
-        None means reload everything."""
+        prefix/KV cache as part of the commit."""
         raise NotImplementedError
 
     async def flush_cache(self) -> None:
         """Evict the engine's prefix/KV cache — the standalone ``/flush_cache`` primitive.
-        Not on the reconcile path: flushing on a reload goes through ``commit(flush_cache=…)``."""
+        Commit-time flushing goes through ``commit(flush_cache=…)`` instead."""
         raise NotImplementedError
 
     async def pause(self) -> None:
@@ -46,13 +43,15 @@ class Engine:
         raise NotImplementedError
 
     async def reset(self) -> None:
-        """Reseed the local checkpoint to the engine's boot base."""
+        """Restore the engine to its boot weights."""
         raise NotImplementedError
 
-    async def prefetch(self) -> None:
-        """Optional: seed the host-local checkpoint from the engine's base ahead of the first
-        stage(), so stage only applies the delta instead of copying the full base off the
-        critical path. Default no-op — an engine with no host-local checkpoint needs nothing."""
+    async def initialize_update_destination(self) -> None:
+        """Initialize engine state required before staging updates.
+
+        This may run while the engine serves its boot weights. A reconciler waits
+        for it before staging the first published update.
+        """
         return
 
     def stamp_request(self, request: dict[str, Any], served: VersionRef) -> None:

--- a/src/stitch/engines/sglang.py
+++ b/src/stitch/engines/sglang.py
@@ -1,105 +1,171 @@
-"""``SGLangEngine`` — the ``Engine`` instance for a single sglang server.
-
-The weight apply lives inside sglang (``weight_sync/local_checkpoint``): ``stage``
-POSTs ``/pull_weights``, which chain-replays deltas from the applied checkpoint with
-per-tensor checksum verification (reseeding from base on corruption), and ``commit``
-reloads the materialized checkpoint via ``/update_weights_from_disk``. This client
-only drives those endpoints and translates the version protocol — it holds no
-host-side decoder and imports no trainer package.
-"""
+"""``Engine`` adapter for SGLang's staged checkpoint updates."""
 
 from __future__ import annotations
 
-import asyncio
-import os
-import shutil
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from stitch.engines.base import Engine
-from stitch.types import VersionManifest, VersionRef
+from stitch.types import VersionKind, VersionManifest, VersionRef
 
 
 class SGLangEngine(Engine):
     def __init__(
         self,
         base_url: str,
-        local_checkpoint_dir: str,
+        base_checkpoint_dir: str,
+        local_checkpoint_dir: str | None = None,
         *,
+        delta_update_mode: Literal["disk", "cpu"] = "disk",
+        disk_load_format: str = "auto",
         control_timeout: float = 120.0,
-        reload_timeout: float = 600.0,
+        weight_update_timeout: float = 600.0,
     ) -> None:
+        if delta_update_mode not in ("disk", "cpu"):
+            raise ValueError(
+                "delta_update_mode must be either 'disk' or 'cpu', "
+                f"got {delta_update_mode!r}"
+            )
+        if delta_update_mode == "disk" and not local_checkpoint_dir:
+            raise ValueError("disk delta update mode requires local_checkpoint_dir")
         self._base_url = base_url.rstrip("/")
+        self.base_checkpoint_dir = base_checkpoint_dir
         self.local_checkpoint_dir = local_checkpoint_dir
+        self.delta_update_mode = delta_update_mode
+        self.disk_load_format = disk_load_format
         self._control_timeout = control_timeout
-        self._reload_timeout = reload_timeout
+        self._weight_update_timeout = weight_update_timeout
 
     def base_url(self) -> str:
         return self._base_url
 
     def blocked_routes(self) -> frozenset[str]:
-        return frozenset({
-            "update_weights_from_disk", "update_weights_from_distributed",
-            "update_weights_from_tensor", "pull_weights", "flush_cache",
-            "pause_generation", "continue_generation", "abort_request",
-        })
-
-    async def stage(self, manifest: VersionManifest, source_dir: str) -> None:
-        # /pull_weights walks the weight_v* dirs under source_dir's parent.
-        await self._post(
-            "/pull_weights",
+        return frozenset(
             {
-                "local_checkpoint_dir": self.local_checkpoint_dir,
-                "source_dir": str(Path(source_dir).parent),
-                "target_version": manifest.ref.version,
-            },
-            timeout=self._reload_timeout,
-            action="weight pull",
+                "update_weights_from_disk",
+                "update_weights_from_cpu",
+                "update_weights_from_distributed",
+                "update_weights_from_tensor",
+                "stage_weight_update",
+                "flush_cache",
+                "pause_generation",
+                "continue_generation",
+                "abort_request",
+            }
         )
 
-    async def prefetch(self) -> None:
-        # target_version=0 seeds base with no deltas applied; source_dir is unused for the seed.
-        await self._post(
-            "/pull_weights",
-            {"local_checkpoint_dir": self.local_checkpoint_dir, "source_dir": self.local_checkpoint_dir, "target_version": 0},
-            timeout=self._reload_timeout,
-            action="base prefetch",
+    async def stage(self, manifest: VersionManifest, source_dir: str) -> None:
+        await self._stage_weight_update(
+            checkpoint_source_dir=str(Path(source_dir).parent),
+            target_version=manifest.ref.version,
+            destination=self._destination_for(manifest),
+        )
+
+    async def initialize_update_destination(self) -> None:
+        await self._stage_weight_update(
+            checkpoint_source_dir=None,
+            target_version=0,
+            destination=self.delta_update_mode,
         )
 
     async def commit(
-        self, ref: VersionRef, *, flush_cache: bool = False, weight_names: list[str] | None = None
+        self,
+        manifest: VersionManifest,
+        *,
+        flush_cache: bool = False,
     ) -> None:
-        payload: dict[str, Any] = {
-            "model_path": self.local_checkpoint_dir,
-            "weight_version": str(ref.version),
-            "flush_cache": flush_cache,
-        }
-        # O(delta) partial reload: naming the touched tensors makes the fork reload only those
-        # (+ their fused/expert closures) instead of the whole checkpoint. STITCH_PARTIAL_RELOAD=0
-        # forces the full reload (kill switch); an engine without the load-plan patch ignores it.
-        if weight_names and os.environ.get("STITCH_PARTIAL_RELOAD", "1") == "1":
-            payload["weight_names"] = list(weight_names)
-        await self._post("/update_weights_from_disk", payload, timeout=self._reload_timeout, action="weight update")
+        if self._destination_for(manifest) == "cpu":
+            path = "/update_weights_from_cpu"
+            payload: dict[str, Any] = {
+                "target_version": manifest.ref.version,
+                "flush_cache": flush_cache,
+            }
+        else:
+            assert self.local_checkpoint_dir is not None
+            path = "/update_weights_from_disk"
+            payload = {
+                "model_path": self.local_checkpoint_dir,
+                "load_format": self.disk_load_format,
+                "weight_version": str(manifest.ref.version),
+                "flush_cache": flush_cache,
+            }
+        await self._post(
+            path,
+            payload,
+            timeout=self._weight_update_timeout,
+            action="weight update",
+        )
 
     async def flush_cache(self) -> None:
         await self._get("/flush_cache", ok=(200, 404))
 
     async def pause(self) -> None:
-        await self._post("/pause_generation", {"mode": "in_place"}, timeout=self._control_timeout)
+        await self._post(
+            "/pause_generation", {"mode": "in_place"}, timeout=self._control_timeout
+        )
 
     async def resume(self) -> None:
         await self._post("/continue_generation", {}, timeout=self._control_timeout)
 
     async def reset(self) -> None:
-        # Wipe + reseed base so a run switch to v0 serves base, not the prior run's weights
-        # under the new (run, 0) identity (stitch#32).
-        await asyncio.to_thread(shutil.rmtree, self.local_checkpoint_dir, ignore_errors=True)
-        await self.prefetch()
+        if self.delta_update_mode == "cpu":
+            raise RuntimeError(
+                "CPU delta update mode cannot reset a live engine to version 0; "
+                "start a fresh rollout replica for a new run"
+            )
+        assert self.local_checkpoint_dir is not None
+        await self._stage_weight_update(
+            checkpoint_source_dir=None,
+            target_version=0,
+            destination="disk",
+        )
         await self._post(
             "/update_weights_from_disk",
-            {"model_path": self.local_checkpoint_dir, "weight_version": "0", "flush_cache": False},
-            timeout=self._reload_timeout,
-            action="reset reload to base",
+            {
+                "model_path": self.local_checkpoint_dir,
+                "load_format": self.disk_load_format,
+                "weight_version": "0",
+                "flush_cache": False,
+            },
+            timeout=self._weight_update_timeout,
+            action="reset weights to base",
+        )
+
+    def _destination_for(
+        self,
+        manifest: VersionManifest,
+    ) -> Literal["disk", "cpu"]:
+        if manifest.kind is VersionKind.FULL:
+            if self.delta_update_mode == "cpu":
+                raise ValueError(
+                    "CPU delta update mode accepts delta manifests only; "
+                    "use disk mode to publish full checkpoints"
+                )
+            return "disk"
+        return self.delta_update_mode
+
+    async def _stage_weight_update(
+        self,
+        *,
+        checkpoint_source_dir: str | None,
+        target_version: int,
+        destination: Literal["disk", "cpu"],
+    ) -> None:
+        payload: dict[str, Any] = {
+            "base_checkpoint_dir": self.base_checkpoint_dir,
+            "target_version": target_version,
+            "destination": destination,
+        }
+        if checkpoint_source_dir is not None:
+            payload["checkpoint_source_dir"] = checkpoint_source_dir
+        if destination == "disk":
+            assert self.local_checkpoint_dir is not None
+            payload["local_checkpoint_dir"] = self.local_checkpoint_dir
+        await self._post(
+            "/stage_weight_update",
+            payload,
+            timeout=self._weight_update_timeout,
+            action="weight staging",
         )
 
     def stamp_request(self, request: dict[str, Any], served: VersionRef) -> None:
@@ -109,7 +175,9 @@ class SGLangEngine(Engine):
         else:
             request["extra_key"] = self._extra_key(served, user)
 
-    def stamp_response(self, response: dict[str, Any], served: VersionRef, current: VersionRef) -> None:
+    def stamp_response(
+        self, response: dict[str, Any], served: VersionRef, current: VersionRef
+    ) -> None:
         meta = response.get("meta_info")
         if isinstance(meta, dict):  # sglang /generate carries attribution in meta_info
             meta["weight_version"] = str(served.version)
@@ -124,7 +192,14 @@ class SGLangEngine(Engine):
         run = f"{served.run_id}/" if served.run_id else ""
         return f"wv{served.version};{run}{user or ''}"
 
-    async def _post(self, path: str, payload: dict[str, Any], *, timeout: float | None, action: str | None = None) -> None:
+    async def _post(
+        self,
+        path: str,
+        payload: dict[str, Any],
+        *,
+        timeout: float | None,
+        action: str | None = None,
+    ) -> None:
         import httpx
 
         async with httpx.AsyncClient(timeout=timeout, trust_env=False) as client:
@@ -134,7 +209,9 @@ class SGLangEngine(Engine):
     async def _get(self, path: str, *, ok: tuple[int, ...] = (200,)) -> None:
         import httpx
 
-        async with httpx.AsyncClient(timeout=self._control_timeout, trust_env=False) as client:
+        async with httpx.AsyncClient(
+            timeout=self._control_timeout, trust_env=False
+        ) as client:
             resp = await client.get(f"{self._base_url}{path}")
         if resp.status_code not in ok:
             _raise_for_engine(resp, path)
@@ -149,4 +226,6 @@ def _raise_for_engine(resp: Any, action: str) -> None:
     except ValueError:
         data = {"message": resp.text}
     if resp.status_code != 200 or data.get("success") is False:
-        raise RuntimeError(f"sglang rejected {action} (HTTP {resp.status_code}): {data.get('message', data)}")
+        raise RuntimeError(
+            f"sglang rejected {action} (HTTP {resp.status_code}): {data.get('message', data)}"
+        )

--- a/src/stitch/engines/sglang_test.py
+++ b/src/stitch/engines/sglang_test.py
@@ -1,19 +1,21 @@
-"""SGLangEngine harness: version stamping (pure dict mutation, no HTTP).
-
-The /pull_weights + /update_weights_from_disk control paths hit a real engine, so they
-are validated e2e; the request/response stamping is the provable-without-sglang part."""
+"""SGLang engine request construction and version-stamping tests."""
 
 from __future__ import annotations
 
 import asyncio
-import os
+
+import pytest
 
 from stitch.engines.sglang import SGLangEngine
-from stitch.types import VersionRef
+from stitch.types import VersionKind, VersionManifest, VersionRef
+
+
+def _manifest(kind: VersionKind) -> VersionManifest:
+    return VersionManifest(VersionRef("r1", 5), kind, ["weights"])
 
 
 def test_stamp_request_namespaces_by_version() -> None:
-    engine = SGLangEngine("http://engine", "/ckpt")
+    engine = SGLangEngine("http://engine", "/base", "/ckpt")
     req: dict = {"text": "hi"}
     engine.stamp_request(req, VersionRef("r1", 7))
     assert req["extra_key"] == "wv7;r1/"  # version + run namespace, no user key
@@ -22,54 +24,224 @@ def test_stamp_request_namespaces_by_version() -> None:
     assert listed["extra_key"] == ["wv3;a", "wv3;b"]  # run-less, per-element
 
 
+def test_delta_update_mode_is_validated() -> None:
+    with pytest.raises(ValueError, match="delta_update_mode"):
+        SGLangEngine(
+            "http://engine",
+            "/base",
+            "/ckpt",
+            delta_update_mode="memory",  # type: ignore[arg-type]
+        )
+
+
+def test_disk_mode_requires_local_checkpoint() -> None:
+    with pytest.raises(ValueError, match="requires local_checkpoint_dir"):
+        SGLangEngine("http://engine", "/base", None)
+
+
+def test_cpu_mode_does_not_require_local_checkpoint() -> None:
+    engine = SGLangEngine(
+        "http://engine",
+        "/base",
+        None,
+        delta_update_mode="cpu",
+    )
+    requests = []
+
+    async def fake_post(path, payload, *, timeout=None, action=None):
+        requests.append((path, payload))
+
+    engine._post = fake_post  # type: ignore[method-assign]
+    asyncio.run(engine.initialize_update_destination())
+    assert requests == [
+        (
+            "/stage_weight_update",
+            {
+                "base_checkpoint_dir": "/base",
+                "target_version": 0,
+                "destination": "cpu",
+            },
+        )
+    ]
+
+
+def test_cpu_mode_reset_requires_a_fresh_replica() -> None:
+    engine = SGLangEngine(
+        "http://engine",
+        "/base",
+        None,
+        delta_update_mode="cpu",
+    )
+    with pytest.raises(RuntimeError, match="fresh rollout replica"):
+        asyncio.run(engine.reset())
+
+
+def test_disk_mode_reset_stages_and_loads_base() -> None:
+    engine = SGLangEngine("http://engine", "/base", "/ckpt")
+    requests = []
+
+    async def fake_post(path, payload, *, timeout=None, action=None):
+        requests.append((path, payload))
+
+    engine._post = fake_post  # type: ignore[method-assign]
+    asyncio.run(engine.reset())
+    assert requests == [
+        (
+            "/stage_weight_update",
+            {
+                "base_checkpoint_dir": "/base",
+                "target_version": 0,
+                "destination": "disk",
+                "local_checkpoint_dir": "/ckpt",
+            },
+        ),
+        (
+            "/update_weights_from_disk",
+            {
+                "model_path": "/ckpt",
+                "load_format": "auto",
+                "weight_version": "0",
+                "flush_cache": False,
+            },
+        ),
+    ]
+
+
 def test_stamp_response_generate_vs_openai() -> None:
-    engine = SGLangEngine("http://engine", "/ckpt")
+    engine = SGLangEngine("http://engine", "/base", "/ckpt")
     gen: dict = {"text": "x", "meta_info": {}}
     engine.stamp_response(gen, VersionRef("r1", 4), VersionRef("r1", 5))
-    assert gen["meta_info"] == {"weight_version": "4", "weight_version_start": 4, "weight_version_end": 5}
+    assert gen["meta_info"] == {
+        "weight_version": "4",
+        "weight_version_start": 4,
+        "weight_version_end": 5,
+    }
     openai: dict = {"choices": []}
     engine.stamp_response(openai, VersionRef("r1", 4), VersionRef("r1", 4))
     assert openai["weight_version_start"] == 4 and openai["weight_version_end"] == 4
     assert "meta_info" not in openai and "weight_version" not in openai
 
 
-def _commit_payload(*, weight_names=None, partial_reload=None) -> dict:
-    """Build the /update_weights_from_disk payload commit() would POST, without HTTP."""
-    engine = SGLangEngine("http://engine", "/ckpt")
+def _commit_request(
+    *,
+    kind: VersionKind,
+    delta_update_mode: str = "disk",
+    disk_load_format: str = "auto",
+) -> tuple[str, dict]:
+    engine = SGLangEngine(
+        "http://engine",
+        "/base",
+        "/ckpt",
+        delta_update_mode=delta_update_mode,
+        disk_load_format=disk_load_format,
+    )
     captured: dict = {}
 
     async def fake_post(path, payload, *, timeout=None, action=None):
         captured["path"], captured["payload"] = path, payload
 
     engine._post = fake_post  # type: ignore[method-assign]
-    prior = os.environ.get("STITCH_PARTIAL_RELOAD")
-    if partial_reload is not None:
-        os.environ["STITCH_PARTIAL_RELOAD"] = partial_reload
-    try:
-        asyncio.run(engine.commit(VersionRef("r1", 5), weight_names=weight_names))
-    finally:
-        if partial_reload is not None:
-            if prior is None:
-                del os.environ["STITCH_PARTIAL_RELOAD"]
-            else:
-                os.environ["STITCH_PARTIAL_RELOAD"] = prior
-    assert captured["path"] == "/update_weights_from_disk"
-    return captured["payload"]
+    asyncio.run(engine.commit(_manifest(kind)))
+    return captured["path"], captured["payload"]
 
 
-def test_commit_names_touched_tensors_for_partial_reload() -> None:
-    payload = _commit_payload(weight_names=["a", "b"])
-    assert payload["weight_names"] == ["a", "b"]  # O(delta): the fork reloads only these
-    assert payload["weight_version"] == "5"
+def test_disk_delta_commit_uses_checkpoint_loader() -> None:
+    path, payload = _commit_request(
+        kind=VersionKind.DELTA,
+        disk_load_format="fastsafetensors",
+    )
+    assert path == "/update_weights_from_disk"
+    assert payload == {
+        "model_path": "/ckpt",
+        "load_format": "fastsafetensors",
+        "weight_version": "5",
+        "flush_cache": False,
+    }
 
 
-def test_commit_full_reload_when_no_names() -> None:
-    assert "weight_names" not in _commit_payload(weight_names=None)  # full reload names nothing
+def test_cpu_delta_commit_uses_host_image() -> None:
+    path, payload = _commit_request(
+        kind=VersionKind.DELTA,
+        delta_update_mode="cpu",
+    )
+    assert path == "/update_weights_from_cpu"
+    assert payload == {"target_version": 5, "flush_cache": False}
 
 
-def test_commit_kill_switch_forces_full_reload() -> None:
-    # STITCH_PARTIAL_RELOAD=0 drops the names even when the reconciler supplies them.
-    assert "weight_names" not in _commit_payload(weight_names=["a", "b"], partial_reload="0")
+def test_full_checkpoint_is_never_loaded_from_cpu() -> None:
+    with pytest.raises(ValueError, match="delta manifests only"):
+        _commit_request(
+            kind=VersionKind.FULL,
+            delta_update_mode="cpu",
+        )
+
+
+def test_cpu_mode_stages_deltas_in_cpu() -> None:
+    engine = SGLangEngine(
+        "http://engine",
+        "/base",
+        "/ckpt",
+        delta_update_mode="cpu",
+    )
+    requests = []
+
+    async def fake_post(path, payload, *, timeout=None, action=None):
+        requests.append((path, payload))
+
+    engine._post = fake_post  # type: ignore[method-assign]
+    asyncio.run(engine.stage(_manifest(VersionKind.DELTA), "/source/weight_v000005"))
+    assert requests == [
+        (
+            "/stage_weight_update",
+            {
+                "base_checkpoint_dir": "/base",
+                "checkpoint_source_dir": "/source",
+                "target_version": 5,
+                "destination": "cpu",
+            },
+        )
+    ]
+
+
+def test_cpu_mode_rejects_full_checkpoint_staging() -> None:
+    engine = SGLangEngine(
+        "http://engine",
+        "/base",
+        "/ckpt",
+        delta_update_mode="cpu",
+    )
+    with pytest.raises(ValueError, match="delta manifests only"):
+        asyncio.run(
+            engine.stage(
+                _manifest(VersionKind.FULL),
+                "/source/weight_v000005",
+            )
+        )
+
+
+@pytest.mark.parametrize("mode", ["disk", "cpu"])
+def test_initialize_update_destination(mode: str) -> None:
+    engine = SGLangEngine(
+        "http://engine",
+        "/base",
+        "/ckpt",
+        delta_update_mode=mode,
+    )
+    requests = []
+
+    async def fake_post(path, payload, *, timeout=None, action=None):
+        requests.append((path, payload))
+
+    engine._post = fake_post  # type: ignore[method-assign]
+    asyncio.run(engine.initialize_update_destination())
+    expected = {
+        "base_checkpoint_dir": "/base",
+        "target_version": 0,
+        "destination": mode,
+    }
+    if mode == "disk":
+        expected["local_checkpoint_dir"] = "/ckpt"
+    assert requests == [("/stage_weight_update", expected)]
 
 
 if __name__ == "__main__":

--- a/src/stitch/engines/vllm.py
+++ b/src/stitch/engines/vllm.py
@@ -2,10 +2,9 @@
 
 Scaffold only. ``engines/sglang.py`` is the reference implementation; a vLLM engine slots
 in behind the same ``Engine`` port with zero core changes. The work is mapping stage/commit
-onto vLLM's weight-update surface, which differs from sglang's ``/pull_weights`` +
-``/update_weights_from_disk`` — vLLM has no built-in disk-delta receiver, so the host-side
-apply (walk to the nearest anchor, replay xor/overwrite deltas, checksum-verify) has to live
-either in a worker extension or a small sidecar step before the reload. Each method below
+onto vLLM's weight-update surface. vLLM has no built-in disk-delta receiver, so the host-side
+apply (walk to the nearest anchor, apply xor/overwrite deltas, checksum-verify) has to live
+either in a worker extension or a small sidecar step before the commit. Each method below
 notes what its vLLM equivalent should do; fill them in when we bring a vLLM pool up.
 """
 
@@ -34,21 +33,21 @@ class VLLMEngine(Engine):
 
     async def stage(self, manifest: VersionManifest, source_dir: str) -> None:
         # TODO: bring the host-local checkpoint to manifest.ref — seed from the nearest FULL
-        # anchor, replay deltas forward, checksum-verify. vLLM lacks sglang's /pull_weights, so
+        # anchor, apply deltas forward, checksum-verify. vLLM lacks a staged checkpoint API, so
         # this apply must be provided (worker extension or a sidecar copy+decode) before commit.
         raise NotImplementedError("VLLMEngine.stage: TODO")
 
     async def commit(
-        self, ref: VersionRef, *, flush_cache: bool = False, weight_names: list[str] | None = None
+        self, manifest: VersionManifest, *, flush_cache: bool = False
     ) -> None:
-        # TODO: reload the staged checkpoint into the serving weights (the gate covers only this)
+        # TODO: load the staged checkpoint into the serving weights (the gate covers only this)
         # — e.g. vLLM collective_rpc into a WorkerExtension that runs load_weights, or vLLM's
         # runtime weight-update API. Must reproduce an initial load for the served quant format.
         raise NotImplementedError("VLLMEngine.commit: TODO")
 
-    async def flush(self) -> None:
-        # TODO: evict KV / prefix cache before a quiesce reload.
-        raise NotImplementedError("VLLMEngine.flush: TODO")
+    async def flush_cache(self) -> None:
+        # TODO: evict KV / prefix cache before a quiesced weight commit.
+        raise NotImplementedError("VLLMEngine.flush_cache: TODO")
 
     async def pause(self) -> None:
         # TODO: pause the scheduler in place (in_place commit), keeping in-flight requests resident.
@@ -62,7 +61,7 @@ class VLLMEngine(Engine):
         # TODO: wipe local_checkpoint_dir so the next stage reseeds from the engine's boot base.
         raise NotImplementedError("VLLMEngine.reset: TODO")
 
-    # prefetch() intentionally inherits the Engine no-op default until stage() exists.
+    # initialize_update_destination() inherits the no-op default until stage() exists.
 
     def stamp_request(self, request: dict[str, Any], served: VersionRef) -> None:
         # TODO: namespace the request to the served version for KV isolation (vLLM equivalent of

--- a/src/stitch/publish.py
+++ b/src/stitch/publish.py
@@ -11,7 +11,12 @@ from typing import Any
 
 from stitch.pools.base import Pool
 from stitch.stores.base import Store
-from stitch.types import VersionConstraint, VersionManifest, VersionRef, decide_pointer_move
+from stitch.types import (
+    VersionConstraint,
+    VersionManifest,
+    VersionRef,
+    decide_pointer_move,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +37,12 @@ def publish_version(
     store.publish(manifest, version_dir)
     store.advance_pointer(manifest.ref)
     _wake(pool, manifest.ref)
+    logger.info(
+        "published %s: kind=%s files=%d",
+        manifest.ref.identity,
+        manifest.kind.value,
+        len(manifest.files),
+    )
     return manifest.ref
 
 
@@ -43,6 +54,7 @@ def claim_run(store: Store, pool: Pool | None, run_id: str) -> None:
     decide_pointer_move(store.read_pointer(), VersionRef(run_id, 0))  # rewind guard (a reused run_id)
     store.claim(run_id)
     _wake(pool, VersionRef(run_id, 0))
+    logger.info("claimed run %s at base", run_id)
 
 
 def _wake(pool: Pool | None, ref: VersionRef) -> None:

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -46,9 +46,9 @@ def create_app(
     (constraint enforced, serving version captured), stamped by the engine, forwarded,
     and the response stamped with the served version. A rejected constraint returns a
     retryable 409; a client disconnect aborts the upstream generation."""
+    import httpx
     from fastapi import FastAPI, Request
     from fastapi.responses import JSONResponse, Response
-    import httpx
 
     engine_url = engine.base_url().rstrip("/")
     blocked = engine.blocked_routes()
@@ -84,7 +84,7 @@ def create_app(
     async def health() -> Response:
         # 503 until the reconciler's first catch-up, so a deployment that gates routing on readiness
         # keeps a not-yet-synced replica out of rotation (else it's routed to and 409s the whole
-        # catch-up). A fresh boot clears at once; a mid-run joiner waits until it has replayed to the
+        # catch-up). A fresh boot clears at once; a mid-run joiner waits until it has applied the
         # live version. Liveness/boot checks use /server_info instead.
         if not reconciler.ready:
             return JSONResponse({"ready": False, "reason": reconciler.readiness_reason()}, status_code=503)
@@ -219,25 +219,30 @@ async def readiness(pool: Pool, *, timeout: float = 15.0) -> PoolState:
     return PoolState(list(states))
 
 
-# The reconciler states in which the engine is legitimately unresponsive: it is pulling or
-# reloading weights, which starves its event loop, so a stale health heartbeat is EXPECTED.
-_SYNCING_STATES = {SyncState.QUEUED.value, SyncState.PREFETCHING.value,
-                   SyncState.PREPARING.value, SyncState.COMMITTING.value}
+# The reconciler states in which the engine is legitimately unresponsive: it is
+# staging or loading weights, so a stale health heartbeat is expected.
+_SYNCING_STATES = {
+    SyncState.STAGING.value,
+    SyncState.COMMITTING.value,
+}
 
 
 def sync_in_progress(server_info_url: str, *, timeout: float = 5.0) -> bool:
-    """Whether the replica's reconciler is mid weight-sync (seeding the base or reloading a
-    version). A deployment's engine-health probe calls this to SUPPRESS a health blip during a
-    sync: the reload starves the engine's event loop, so an unresponsive detokenizer is expected,
-    not a crash. A boot base-seed runs with sync_state IDLE, so ``prefetch_done`` is its separate
-    signal. Best-effort: an unreachable sidecar returns False, so the caller reports the error."""
+    """Whether the replica is initializing, staging, or committing weights.
+
+    A deployment's engine-health probe uses this to suppress expected health
+    blips during weight work. An unreachable sidecar returns ``False`` so the
+    caller still reports an actual failure.
+    """
     try:
         with urllib.request.urlopen(server_info_url, timeout=timeout) as resp:
             info = json.loads(resp.read())
     except Exception:  # noqa: BLE001
         return False
-    seeding = not info.get("prefetch_done", True) and not info.get("prefetch_error")
-    return bool(seeding or info.get("sync_state") in _SYNCING_STATES)
+    initializing = not info.get(
+        "update_destination_ready", True
+    ) and not info.get("update_destination_error")
+    return bool(initializing or info.get("sync_state") in _SYNCING_STATES)
 
 
 def await_pool_ready(pool: Pool, *, timeout: float = 20 * 60, interval: float = 30.0) -> bool:

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -1,5 +1,5 @@
 """``sync_in_progress`` — the shared /server_info interpretation a deployment's engine-health
-probe uses to suppress health blips while the reconciler is reloading weights."""
+probe uses to suppress health blips while the reconciler commits staged weights."""
 
 from __future__ import annotations
 
@@ -36,11 +36,24 @@ def _server_info(payload):
 @pytest.mark.parametrize(
     "info,expected",
     [
-        ({"prefetch_done": True, "sync_state": "COMMITTING"}, True),   # reloading
-        ({"prefetch_done": True, "sync_state": "PREFETCHING"}, True),  # staging deltas
-        ({"prefetch_done": False, "prefetch_error": None}, True),      # boot base-seed (IDLE)
-        ({"prefetch_done": True, "sync_state": "IDLE"}, False),        # settled: a blip is real
-        ({"prefetch_done": False, "prefetch_error": "boom"}, False),   # seed failed: report it
+        ({"update_destination_ready": True, "sync_state": "COMMITTING"}, True),
+        ({"update_destination_ready": True, "sync_state": "STAGING"}, True),
+        ({"update_destination_ready": True, "sync_state": "FETCHING"}, False),
+        (
+            {
+                "update_destination_ready": False,
+                "update_destination_error": None,
+            },
+            True,
+        ),
+        ({"update_destination_ready": True, "sync_state": "IDLE"}, False),
+        (
+            {
+                "update_destination_ready": False,
+                "update_destination_error": "boom",
+            },
+            False,
+        ),
     ],
 )
 def test_sync_in_progress(info, expected):

--- a/src/stitch/stores/base.py
+++ b/src/stitch/stores/base.py
@@ -41,8 +41,11 @@ class Store:
         raise NotImplementedError
 
     def materialize(self, ref: VersionRef) -> str:
-        """Ensure the version's files are locally readable and return their directory
-        (hides mount vs download)."""
+        """Return a local directory for the version.
+
+        Download-backed stores materialize into a cache. Mounted stores assume
+        the caller has already made remote writes visible with ``refresh``.
+        """
         raise NotImplementedError
 
     def commit(self) -> None:

--- a/src/stitch/stores/modal_volume.py
+++ b/src/stitch/stores/modal_volume.py
@@ -63,7 +63,8 @@ class ModalVolumeStore(Store):
             _volume(self.volume_name).commit()
 
     def materialize(self, ref: VersionRef) -> str:
-        self.refresh()
+        # The reconciler refreshed the mount before reading the pointer and manifest.
+        # Repeating the Volume reload here adds no visibility and can serialize I/O.
         return str(self._version_dir(ref))
 
     def commit(self) -> None:
@@ -75,21 +76,6 @@ class ModalVolumeStore(Store):
 
     def _version_dir(self, ref: VersionRef) -> Path:
         return self.root / ref.identity
-
-
-def pull_weights_pre_read_hook(source_dir: str, target_version: int) -> None:
-    """Engine-side ``--custom-pull-weights-pre-read-hook``: reload the delta Volume onto
-    THIS host exactly once so the engine's pull can read the published version.
-
-    One reload, not a loop: looping thrashes the Modal-v2 mount (turned ~3s delta pulls into
-    100-500s and tripped the engine's 300s watchdog). Completeness is verified downstream —
-    the engine size-checks each staged delta and fails fast so the sidecar retries with a
-    fresh reload. Volume name comes from ``DELTA_VOLUME_NAME`` (set on the serving container)."""
-    del source_dir  # unused: the reload is by volume name, not path
-    volume_name = os.environ.get("DELTA_VOLUME_NAME", "")
-    if not volume_name or target_version <= 0:
-        return
-    _volume(volume_name).reload()
 
 
 def _volume(name: str):

--- a/src/stitch/stores/s3.py
+++ b/src/stitch/stores/s3.py
@@ -5,7 +5,7 @@ delta metadata, and a ``<prefix>/latest`` object holds the self-identifying poin
 identity. S3 is strongly read-after-write consistent, so ``refresh`` is a no-op and a
 single ``latest`` PUT is the durable, immediately-visible pointer move (no rename). Unlike
 a mounted Volume there is no shared filesystem, so ``materialize`` downloads a version's
-chain into ``cache_dir`` — the local path the engine's pull then reads.
+chain into ``cache_dir`` — the local path the engine's staging step reads.
 
 ``boto3`` is imported lazily (only when the store is used), so the module loads without it;
 credentials/region come from the standard AWS resolution chain, and ``endpoint_url`` targets
@@ -14,7 +14,6 @@ S3-compatible stores (MinIO, R2, ...).
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -26,7 +25,9 @@ _INDEX = "model.safetensors.index.json"
 
 
 class S3Store(Store):
-    def __init__(self, root: str, *, cache_dir: str | Path, endpoint_url: str | None = None) -> None:
+    def __init__(
+        self, root: str, *, cache_dir: str | Path, endpoint_url: str | None = None
+    ) -> None:
         parsed = urlparse(root if "://" in root else f"s3://{root}")
         self.bucket = parsed.netloc
         self.prefix = parsed.path.strip("/")
@@ -42,11 +43,17 @@ class S3Store(Store):
         return VersionRef.parse(text) if text else None
 
     def advance_pointer(self, ref: VersionRef) -> None:
-        self._s3().put_object(Bucket=self.bucket, Key=self._key(_POINTER), Body=ref.identity.encode("utf-8"))
+        self._s3().put_object(
+            Bucket=self.bucket,
+            Key=self._key(_POINTER),
+            Body=ref.identity.encode("utf-8"),
+        )
 
     def claim(self, run_id: str) -> None:
         if not run_id:
-            raise ValueError("claim requires a run_id (the run's per-launch epoch token)")
+            raise ValueError(
+                "claim requires a run_id (the run's per-launch epoch token)"
+            )
         self.advance_pointer(VersionRef(run_id, 0))
 
     def read_manifest(self, ref: VersionRef) -> VersionManifest:
@@ -62,7 +69,8 @@ class S3Store(Store):
             self._s3().upload_file(str(path), self.bucket, key)
 
     def materialize(self, ref: VersionRef) -> str:
-        # No shared mount: sync the run's chain into the local cache; its parent is the run dir the pull walks.
+        # No shared mount: sync the run's chain into the local cache; its parent is
+        # the run directory the engine stages from.
         self._sync(self._key(ref.run_id), self.cache_dir / ref.run_id)
         return str(self.cache_dir / ref.identity)
 
@@ -80,7 +88,12 @@ class S3Store(Store):
     def _read_text(self, key: str) -> str | None:
         s3 = self._s3()
         try:
-            return s3.get_object(Bucket=self.bucket, Key=key)["Body"].read().decode("utf-8").strip()
+            return (
+                s3.get_object(Bucket=self.bucket, Key=key)["Body"]
+                .read()
+                .decode("utf-8")
+                .strip()
+            )
         except s3.exceptions.NoSuchKey:
             return None
 
@@ -92,9 +105,11 @@ class S3Store(Store):
         """Download every object under ``key_prefix`` into ``dest_root``, skipping any file
         already present at the same size — so re-materializing a chain only fetches new versions."""
         s3 = self._s3()
-        for page in s3.get_paginator("list_objects_v2").paginate(Bucket=self.bucket, Prefix=key_prefix + "/"):
+        for page in s3.get_paginator("list_objects_v2").paginate(
+            Bucket=self.bucket, Prefix=key_prefix + "/"
+        ):
             for obj in page.get("Contents", []):
-                rel = obj["Key"][len(key_prefix) + 1:]
+                rel = obj["Key"][len(key_prefix) + 1 :]
                 if not rel:  # the prefix "directory" placeholder, if any
                     continue
                 dest = dest_root / rel
@@ -102,19 +117,3 @@ class S3Store(Store):
                     continue
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 s3.download_file(self.bucket, obj["Key"], str(dest))
-
-
-def pull_weights_pre_read_hook(source_dir: str, target_version: int) -> None:
-    """Engine-side ``--custom-pull-weights-pre-read-hook``: download the run's published
-    versions onto THIS host's ``source_dir`` so the engine's pull can read them — the S3
-    analogue of the Modal-Volume reload, for engines that span hosts not sharing the cache.
-
-    ``source_dir`` is the run dir (``<cache>/<run_id>``); its basename is the run. The bucket/
-    prefix travel via ``DELTA_S3_URI`` (and optional ``DELTA_S3_ENDPOINT_URL``) on the serving
-    container. Guarded on ``target_version > 0`` — version 0 is the engine's own served base."""
-    uri = os.environ.get("DELTA_S3_URI", "")
-    if not uri or target_version <= 0:
-        return
-    run_id = Path(source_dir).name
-    store = S3Store(uri, cache_dir=Path(source_dir).parent, endpoint_url=os.environ.get("DELTA_S3_ENDPOINT_URL") or None)
-    store.materialize(VersionRef(run_id, target_version))

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -18,7 +18,13 @@ from typing import Any, Literal
 
 from stitch.engines.base import Engine
 from stitch.stores.base import Store
-from stitch.types import SyncState, VersionConstraint, VersionKind, VersionManifest, VersionRef
+from stitch.types import (
+    SyncState,
+    VersionConstraint,
+    VersionKind,
+    VersionManifest,
+    VersionRef,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,13 +52,12 @@ class ConstraintUnmet(Exception):
 class AdmissionGate:
     """Request admission + the commit gate.
 
-    ``quiesce`` drains all in-flight requests and flushes before applying; ``in_place``
-    pauses the engine and lets non-exact requests keep decoding on stale KV (only exact
-    pins are drained) — but only across *compatible* commits: an incompatible transition
-    (a run switch's base reset) commits with ``drain_all=True``, which drains and gates
-    everything regardless of mode. Either way the committer holds the lock across the
-    apply and the version flip, so no request is ever admitted seeing the stale version
-    on new weights.
+    ``quiesce`` drains all in-flight requests before applying; ``in_place``
+    pauses the engine and lets non-exact requests already in flight continue on the new
+    weights (only exact pins are drained). Admission closes during either commit, so a
+    newly arriving request is attributed to the version it will actually run on. An
+    incompatible transition (a run switch's base reset) commits with ``drain_all=True``,
+    which also drains all in-flight requests. The version flips before admission reopens.
     """
 
     def __init__(self, *, commit_mode: CommitMode = "in_place") -> None:
@@ -67,14 +72,6 @@ class AdmissionGate:
     @property
     def active_requests(self) -> int:
         return self._active
-
-    def _gated(self, c: VersionConstraint) -> bool:
-        if not self._committing:
-            return False
-        # in_place gates only exact pins across a compatible commit; drain_all / quiesce gate everything.
-        if self._drain_all or self.commit_mode != "in_place":
-            return True
-        return c.exact_version is not None
 
     def _rejection(self, c: VersionConstraint) -> dict[str, Any] | None:
         applied = self.applied.version if self.applied else None
@@ -104,7 +101,7 @@ class AdmissionGate:
         is served on. Raises :class:`ConstraintUnmet` if the constraint can't be met."""
         c = constraint or VersionConstraint()
         async with self._cond:
-            await self._cond.wait_for(lambda: not self._gated(c))
+            await self._cond.wait_for(lambda: not self._committing)
             error = self._rejection(c)
             if error is not None:
                 self._on_reject(error)
@@ -167,7 +164,7 @@ class AdmissionGate:
 
 class Reconciler(AdmissionGate):
     """Converges one replica to the store's ``latest`` pointer: stage the chain,
-    reload once, flip the served version. A run change resets to base (the engine
+    commit once, flip the served version. A run change resets to base (the engine
     reseeds), so a run's chain is never mistaken for another's."""
 
     def __init__(
@@ -195,22 +192,24 @@ class Reconciler(AdmissionGate):
         self._boot_monotonic = time.monotonic()
         self._catchup_passes = 0
         self._task: asyncio.Task[None] | None = None
-        self._prefetch_task: asyncio.Task[None] | None = None
-        self._prefetch_done = False
-        self._prefetch_error: str | None = None
+        self._destination_init_task: asyncio.Task[None] | None = None
+        self._destination_ready = False
+        self._destination_init_error: str | None = None
         self._periodic_task: asyncio.Task[None] | None = None
         self._lock = asyncio.Lock()
 
     async def startup(self) -> None:
-        # Background base seed so the first real stage() is delta-only; a later stage waits on it (see
-        # _reconcile_once_measured), so the two writes to the checkpoint never race.
-        self._prefetch_task = asyncio.create_task(self._prefetch_base())
+        # Serving the boot weights does not depend on this one-time setup. A
+        # published update waits for the task before it can enter staging.
+        self._destination_init_task = asyncio.create_task(
+            self._initialize_update_destination()
+        )
         await self.reconcile()
         if self.reconcile_interval > 0:
             self._periodic_task = asyncio.create_task(self._periodic_reconcile())
 
     async def shutdown(self) -> None:
-        for task in (self._periodic_task, self._prefetch_task):
+        for task in (self._periodic_task, self._destination_init_task):
             if task is not None:
                 task.cancel()
                 with suppress(BaseException):
@@ -223,13 +222,13 @@ class Reconciler(AdmissionGate):
             await asyncio.sleep(self.reconcile_interval)
             self.wake()
 
-    async def _prefetch_base(self) -> None:
+    async def _initialize_update_destination(self) -> None:
         try:
-            await self.engine.prefetch()
-            self._prefetch_done = True
-        except Exception as exc:  # noqa: BLE001 — best-effort; first pull falls back to a full copy
-            self._prefetch_error = str(exc)
-            logger.exception("base prefetch failed; first sync will pay the full base copy")
+            await self.engine.initialize_update_destination()
+            self._destination_ready = True
+        except Exception as exc:  # noqa: BLE001
+            self._destination_init_error = str(exc)
+            logger.exception("weight update destination initialization failed")
 
     def server_info(self) -> dict[str, Any]:
         # applied = version on the GPU (the pool reads it to see which version each replica has);
@@ -242,17 +241,20 @@ class Reconciler(AdmissionGate):
             "run_id": self.run_id,
             "commit_mode": self.commit_mode,
             "active_requests": self._active,
-            "prefetch_done": self._prefetch_done,
-            "prefetch_error": self._prefetch_error,
+            "update_destination_ready": self._destination_ready,
+            "update_destination_error": self._destination_init_error,
             "metrics": self.metrics,
         }
 
     def readiness_reason(self) -> str:
         """Why /health is still 503, so a not-yet-admitted replica reads as 'catching up', not broken."""
-        if self._prefetch_error:
-            return f"base seed failed: {self._prefetch_error}"
-        if not self._prefetch_done:
-            return "seeding base checkpoint"
+        if self._destination_init_error:
+            return (
+                "weight update destination initialization failed: "
+                f"{self._destination_init_error}"
+            )
+        if not self._destination_ready:
+            return "initializing weight update destination"
         if self.last_error:
             return f"sync error: {self.last_error}"
         applied = self.applied.identity if self.applied else "base"
@@ -303,25 +305,29 @@ class Reconciler(AdmissionGate):
             return True
         return pointer.version > self.applied.version
 
-    def _touched_names(self, target: VersionManifest) -> list[str] | None:
-        """Union of the tensor names touched across the versions this pass applies
-        (``applied``+1 .. ``target``), for an engine that can reload only those (O(delta)).
-        Returns None — reload everything — when the applied→target range reseeds from a FULL
-        anchor or the baseline is unknown: a full reload is always correct, a partial one only
-        when the served weights already hold every tensor the deltas didn't touch."""
+    def _range_has_weight_changes(self, target: VersionManifest) -> bool:
+        """Return whether the catch-up range can change any checkpoint bytes.
+
+        An empty delta has no payload files. Skipping the GPU update is safe only
+        when every version since the applied checkpoint is an empty delta.
+        """
         applied = self.applied
         ref = target.ref
-        if applied is None or applied.run_id != ref.run_id or ref.version <= applied.version:
-            return None
-        names: set[str] = set()
+        if (
+            applied is None
+            or applied.run_id != ref.run_id
+            or ref.version <= applied.version
+        ):
+            return True
         for v in range(ref.version, applied.version, -1):
-            m = target if v == ref.version else self.store.read_manifest(VersionRef(ref.run_id, v))
-            # full reload (None) for either: a FULL anchor in range (the stage reseeds from it), or a
-            # non-empty delta with no recorded touched names (an empty union would skip it → stale)
-            if m.kind is not VersionKind.DELTA or (m.files and not m.tensor_names):
-                return None
-            names.update(m.tensor_names)
-        return sorted(names)
+            m = (
+                target
+                if v == ref.version
+                else self.store.read_manifest(VersionRef(ref.run_id, v))
+            )
+            if m.kind is not VersionKind.DELTA or m.files:
+                return True
+        return False
 
     async def _reconcile_once(self) -> bool:
         async with self._lock:
@@ -332,15 +338,21 @@ class Reconciler(AdmissionGate):
                 m["error"] = str(exc)
                 raise
             finally:
-                if len(m) > 1 or "error" in m:  # a no-work pass leaves the last breakdown alone
+                if (
+                    len(m) > 1 or "error" in m
+                ):  # a no-work pass leaves the last breakdown alone
                     m["at"] = time.time()
                     self.metrics = m
                     timings = {k: v for k, v in m.items() if k.endswith("_s")}
                     if timings:
                         if not self.ready:
                             self._catchup_passes += 1
-                        logger.info("catch-up pass v%s->v%s timing(s): %s",
-                                    m.get("applied_version"), m.get("target_version"), timings)
+                        logger.info(
+                            "catch-up pass v%s->v%s timing(s): %s",
+                            m.get("applied_version"),
+                            m.get("target_version"),
+                            timings,
+                        )
 
     async def _reconcile_once_measured(self, m: dict[str, Any]) -> bool:
         await asyncio.to_thread(self.store.refresh)
@@ -352,57 +364,55 @@ class Reconciler(AdmissionGate):
         if not self._behind(pointer):
             return True
 
-        self.sync_state = SyncState.PREFETCHING
+        self.sync_state = SyncState.FETCHING
         self.last_error = None
         m["target_version"] = pointer.version
         m["applied_version"] = self.applied.version if self.applied else -1
         target = self.store.read_manifest(pointer)
         source_dir = await asyncio.to_thread(self.store.materialize, pointer)
         logger.info(
-            "catch-up: %s -> v%d, staging deltas",
+            "catch-up: %s -> v%d, preparing weight update",
             "base" if self.applied is None else f"v{self.applied.version}",
             pointer.version,
         )
 
-        # Touched tensor names for an O(delta) reload: the union across the versions this pass
-        # applies (applied+1 .. target). None => the range reseeds from a FULL anchor, so the
-        # engine must reload everything. Computed under the pre-flip `applied` (on_applied moves it).
-        weight_names = await asyncio.to_thread(self._touched_names, target)
+        has_weight_changes = await asyncio.to_thread(
+            self._range_has_weight_changes, target
+        )
 
-        # Both prefetch and stage write the host checkpoint; wait for the prefetch so they're ordered.
-        # If it failed, this stage seeds the full base itself.
-        if self._prefetch_task is not None and not self._prefetch_task.done():
-            with _timed(m, "prefetch_wait_s"):
-                await self._prefetch_task
-        if self._prefetch_error is not None:
-            m["paid_base_copy"] = True
-
-        # Stage (host-side apply) runs while serving; the gate covers only the reload.
-        self.sync_state = SyncState.PREPARING
-        with _timed(m, "stage_s"):
-            await self.engine.stage(target, source_dir)
+        if self._destination_init_task is not None:
+            if self._destination_init_task.done():
+                await self._destination_init_task
+            else:
+                with _timed(m, "destination_init_wait_s"):
+                    await self._destination_init_task
+        if self._destination_init_error is not None:
+            raise RuntimeError(
+                "weight update destination initialization failed: "
+                f"{self._destination_init_error}"
+            )
 
         def on_applied() -> None:
             self.applied = pointer
 
-        if weight_names is not None and not weight_names:
-            # Nothing changed across the applied→target range: advance the version, no reload —
-            # the weights are byte-identical, so the KV cache stays valid.
+        if not has_weight_changes:
+            # Nothing changed across the applied→target range: advance the
+            # version without preparing or loading byte-identical weights.
             await self.commit(apply=self._commit_noop, on_applied=on_applied)
-            m["skipped_reload"] = True
+            m["skipped_weight_update"] = True
         else:
-            m["reload_names"] = "full" if weight_names is None else len(weight_names)
-            logger.info(
-                "catch-up: reloading v%d (%s)",
-                pointer.version,
-                "all tensors" if weight_names is None else f"{len(weight_names)} tensors",
-            )
+            # Preparation runs while serving; the gate covers only the load.
+            self.sync_state = SyncState.STAGING
+            with _timed(m, "stage_s"):
+                await self.engine.stage(target, source_dir)
+            logger.info("catch-up: loading v%d into the engine", pointer.version)
 
             async def apply() -> None:
                 self.sync_state = SyncState.COMMITTING
                 with _timed(m, "commit_s"):
                     await self.engine.commit(
-                        pointer, flush_cache=self.flush_cache_on_commit, weight_names=weight_names
+                        target,
+                        flush_cache=self.flush_cache_on_commit,
                     )
 
             await self.commit(
@@ -411,17 +421,21 @@ class Reconciler(AdmissionGate):
                 pause=self.engine.pause,
                 resume=self.engine.resume,
             )
-        self.sync_state = SyncState.PREFETCHING
-        return not self._behind(self.store.read_pointer())  # a mid-pass publish is next tick's work
+        self.sync_state = SyncState.FETCHING
+        return not self._behind(
+            self.store.read_pointer()
+        )  # a mid-pass publish is next tick's work
 
     async def _commit_noop(self) -> None:
         self.sync_state = SyncState.COMMITTING
 
     async def _switch_run(self, new_run: str | None) -> None:
-        """Rebase onto a new run: reset to base (the engine reseeds on the next stage).
-        Commits with ``drain_all`` — a base reset is an incompatible transition, so even
-        in ``in_place`` mode no rolling request is admitted during, or decodes across,
-        the wipe."""
+        """Select a new run at version 0, resetting patched weights to the boot base.
+
+        A reset commits with ``drain_all`` because it is incompatible with
+        in-flight requests. Selecting the boot run on an unpatched engine only
+        updates attribution and does not pause generation.
+        """
         old_run = self.applied.run_id if self.applied else None
         logger.info("run change %r -> %r: resetting to base", old_run, new_run)
         # Reset if weights are patched (v>0), or a prior error may have left the checkpoint dirty (stitch#32).
@@ -440,7 +454,7 @@ class Reconciler(AdmissionGate):
         await self.commit(
             apply=apply,
             on_applied=on_applied,
-            pause=self.engine.pause,
-            resume=self.engine.resume,
+            pause=self.engine.pause if was_patched else None,
+            resume=self.engine.resume if was_patched else None,
             drain_all=True,
         )

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -12,11 +12,11 @@ from stitch.engines.base import Engine
 from stitch.stores.base import Store
 from stitch.sync import ConstraintUnmet, Reconciler
 from stitch.types import (
+    SyncState,
     VersionConstraint,
     VersionKind,
     VersionManifest,
     VersionRef,
-    SyncState,
 )
 
 
@@ -53,18 +53,19 @@ class FakeEngine(Engine):
         self.calls: list[str] = []
         self.staged: list[VersionRef] = []
         self.committed: list[VersionRef] = []
-        self.commit_weight_names: list[list[str] | None] = []
 
     async def stage(self, manifest: VersionManifest, source_dir: str) -> None:
         self.staged.append(manifest.ref)
         self.calls.append(f"stage:{manifest.ref.version}")
 
     async def commit(
-        self, ref: VersionRef, *, flush_cache: bool = False, weight_names: list[str] | None = None
+        self,
+        manifest: VersionManifest,
+        *,
+        flush_cache: bool = False,
     ) -> None:
-        self.committed.append(ref)
-        self.commit_weight_names.append(weight_names)
-        self.calls.append(f"commit:{ref.version}")
+        self.committed.append(manifest.ref)
+        self.calls.append(f"commit:{manifest.ref.version}")
 
     async def flush_cache(self) -> None:
         self.calls.append("flush_cache")
@@ -78,8 +79,8 @@ class FakeEngine(Engine):
     async def reset(self) -> None:
         self.calls.append("reset")
 
-    async def prefetch(self) -> None:
-        self.calls.append("prefetch")
+    async def initialize_update_destination(self) -> None:
+        self.calls.append("initialize_update_destination")
 
     def stamp_request(self, request, served) -> None:
         pass
@@ -95,10 +96,8 @@ def _full(run: str, version: int) -> VersionManifest:
     return VersionManifest(VersionRef(run, version), VersionKind.FULL, ["model.safetensors"])
 
 
-def _delta(
-    run: str, version: int, *, files: list[str], tensor_names: list[str] | None = None
-) -> VersionManifest:
-    return VersionManifest(VersionRef(run, version), VersionKind.DELTA, files, tensor_names or [])
+def _delta(run: str, version: int, *, files: list[str]) -> VersionManifest:
+    return VersionManifest(VersionRef(run, version), VersionKind.DELTA, files)
 
 
 def _run(coro) -> None:
@@ -131,13 +130,13 @@ def test_reconcile_latches_ready() -> None:
     _run(go())
 
 
-def test_startup_prefetches_base() -> None:
+def test_startup_initializes_update_destination() -> None:
     async def go() -> None:
         engine = FakeEngine()
         r = Reconciler(store=FakeStore(), engine=engine)  # unclaimed pool: reconcile is a no-op
         await r.startup()
-        await r._prefetch_task  # let the background base-seed finish
-        assert "prefetch" in engine.calls
+        await r._destination_init_task
+        assert "initialize_update_destination" in engine.calls
 
     _run(go())
 
@@ -149,8 +148,39 @@ def test_catch_up() -> None:
         r.applied = VersionRef("r1", 3)
         await r.reconcile()
         assert r.applied == VersionRef("r1", 5)
-        assert engine.committed == [VersionRef("r1", 5)]  # one composed stage+reload, not per-version
-        assert engine.commit_weight_names == [None]  # FULL target reseeds -> full reload, not partial
+        assert engine.committed == [VersionRef("r1", 5)]  # one staged chain and one commit
+
+    _run(go())
+
+
+def test_latest_advance_during_stage_folds_next_pass() -> None:
+    async def go() -> None:
+        manifests = [_delta("r1", version, files=[f"v{version}"]) for version in range(7, 11)]
+        store = FakeStore(VersionRef("r1", 7), *manifests)
+        engine = FakeEngine()
+        stage_started = asyncio.Event()
+        finish_stage = asyncio.Event()
+        base_stage = engine.stage
+
+        async def slow_stage(manifest: VersionManifest, source_dir: str) -> None:
+            await base_stage(manifest, source_dir)
+            if manifest.ref.version == 7:
+                stage_started.set()
+                await finish_stage.wait()
+
+        engine.stage = slow_stage  # type: ignore[method-assign]
+        r = Reconciler(store=store, engine=engine)
+        r.applied = VersionRef("r1", 6)
+
+        syncing = asyncio.create_task(r.reconcile())
+        await stage_started.wait()
+        store.advance_pointer(VersionRef("r1", 10))
+        finish_stage.set()
+        await syncing
+
+        assert engine.staged == [VersionRef("r1", 7), VersionRef("r1", 10)]
+        assert engine.committed == [VersionRef("r1", 7), VersionRef("r1", 10)]
+        assert r.applied == VersionRef("r1", 10)
 
     _run(go())
 
@@ -164,7 +194,7 @@ def test_run_switch_resets_in_place() -> None:
         assert r.applied == VersionRef("r2", 2)
         assert "reset" in engine.calls  # was patched -> reseed base for the new run
         assert engine.calls.index("pause") < engine.calls.index("reset") < engine.calls.index("resume")
-        assert "flush" not in engine.calls  # in_place never flushes
+        assert "flush_cache" not in engine.calls  # cache flushing is an explicit commit policy
 
     _run(go())
 
@@ -227,56 +257,99 @@ def test_rolling_requests_cross_in_place_commit() -> None:
     _run(go())
 
 
-def test_empty_delta_skips_reload() -> None:
+def test_new_request_waits_for_in_place_commit() -> None:
+    async def go() -> None:
+        engine = FakeEngine()
+        commit_started = asyncio.Event()
+        finish_commit = asyncio.Event()
+        original_commit = engine.commit
+
+        async def slow_commit(
+            manifest: VersionManifest,
+            *,
+            flush_cache: bool = False,
+        ) -> None:
+            commit_started.set()
+            await finish_commit.wait()
+            await original_commit(manifest, flush_cache=flush_cache)
+
+        engine.commit = slow_commit  # type: ignore[method-assign]
+        r = Reconciler(
+            store=FakeStore(VersionRef("r1", 4), _full("r1", 4)),
+            engine=engine,
+            commit_mode="in_place",
+        )
+        r.applied = VersionRef("r1", 3)
+        rolling_release = asyncio.Event()
+        late_served: list[VersionRef | None] = []
+
+        async def rolling() -> None:
+            async with r.admit():
+                await rolling_release.wait()
+
+        async def late() -> None:
+            async with r.admit() as served:
+                late_served.append(served)
+
+        rolling_task = asyncio.create_task(rolling())
+        await asyncio.sleep(0)
+        sync_task = asyncio.create_task(r.reconcile())
+        await commit_started.wait()
+        late_task = asyncio.create_task(late())
+        await asyncio.sleep(0.01)
+        assert not late_served
+
+        finish_commit.set()
+        await asyncio.gather(sync_task, late_task)
+        assert late_served == [VersionRef("r1", 4)]
+        assert not rolling_task.done()
+        rolling_release.set()
+        await rolling_task
+
+    _run(go())
+
+
+def test_empty_delta_skips_commit() -> None:
     async def go() -> None:
         engine = FakeEngine()
         r = Reconciler(store=FakeStore(VersionRef("r1", 4), _delta("r1", 4, files=[])), engine=engine)
         r.applied = VersionRef("r1", 3)
         await r.reconcile()
         assert r.applied == VersionRef("r1", 4)
-        assert engine.staged == [VersionRef("r1", 4)]
-        assert engine.committed == []  # no reload for a zero-file delta
-        assert r.metrics.get("skipped_reload") is True
+        assert engine.staged == []
+        assert engine.committed == []  # no commit for a zero-file delta
+        assert r.metrics.get("skipped_weight_update") is True
 
     _run(go())
 
 
-def test_touched_names_union_reaches_commit() -> None:
-    # A multi-version catch-up hands the engine the UNION of touched tensor names across the
-    # applied→target range, so an O(delta) reload refreshes every tensor any delta changed —
-    # not just the target's. (This is the plumbing a partial reload needs; without it the
-    # engine names no tensors and pays a full reload.)
+def test_nonempty_delta_in_catch_up_range_commits() -> None:
     async def go() -> None:
         engine = FakeEngine()
         store = FakeStore(
             VersionRef("r1", 5),
-            _delta("r1", 4, files=["f1"], tensor_names=["a", "b"]),
-            _delta("r1", 5, files=["f1", "f2"], tensor_names=["b", "c"]),
+            _delta("r1", 4, files=["f1"]),
+            _delta("r1", 5, files=[]),
         )
         r = Reconciler(store=store, engine=engine)
         r.applied = VersionRef("r1", 3)
         await r.reconcile()
         assert r.applied == VersionRef("r1", 5)
-        assert engine.commit_weight_names == [["a", "b", "c"]]  # union of v4 + v5, deduped + sorted
-        assert r.metrics.get("reload_names") == 3
+        assert engine.committed == [VersionRef("r1", 5)]
 
     _run(go())
 
 
-def test_delta_without_touched_names_full_reloads_not_skips() -> None:
-    # A store that records a non-empty delta but NOT its touched tensor names must full-reload,
-    # never skip: an empty touched-set reads as "nothing changed" and would advance the version
-    # onto stale weights (a downstream DeltaStore regression). weight_names=None => full reload.
+def test_nonempty_delta_commits() -> None:
     async def go() -> None:
         engine = FakeEngine()
-        store = FakeStore(VersionRef("r1", 5), _delta("r1", 5, files=["f1"], tensor_names=[]))
+        store = FakeStore(VersionRef("r1", 5), _delta("r1", 5, files=["f1"]))
         r = Reconciler(store=store, engine=engine)
         r.applied = VersionRef("r1", 4)
         await r.reconcile()
         assert r.applied == VersionRef("r1", 5)
-        assert engine.committed == [VersionRef("r1", 5)]  # reloaded, not skipped
-        assert engine.commit_weight_names == [None]       # full reload (touched names unknown)
-        assert r.metrics.get("skipped_reload") is not True
+        assert engine.committed == [VersionRef("r1", 5)]
+        assert r.metrics.get("skipped_weight_update") is not True
 
     _run(go())
 
@@ -311,26 +384,80 @@ def test_reconcile_interval_zero_disables_backstop() -> None:
     _run(go())
 
 
-def test_stage_waits_for_prefetch() -> None:
-    # Prefetch and stage both write the checkpoint; the stage must wait for the prefetch so they never race.
+def test_stage_waits_for_update_destination() -> None:
     async def go() -> None:
         engine = FakeEngine()
         release = asyncio.Event()
-        base_prefetch = engine.prefetch
+        initialize = engine.initialize_update_destination
 
-        async def slow_prefetch() -> None:
+        async def slow_initialize() -> None:
             await release.wait()
-            await base_prefetch()
+            await initialize()
 
-        engine.prefetch = slow_prefetch  # type: ignore[method-assign]
+        engine.initialize_update_destination = slow_initialize  # type: ignore[method-assign]
         r = Reconciler(store=FakeStore(VersionRef("r1", 2), _full("r1", 2)), engine=engine, reconcile_interval=0.0)
         r.applied = VersionRef("r1", 0)  # same run, behind -> stage v2 (no run switch)
         task = asyncio.create_task(r.startup())
-        await asyncio.sleep(0.05)  # startup fires the prefetch; reconcile reaches the await
-        assert "stage:2" not in engine.calls  # blocked on the (still-running) prefetch
+        await asyncio.sleep(0.05)
+        assert "stage:2" not in engine.calls
         release.set()
         await task
-        assert engine.calls.index("prefetch") < engine.calls.index("stage:2")
+        assert engine.calls.index(
+            "initialize_update_destination"
+        ) < engine.calls.index("stage:2")
+        assert r.metrics["destination_init_wait_s"] > 0
+        await r.shutdown()
+
+    _run(go())
+
+
+def test_boot_weights_serve_before_update_destination_is_ready() -> None:
+    async def go() -> None:
+        engine = FakeEngine()
+        release = asyncio.Event()
+
+        async def slow_initialize() -> None:
+            await release.wait()
+            engine.calls.append("initialize_update_destination")
+
+        engine.initialize_update_destination = slow_initialize  # type: ignore[method-assign]
+        r = Reconciler(
+            store=FakeStore(VersionRef("r1", 0)),
+            engine=engine,
+            reconcile_interval=0.0,
+        )
+        await r.startup()
+        assert r.ready
+        assert r.applied == VersionRef("r1", 0)
+        assert "pause" not in engine.calls
+        assert not r._destination_ready
+        release.set()
+        await r._destination_init_task
+        assert r._destination_ready
+        await r.shutdown()
+
+    _run(go())
+
+
+def test_update_fails_after_update_destination_initialization_fails() -> None:
+    async def go() -> None:
+        engine = FakeEngine()
+
+        async def fail_initialize() -> None:
+            raise RuntimeError("broken destination")
+
+        engine.initialize_update_destination = fail_initialize  # type: ignore[method-assign]
+        r = Reconciler(
+            store=FakeStore(VersionRef("r1", 2), _full("r1", 2)),
+            engine=engine,
+            reconcile_interval=0.0,
+        )
+        r.applied = VersionRef("r1", 0)
+        await r.startup()
+        assert r.sync_state is SyncState.ERROR
+        assert r.last_error is not None
+        assert "broken destination" in r.last_error
+        assert "stage:2" not in engine.calls
         await r.shutdown()
 
     _run(go())

--- a/src/stitch/types.py
+++ b/src/stitch/types.py
@@ -9,7 +9,7 @@ with their instances (``stores/base.py``, ``engines/base.py``, ``pools/base.py``
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -35,7 +35,7 @@ class VersionRef:
         return f"{self.run_id}/{name}" if self.run_id else name
 
     @classmethod
-    def parse(cls, text: str) -> "VersionRef":
+    def parse(cls, text: str) -> VersionRef:
         # ``[<run_id>/]weight_vNNNNNN`` (or legacy bare ``NNNNNN``). Non-empty unparseable content
         # raises — never fall back to base and serve the wrong weights (stitch#31).
         text = (text or "").strip()
@@ -59,18 +59,15 @@ class VersionManifest:
     ``checksum_format``) and lineage straight off the on-disk index — the codec is the
     engine's concern, not part of this domain type.
 
-    ``tensor_names`` are the version's touched tensor names (the index's ``weight_map``
-    keys); the reconciler unions them across a catch-up range and hands them to the engine
-    for an O(delta) partial reload (``files`` are the changed *file* names, for FULL seeding).
+    ``files`` are the checkpoint or delta payload files named by the index.
     """
 
     ref: VersionRef
     kind: VersionKind
     files: list[str]
-    tensor_names: list[str] = field(default_factory=list)
 
     @classmethod
-    def from_hf_index(cls, version_dir: str | Path, *, run_id: str | None = None) -> "VersionManifest":
+    def from_hf_index(cls, version_dir: str | Path, *, run_id: str | None = None) -> VersionManifest:
         # model.safetensors.index.json holds the version number under `metadata` and the
         # files as `weight_map` values; a `delta_encoding` key (the same one the engine's
         # applier reads) marks a delta.
@@ -81,7 +78,6 @@ class VersionManifest:
             ref=VersionRef(run_id, int(meta["version"])),
             kind=VersionKind.DELTA if meta.get("delta_encoding") else VersionKind.FULL,
             files=sorted({str(f) for f in weight_map.values()}),
-            tensor_names=sorted(str(k) for k in weight_map),
         )
 
 
@@ -96,7 +92,7 @@ class VersionConstraint:
     exact_version: int | None = None
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any] | None) -> "VersionConstraint":
+    def from_payload(cls, payload: dict[str, Any] | None) -> VersionConstraint:
         raw = (payload or {}).get("weight_version")
         raw = raw if isinstance(raw, dict) else {}
         mn, ex = raw.get("min_version"), raw.get("exact_version")
@@ -115,9 +111,8 @@ class VersionConstraint:
 
 class SyncState(str, Enum):
     IDLE = "IDLE"
-    QUEUED = "QUEUED"
-    PREFETCHING = "PREFETCHING"
-    PREPARING = "PREPARING"
+    FETCHING = "FETCHING"
+    STAGING = "STAGING"
     COMMITTING = "COMMITTING"
     ERROR = "ERROR"
 
@@ -139,7 +134,7 @@ class ReplicaState:
         return self.applied == target and self.sync_state is not SyncState.ERROR
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "ReplicaState":
+    def from_dict(cls, data: dict[str, Any]) -> ReplicaState:
         applied, state = data.get("applied"), data.get("sync_state")
         return cls(
             applied=VersionRef.parse(applied) if applied else None,


### PR DESCRIPTION
## Stack

1. This PR: core staged-weight runtime
2. Trainer publication and affinity hooks
3. Cookbook integration
4. Profiling and probe tools
5. Repository lint configuration
6. Documentation

## Summary

- replace partial tensor reload with general staged disk and CPU destinations
- initialize update destinations in the background while base weights serve
- fold lagging delta chains into one stage/commit transition
- preserve admission and cache-version correctness during in-place commits
- make S3 and Modal Volume stores materialize the data required by the staged engine

The engine, manifest, reconciler, service, and store contracts change together here because they form one atomic runtime boundary. Cookbook wiring is intentionally deferred to PR 3.

## Validation

- uv run pytest -q — 66 passed
- uv run ruff check src/stitch
