### PR TITLE
Weight sync 3/6: cookbook integration

### DIFF
--- a/cookbook/common/config.py
+++ b/cookbook/common/config.py
@@ -16,7 +16,7 @@ class ModalConfig:
     """Modal infrastructure: GPU model, region, rollout-pool sizing, prep topology."""
 
     gpu: GPUType = "B200"
-    memory: tuple[int, int] | None = None
+    trainer_memory_mib: tuple[int, int] | None = None
     cloud: str | None = None
     region: str | None = None
     rollout_min_containers: int = 2
@@ -26,7 +26,7 @@ class ModalConfig:
     rollout_target_inputs: int | None = None
     proxy_regions: list[str] = ["us-west"]
     rollout_ephemeral_disk_mib: int | None = None
-    rollout_memory_mib: int | None = None
+    rollout_memory_mib: tuple[int, int] | None = None
     torch_dist_prep_nodes: int = 2
     torch_dist_prep_gpus_per_node: int = 8
     torch_dist_convert_extra_args: str = ""

--- a/cookbook/common/process.py
+++ b/cookbook/common/process.py
@@ -17,19 +17,45 @@ SIDECAR_MODULE = "cookbook.common.sidecar"
 
 
 def start_sidecar(
-    *, sidecar_port: int, sglang_port: int, bulletin_root: str, local_checkpoint_dir: str,
-    volume_name: str, commit_mode: str, flush_cache_on_commit: bool = False, debug_requests: bool = False,
+    *,
+    sidecar_port: int,
+    sglang_port: int,
+    bulletin_root: str,
+    base_checkpoint_dir: str,
+    local_checkpoint_dir: str | None,
+    delta_update_mode: str,
+    disk_load_format: str,
+    volume_name: str,
+    commit_mode: str,
+    flush_cache_on_commit: bool = False,
+    debug_requests: bool = False,
 ) -> subprocess.Popen:
     """Launch the versioned rollout proxy (the shared sidecar) beside sglang."""
     cmd = [
-        "python3", "-m", SIDECAR_MODULE,
-        "--host", "0.0.0.0", "--port", str(sidecar_port),
-        "--upstream", f"http://127.0.0.1:{sglang_port}",
-        "--bulletin-root", bulletin_root,
-        "--local-checkpoint-dir", local_checkpoint_dir,
-        "--volume-name", volume_name,
-        "--commit-mode", commit_mode,
+        "python3",
+        "-m",
+        SIDECAR_MODULE,
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(sidecar_port),
+        "--upstream",
+        f"http://127.0.0.1:{sglang_port}",
+        "--bulletin-root",
+        bulletin_root,
+        "--base-checkpoint-dir",
+        base_checkpoint_dir,
+        "--delta-update-mode",
+        delta_update_mode,
+        "--disk-load-format",
+        disk_load_format,
+        "--volume-name",
+        volume_name,
+        "--commit-mode",
+        commit_mode,
     ]
+    if local_checkpoint_dir is not None:
+        cmd.extend(["--local-checkpoint-dir", local_checkpoint_dir])
     if flush_cache_on_commit:
         cmd.append("--flush-cache-on-commit")
     if debug_requests:

--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -9,7 +9,6 @@ private sglang on SGLANG_PORT).
 
 from __future__ import annotations
 
-import os
 from typing import Any
 
 from stitch.service import sync_in_progress
@@ -26,29 +25,39 @@ def serve_startup(
     tp: int,
     concurrency: int,
     bulletin_root: str,
-    local_checkpoint_dir: str,
+    local_checkpoint_dir: str | None,
+    delta_update_mode: str,
     volume_name: str,
     commit_mode: str,
     flush_cache_on_commit: bool = False,
     startup_timeout: int,
-    sglang_env: dict[str, str] | None = None,
 ) -> None:
     """Start sglang + the versioned-proxy sidecar on a Server replica (from ``@modal.enter``).
-    The engine serves ``model_name`` and materializes each version into
-    ``local_checkpoint_dir`` itself via /pull_weights; the sidecar drives the sync.
-    ``sglang_env`` is a per-config override of the sglang process env (over the image's
-    baked defaults) — set before launch so the engine subprocess inherits it."""
+    SGLang starts directly from the immutable base. The sidecar initializes the
+    selected update destination in the background after serving is available."""
     from autoinference_utils.endpoint import (
         SGLangEndpoint,
         start_heartbeat_thread,
         warmup_chat_completions,
     )
 
-    if sglang_env:
-        os.environ.update(sglang_env)
+    if delta_update_mode not in {"disk", "cpu"}:
+        raise ValueError(f"unsupported delta update mode: {delta_update_mode!r}")
+    cpu_cache_enabled = "--enable-cpu-weight-cache" in sglang_args
+    if cpu_cache_enabled != (delta_update_mode == "cpu"):
+        raise ValueError(
+            "SGLANG_DELTA_UPDATE_MODE must be 'cpu' exactly when "
+            "--enable-cpu-weight-cache is present in SGLANG_SERVER_ARGS"
+        )
+
     replica.endpoint = SGLangEndpoint(
-        model_path=model_name, worker_port=SGLANG_PORT, tp=tp,
-        extra_server_args=sglang_args, health_timeout=startup_timeout, health_poll_interval=10.0,
+        model_path=model_name,
+        worker_port=SGLANG_PORT,
+        tp=tp,
+        extra_server_args=sglang_args,
+        health_timeout=startup_timeout,
+        health_poll_interval=10.0,
+        log_requests_level=-1,
     )
     replica.endpoint.start()
     warmup = {
@@ -59,21 +68,26 @@ def serve_startup(
     warmup_chat_completions(port=SGLANG_PORT, payload=warmup, successful_requests=2,
                             request_timeout=120.0, max_attempts_per_request=3)
     replica.sidecar = process.start_sidecar(
-        sidecar_port=SIDECAR_PORT, sglang_port=SGLANG_PORT, bulletin_root=bulletin_root,
-        local_checkpoint_dir=local_checkpoint_dir, volume_name=volume_name, commit_mode=commit_mode,
+        sidecar_port=SIDECAR_PORT,
+        sglang_port=SGLANG_PORT,
+        bulletin_root=bulletin_root,
+        base_checkpoint_dir=model_name,
+        local_checkpoint_dir=local_checkpoint_dir,
+        delta_update_mode=delta_update_mode,
+        disk_load_format=str(sglang_args.get("--load-format", "auto")),
+        volume_name=volume_name,
+        commit_mode=commit_mode,
         flush_cache_on_commit=flush_cache_on_commit,
     )
     # Modal admits the container to Flash routing when @enter returns and never re-polls /health, so
     # blocking here on /health (503 until the reconciler's first catch-up) is the only thing that keeps a
     # not-yet-synced replica out of rotation. Fresh boot (no pointer) clears at once; a mid-run joiner
-    # waits until it has replayed to the live version, bounded by startup_timeout.
+    # waits until it has applied the live version, bounded by startup_timeout.
     process.wait_http(f"http://127.0.0.1:{SIDECAR_PORT}/health", replica.sidecar, startup_timeout)
 
     def engine_health() -> str | None:
-        # The base seed and every delta apply drive the fork's /pull_weights, which starves
-        # sglang's event loop enough that its detokenizer heartbeat goes stale and /health 503s.
-        # That stall is EXPECTED mid-sync — suppress it unless the reconciler is idle (a dead
-        # engine process still raises once the sync is done or errored).
+        # Weight staging can make the engine health endpoint briefly stale.
+        # Suppress that expected blip only while the reconciler reports work.
         error = replica.endpoint.health_check()
         if error is None:
             return None

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -1,25 +1,25 @@
 """The weight-sync sglang SERVING image — shared by every recipe.
 
 Trainer-agnostic: no trainer package is installed (the delta apply lives in the engine behind
-``/pull_weights``), so miles and slime serve on the identical image; precision comes from the
-served checkpoint, not a ``--quantization`` flag. The fork pin carries ``/pull_weights``, the
-hardened local_checkpoint receiver, the quantized-reload restore protocol (reload == init), and
-the O(delta) partial-reload load plan. See ``SGLANG_FORK.md`` for the patch stack and how to
-re-port onto a newer sglang release.
+``/stage_weight_update``), so miles and slime serve on the identical image; precision comes
+from the served checkpoint, not a ``--quantization`` flag. The fork pin carries asynchronous
+weight staging, correct quantized weight loading, and the optional CPU delta cache. See
+``SGLANG_FORK.md`` for the patch stack and how to re-port onto a newer sglang release.
 """
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 import modal
 
 # The base tag MUST match the branch's base tag: the fork overlays python/ only, so the
 # baked kernels/CUDA must be ABI-compatible with it.
-SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.15.post1"
+SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.16"
 SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
-SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.15-post1"
-SGLANG_FORK_COMMIT = "557e19e1b6fdceeea46d8674f6e3ae3428d1d102"
+SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.16"
+SGLANG_FORK_COMMIT = "418b2fb4995f3b0eac9d7424c6cd9877ecc386ec"
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent
 
@@ -30,35 +30,60 @@ _SERVING_ENV = {
     "SGLANG_DISABLE_CUDNN_CHECK": "1",
     "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
     "SGLANG_TIMEOUT_KEEP_ALIVE": "300",
-    # gVisor lacks nvidia-fs, so GDS/cuFile is unavailable — force fastsafetensors onto its
-    # nogds path. Only read under --load-format fastsafetensors.
-    "SGLANG_FASTSAFETENSORS_NOGDS": "1",
 }
 
 
-def build_serving_image(*, hf_cache_path: str, delta_volume_name: str, experiment: str, run_id: str | None = None) -> modal.Image:
-    """The rollout-pool image. ``DELTA_VOLUME_NAME`` is read by the engine's pre-read hook and
-    the sidecar's Store; ``EXPERIMENT_CONFIG`` (and ``RUN_ID`` where the recipe scopes per run) let
-    the container's re-import resolve the same experiment/run as the deploy; stitch + the cookbook
-    package are mounted so the sidecar and the framework hooks resolve."""
+def build_serving_image(
+    *,
+    hf_cache_path: str,
+    delta_volume_name: str | None = None,
+    experiment: str,
+    run_id: str | None = None,
+    extra_packages: Sequence[str] = (),
+    extra_env: Mapping[str, str] | None = None,
+) -> modal.Image:
+    """The rollout-pool image. Volume-backed recipes set ``delta_volume_name`` for their
+    Store; other Store backends omit it. Backend-specific packages and environment
+    belong in ``extra_packages`` / ``extra_env`` so all build steps still precede the
+    local source layers."""
     return (
         modal.Image.from_registry(SGLANG_IMAGE_TAG)
         .run_commands(
             f"cd /sgl-workspace/sglang && git remote add modal-fork {SGLANG_FORK_REPO}"
             f" && git fetch modal-fork {SGLANG_FORK_BRANCH} && git checkout {SGLANG_FORK_COMMIT} -- python/"
         )
-        .run_commands(f"rm -rf {hf_cache_path}")  # baked HF cache must not shadow the mounted volume
+        .run_commands(
+            f"rm -rf {hf_cache_path}"
+        )  # baked HF cache must not shadow the mounted volume
         .pip_install(
             "autoinference-utils==0.2.3",  # sglang server lifecycle
-            "fastapi", "httpx", "uvicorn",  # the stitch sidecar
-            "zstandard", "xxhash", "blake3",  # engine-side /pull_weights receiver's codecs
-            "fastsafetensors",  # --load-format fastsafetensors: per-rank read (nogds, see env below)
+            "fastapi",
+            "httpx",
+            "uvicorn",  # the stitch sidecar
+            "zstandard",
+            "xxhash",
+            "blake3",  # engine-side weight-staging checksum
+            "fastsafetensors",
+            *extra_packages,
         )
-        .env({**_SERVING_ENV, "DELTA_VOLUME_NAME": delta_volume_name, "EXPERIMENT_CONFIG": experiment,
-              **({"RUN_ID": run_id} if run_id else {})})
+        .env(
+            {
+                **_SERVING_ENV,
+                **(extra_env or {}),
+                "EXPERIMENT_CONFIG": experiment,
+                **(
+                    {"DELTA_VOLUME_NAME": delta_volume_name}
+                    if delta_volume_name
+                    else {}
+                ),
+                **({"RUN_ID": run_id} if run_id else {}),
+            }
+        )
         # The kernel-cache volume can't mount over a non-empty path — clear it as the final
         # filesystem step (repopulated on boot).
         .run_commands("rm -rf /root/.cache/sglang")
         .add_local_python_source("stitch")
-        .add_local_dir(str(_COOKBOOK_DIR), remote_path="/root/cookbook", ignore=["**/__pycache__"])
+        .add_local_dir(
+            str(_COOKBOOK_DIR), remote_path="/root/cookbook", ignore=["**/__pycache__"]
+        )
     )

--- a/cookbook/common/sidecar.py
+++ b/cookbook/common/sidecar.py
@@ -34,7 +34,10 @@ def main() -> None:
     p.add_argument("--port", type=int, default=8000)
     p.add_argument("--upstream", default="http://127.0.0.1:8001")
     p.add_argument("--bulletin-root", required=True)
-    p.add_argument("--local-checkpoint-dir", required=True)
+    p.add_argument("--base-checkpoint-dir", required=True)
+    p.add_argument("--local-checkpoint-dir")
+    p.add_argument("--delta-update-mode", choices=["disk", "cpu"], required=True)
+    p.add_argument("--disk-load-format", default="auto")
     p.add_argument("--volume-name", default="")
     p.add_argument("--commit-mode", choices=["in_place", "quiesce"], default="in_place")
     p.add_argument("--flush-cache-on-commit", action="store_true")
@@ -42,14 +45,26 @@ def main() -> None:
     p.add_argument("--debug-requests", action="store_true")
     p.add_argument("--reconcile-interval", type=float, default=5.0)  # 0 disables the periodic re-check
     args = p.parse_args()
+    if args.delta_update_mode == "disk" and not args.local_checkpoint_dir:
+        p.error("--local-checkpoint-dir is required in disk mode")
 
     store = ModalVolumeStore(args.bulletin_root, volume_name=args.volume_name or None)
-    engine = SGLangEngine(args.upstream, args.local_checkpoint_dir)
+    engine = SGLangEngine(
+        args.upstream,
+        args.base_checkpoint_dir,
+        args.local_checkpoint_dir,
+        delta_update_mode=args.delta_update_mode,
+        disk_load_format=args.disk_load_format,
+    )
     serve(
-        store, engine,
-        run_id=args.run_id, commit_mode=args.commit_mode,
+        store,
+        engine,
+        run_id=args.run_id,
+        commit_mode=args.commit_mode,
         flush_cache_on_commit=args.flush_cache_on_commit,
-        host=args.host, port=args.port, debug_requests=args.debug_requests,
+        host=args.host,
+        port=args.port,
+        debug_requests=args.debug_requests,
         reconcile_interval=args.reconcile_interval,
     )
 

--- a/cookbook/common/smoke.py
+++ b/cookbook/common/smoke.py
@@ -29,6 +29,10 @@ def smoke_flash_pool(*, app_name: str, cls_name: str, model_name: str, weight_ve
             # A fresh pool has no claimed run, so version 0 is unpinnable — an exact-version
             # request would 409. Gate on plain serving until a run has claimed the pool.
             if _get_json(f"{gateway}/server_info", timeout=60).get("run_id") is None:
+                if weight_version != 0:
+                    raise RuntimeError(
+                        f"pool is unclaimed; cannot serve expected weight version {weight_version}"
+                    )
                 data = _post_json(f"{gateway}/v1/chat/completions", _completion(model_name), timeout=900)
                 _check_serves(data)
                 print(f"Pool serves base (unclaimed): {data.get('choices')}")
@@ -99,3 +103,27 @@ def _post_json(url: str, payload: dict, *, timeout: float) -> dict:
     request = urllib.request.Request(url, data=json.dumps(payload).encode(), headers={"Content-Type": "application/json"})
     with urllib.request.urlopen(request, timeout=timeout) as resp:
         return json.load(resp)
+
+
+def main() -> None:
+    """Run a smoke check as a plain client without creating a transient Modal app."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--app-name", required=True)
+    parser.add_argument("--model-name", required=True)
+    parser.add_argument("--weight-version", type=int, default=0)
+    parser.add_argument("--class-name", default="Server")
+    parser.add_argument("--timeout-seconds", type=int, default=1800)
+    args = parser.parse_args()
+    smoke_flash_pool(
+        app_name=args.app_name,
+        cls_name=args.class_name,
+        model_name=args.model_name,
+        weight_version=args.weight_version,
+        timeout_seconds=args.timeout_seconds,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbook/common/smoke_test.py
+++ b/cookbook/common/smoke_test.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from cookbook.common import smoke
+
+
+class _Pool:
+    def __init__(self, app_name: str, cls_name: str) -> None:
+        pass
+
+    def gateway_url(self) -> str:
+        return "https://pool"
+
+
+def test_unclaimed_pool_cannot_satisfy_nonzero_version(monkeypatch) -> None:
+    monkeypatch.setattr(smoke, "ModalFlashPool", _Pool)
+    monkeypatch.setattr(smoke, "_get_json", lambda *args, **kwargs: {"run_id": None})
+
+    with pytest.raises(TimeoutError, match="pool is unclaimed"):
+        smoke.smoke_flash_pool(
+            app_name="app",
+            cls_name="Server",
+            model_name="model",
+            weight_version=10,
+            timeout_seconds=0,
+        )
+
+
+def test_unclaimed_pool_can_serve_base(monkeypatch) -> None:
+    monkeypatch.setattr(smoke, "ModalFlashPool", _Pool)
+    monkeypatch.setattr(smoke, "_get_json", lambda *args, **kwargs: {"run_id": None})
+    monkeypatch.setattr(
+        smoke,
+        "_post_json",
+        lambda *args, **kwargs: {
+            "choices": [{"message": {"content": "OK"}}],
+        },
+    )
+
+    smoke.smoke_flash_pool(
+        app_name="app",
+        cls_name="Server",
+        model_name="model",
+        weight_version=0,
+        timeout_seconds=0,
+    )

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -30,16 +30,22 @@ from typing import Any
 import modal
 import modal.experimental
 
-from stitch.pools.modal_flash import ModalFlashPool
-
-from cookbook.common import launch, ray_cluster, serving_image, server, smoke
+from cookbook.common import launch, ray_cluster, server, serving_image
 from cookbook.common.constants import (
-    CHECKPOINTS_PATH, DATA_PATH, HF_CACHE_PATH, MINUTES, PREP_PATH, RAY_PORT,
-    SERVER_STARTUP_TIMEOUT, SGLANG_CACHE_PATH, SIDECAR_PORT,
+    CHECKPOINTS_PATH,
+    DATA_PATH,
+    HF_CACHE_PATH,
+    MINUTES,
+    PREP_PATH,
+    RAY_PORT,
+    SERVER_STARTUP_TIMEOUT,
+    SGLANG_CACHE_PATH,
+    SIDECAR_PORT,
 )
 from cookbook.miles_disagg import trainer_image
-from cookbook.miles_disagg.config import MilesConfig, YAML_CONFIG_FIELDS
+from cookbook.miles_disagg.config import YAML_CONFIG_FIELDS, MilesConfig
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
+from stitch.pools.modal_flash import ModalFlashPool
 
 EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]  # required; a default would silently serve the wrong experiment
 MILES_LOCAL_DIR = os.environ.get("MILES_LOCAL_DIR")  # optional dev overlay of a local miles checkout
@@ -68,7 +74,7 @@ hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=
 data_volume = modal.Volume.from_name("miles-data", create_if_missing=True, version=2)
 checkpoints_volume = modal.Volume.from_name("miles-checkpoints", create_if_missing=True, version=2)
 prep_volume = modal.Volume.from_name("miles-prep-checkpoints", create_if_missing=True, version=2)
-sglang_cache_volume = modal.Volume.from_name("miles-sglang-cache", create_if_missing=True, version=2)  # survives cold starts
+sglang_cache_volume = modal.Volume.from_name("sglang-cache", create_if_missing=True, version=2)  # survives cold starts
 delta_volume = modal.Volume.from_name(exp.DELTA_VOLUME_NAME, create_if_missing=True, version=2)
 
 train_volumes = {
@@ -86,8 +92,6 @@ SGLANG_SERVER_ARGS = {
     "--cuda-graph-max-bs-decode": str(ROLLOUT_CONCURRENCY),
     "--max-running-requests": str(ROLLOUT_CONCURRENCY),
     "--trust-remote-code": "",
-    # Volume writes aren't cross-host visible until a reload; this hook reloads before the pull.
-    "--custom-pull-weights-pre-read-hook": "stitch.stores.modal_volume.pull_weights_pre_read_hook",
     **exp.SGLANG_SERVER_ARGS,
 }
 
@@ -120,10 +124,12 @@ class Server:
         server.serve_startup(
             self, model_name=miles_cfg.hf_checkpoint, sglang_args=SGLANG_SERVER_ARGS,
             tp=miles_cfg.rollout_num_gpus_per_engine, concurrency=ROLLOUT_CONCURRENCY,
-            bulletin_root=BULLETIN_ROOT, local_checkpoint_dir=exp.LOCAL_CHECKPOINT_PATH,
+            bulletin_root=BULLETIN_ROOT,
+            local_checkpoint_dir=exp.LOCAL_CHECKPOINT_PATH,
+            delta_update_mode=exp.SGLANG_DELTA_UPDATE_MODE,
             volume_name=exp.DELTA_VOLUME_NAME, commit_mode=exp.SIDECAR_COMMIT_MODE,
             flush_cache_on_commit=exp.SIDECAR_FLUSH_CACHE_ON_COMMIT,
-            startup_timeout=SERVER_STARTUP_TIMEOUT, sglang_env=getattr(exp, "SGLANG_ENV", {}),
+            startup_timeout=SERVER_STARTUP_TIMEOUT,
         )
 
     @modal.exit()
@@ -140,7 +146,7 @@ _MULTINODE = miles_cfg.n_train_nodes > 1
 @app.cls(
     image=image,
     gpu=f"{modal_cfg.gpu}:{miles_cfg.actor_num_gpus_per_node}",
-    memory=modal_cfg.memory,
+    memory=modal_cfg.trainer_memory_mib,
     cloud=modal_cfg.cloud, region=modal_cfg.region,
     volumes=train_volumes,
     ephemeral_disk=modal_cfg.trainer_ephemeral_disk_mib,
@@ -242,14 +248,5 @@ def launch_train() -> None:
         raise SystemExit(
             f"App {APP_NAME!r} is not deployed. Launch a fresh run with:\n"
             f"  EXPERIMENT_CONFIG={EXPERIMENT} uv run --extra modal python -m cookbook.miles_disagg.launch"
-        )
+        ) from None
     print(f"stop this run when done: modal app stop {APP_NAME}")
-
-
-@app.local_entrypoint()
-def smoke_flash_pool(weight_version: int = 0, timeout_seconds: int = 30 * MINUTES) -> None:
-    """Check the deployed Flash pool serves completions at the expected weight version."""
-    smoke.smoke_flash_pool(
-        app_name=APP_NAME, cls_name="Server", model_name=miles_cfg.hf_checkpoint,
-        weight_version=weight_version, timeout_seconds=timeout_seconds,
-    )

--- a/cookbook/miles_disagg/config.py
+++ b/cookbook/miles_disagg/config.py
@@ -86,7 +86,7 @@ class MilesConfig:
         }
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "MilesConfig":
+    def from_payload(cls, payload: dict[str, Any]) -> MilesConfig:
         cfg = cls(**payload["fields"])
         cfg.environment = dict(payload["environment"])
         cfg.async_mode = payload["async_mode"]

--- a/cookbook/miles_disagg/configs/glm45_air_bf16.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16.py
@@ -6,14 +6,13 @@ from cookbook.common.config import ModalConfig
 from cookbook.common.constants import DATA_PATH, PREP_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
-
 APP_NAME = "stitch-glm45-air-bf16"
 DELTA_VOLUME_NAME = "stitch-delta-glm45-air-bf16"
 DELTA_BULLETIN_ROOT = "/delta-bulletin"
 LOCAL_CHECKPOINT_PATH = "/local-checkpoint"
 
 SOURCE_MODEL = "zai-org/GLM-4.5-Air"
-MODEL_TAG = "glm45-air-bf16"
+MODEL_TAG = "glm45-air"
 SERVED_CHECKPOINT_FORMAT = "bf16"
 USE_MODAL_TORCH_DIST_WRAPPER = True
 DISABLE_HF_XET = True
@@ -21,14 +20,17 @@ DISABLE_HF_TRANSFER = True
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
+SGLANG_DELTA_UPDATE_MODE = "disk"
 MEGATRON_RUNTIME_PATCHES = ["/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"]
 
 
 SGLANG_SERVER_ARGS = {
-    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
+    "--model-loader-extra-config": '{"enable_gds":false}',
+    "--weight-loader-drop-cache-after-load": "",
     "--reasoning-parser": "glm45",
-    "--tool-call-parser": "glm45",
+    "--tool-call-parser": "glm",
     "--dist-timeout": "3600",
     "--context-length": "32768",
     "--mem-fraction-static": "0.8",
@@ -39,7 +41,7 @@ SGLANG_SERVER_ARGS = {
 modal = ModalConfig(
     gpu="H200",
     region="us",
-    memory=(1024, int(2 * 1024 * 1024)),
+    trainer_memory_mib=(1024, int(2 * 1024 * 1024)),
     rollout_min_containers=1,
     rollout_target_inputs=32,
     proxy_regions=["us-west"],

--- a/cookbook/miles_disagg/configs/glm45_air_fp8.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8.py
@@ -9,11 +9,12 @@ from cookbook.miles_disagg.config import MilesConfig
 APP_NAME = "stitch-glm45-air-fp8"
 DELTA_VOLUME_NAME = "stitch-delta-glm45-air-fp8"
 DELTA_BULLETIN_ROOT = "/delta-bulletin"
-LOCAL_CHECKPOINT_PATH = "/local-checkpoint"
-SIDECAR_COMMIT_MODE = "in_place"  # reload without pausing generation — no serving gap; weights shift under in-flight decodes, RL-tolerated
+LOCAL_CHECKPOINT_PATH = None
+SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
+SGLANG_DELTA_UPDATE_MODE = "cpu"
 
-MODEL_TAG = "glm45-air-bf16"
+MODEL_TAG = "glm45-air"
 SOURCE_MODEL = "zai-org/GLM-4.5-Air"
 ROLLOUT_SOURCE_MODEL = "zai-org/GLM-4.5-Air-FP8"
 SERVED_CHECKPOINT_FORMAT = "fp8"
@@ -24,13 +25,15 @@ DISABLE_HF_TRANSFER = True
 MEGATRON_RUNTIME_PATCHES = ["/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"]
 
 SGLANG_SERVER_ARGS = {
-    # Dense FP8 reloads the full checkpoint each step; fastsafetensors splits files across TP
-    # ranks (each reads 1/N) to cut bytes under gVisor's byte-copy-bound read. nogds is forced
-    # via SGLANG_FASTSAFETENSORS_NOGDS in the serving image (GDS/nvidia-fs is absent under gVisor).
+    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
+    "--model-loader-extra-config": '{"enable_gds":false}',
+    "--enable-cpu-weight-cache": "",
+    "--cpu-weight-cache-max-compile-group-gb": "8",
+    "--weight-loader-drop-cache-after-load": "",
     "--dtype": "auto",
     "--reasoning-parser": "glm45",
-    "--tool-call-parser": "glm45",
+    "--tool-call-parser": "glm",
     "--dist-timeout": "3600",
     "--context-length": "32768",
     "--mem-fraction-static": "0.7",
@@ -108,6 +111,7 @@ class _Miles(MilesConfig):
     recompute_granularity = "full"
     recompute_method = "uniform"
     recompute_num_layers = 1
+    attention_backend = "flash"
     attention_dropout = 0.0
     hidden_dropout = 0.0
     accumulate_allreduce_grads_in_fp32 = True
@@ -152,12 +156,13 @@ class _Miles(MilesConfig):
 
 modal = ModalConfig(
     gpu="H200",
-    memory=(1024, int(2 * 1024 * 1024)),
+    trainer_memory_mib=(1024, 2 * 1024 * 1024),
     rollout_min_containers=2,
     rollout_max_containers=4,   # start at 2; scale to 4 mid-run to exercise elastic join
     rollout_target_inputs=32,
     proxy_regions=["us-west"],
-    rollout_ephemeral_disk_mib=819_200,
+    rollout_ephemeral_disk_mib=524_288,
+    rollout_memory_mib=(512 * 1024, 2 * 1024 * 1024),
     torch_dist_prep_nodes=4,
     torch_dist_prep_gpus_per_node=8,
     torch_dist_convert_extra_args=(

--- a/cookbook/miles_disagg/configs/glm45_air_fp8_disk.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8_disk.py
@@ -1,0 +1,19 @@
+"""GLM-4.5-Air FP8 with the lower-RAM disk delta destination."""
+
+from cookbook.miles_disagg.configs import glm45_air_fp8
+
+APP_NAME = "stitch-glm45-air-fp8-disk"
+DELTA_VOLUME_NAME = glm45_air_fp8.DELTA_VOLUME_NAME
+DELTA_BULLETIN_ROOT = glm45_air_fp8.DELTA_BULLETIN_ROOT
+LOCAL_CHECKPOINT_PATH = "/local-checkpoint"
+SIDECAR_COMMIT_MODE = glm45_air_fp8.SIDECAR_COMMIT_MODE
+SIDECAR_FLUSH_CACHE_ON_COMMIT = glm45_air_fp8.SIDECAR_FLUSH_CACHE_ON_COMMIT
+SGLANG_DELTA_UPDATE_MODE = "disk"
+MEGATRON_RUNTIME_PATCHES = glm45_air_fp8.MEGATRON_RUNTIME_PATCHES
+SGLANG_SERVER_ARGS = {
+    key: value
+    for key, value in glm45_air_fp8.SGLANG_SERVER_ARGS.items()
+    if key not in {"--enable-cpu-weight-cache", "--cpu-weight-cache-max-compile-group-gb"}
+}
+modal = glm45_air_fp8.modal
+miles = glm45_air_fp8.miles

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -9,7 +9,6 @@ from cookbook.common.config import ModalConfig
 from cookbook.common.constants import DATA_PATH, PREP_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
-
 APP_NAME = "stitch-glm5-2-nvfp4"
 DELTA_VOLUME_NAME = "stitch-delta-glm5-2-nvfp4"
 DELTA_BULLETIN_ROOT = "/delta-bulletin"
@@ -17,10 +16,11 @@ LOCAL_CHECKPOINT_PATH = "/local-checkpoint"
 
 # GLM-5.2 ships bf16 (unlike Kimi's INT4): the bf16 masters ARE the source, no dequant.
 SOURCE_MODEL = "zai-org/GLM-5.2"
-MODEL_TAG = "glm5-2-nvfp4"
+MODEL_TAG = "glm5-2"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
+SGLANG_DELTA_UPDATE_MODE = "disk"
 # R3 routing-replay needs the dropless Megatron dispatch fix at startup.
 MEGATRON_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
@@ -28,9 +28,11 @@ MEGATRON_RUNTIME_PATCHES = [
 
 
 SGLANG_SERVER_ARGS = {
-    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
-    # v0.5.15 has no glm5.2 parser; glm45/glm47 are closest. TODO(glm5.2): confirm 5.2's format.
+    "--model-loader-extra-config": '{"enable_gds":false}',
+    "--weight-loader-drop-cache-after-load": "",
+    # The pinned SGLang has no GLM-5.2 parser; these are the closest available formats.
     "--reasoning-parser": "glm45",
     "--tool-call-parser": "glm47",
     "--dist-timeout": "3600",
@@ -50,14 +52,12 @@ SGLANG_SERVER_ARGS = {
     "--enable-return-routed-experts": "",  # routing replay (DeepSeek-V3-arch MoE)
 }
 
-SGLANG_ENV = {"SGLANG_ENABLE_RELOAD_LOAD_PLAN": "1"}  # NVFP4: load-plan replay + O(delta) partial reload
-
 modal = ModalConfig(
     gpu="B200",
     region="us",
     # TODO(glm5.2): size to the actual model. These are Kimi's (~1T) numbers — scale
     # down for a smaller GLM 5.2 (memory, ephemeral disk, node count).
-    memory=(1024, int(3 * 1024 * 1024)),
+    trainer_memory_mib=(1024, int(3 * 1024 * 1024)),
     rollout_min_containers=8,  # warm floor; Flash scales above under load
     rollout_target_inputs=32,
     proxy_regions=["us-west"],
@@ -144,8 +144,8 @@ class _Miles(MilesConfig):
         },
     }
     num_layers_at_start_in_bf16 = 3
-    # END must stay 0: sglang's fused-MoE reload allocates NVFP4 for every expert layer,
-    # so a bf16 last layer can't reload.
+    # END must stay 0: SGLang's fused-MoE weight update allocates NVFP4 for
+    # every expert layer, so a bf16 last layer cannot be updated.
     num_layers_at_end_in_bf16 = 0
 
     update_weight_transfer_mode = "disk-delta"
@@ -239,7 +239,7 @@ class _Miles(MilesConfig):
 
 
 # TODO(glm5.2) — still to confirm before a real run:
-#  1. Parsers: glm45 vs a GLM-5.2-specific reasoning/tool parser in sglang v0.5.15.
+#  1. Parsers: glm45/glm47 vs a future GLM-5.2-specific parser.
 #  2. Size the trainer to 744B-A40B / 78 layers: actor_num_nodes + TP/PP/CP/EP +
 #     decoder_last_pipeline_num_layers + memory / ephemeral disk (values above are
 #     Kimi's ~1T/128-GPU layout as a starting point).

--- a/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
@@ -10,17 +10,17 @@ from cookbook.common.config import ModalConfig
 from cookbook.common.constants import DATA_PATH, PREP_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
-
 APP_NAME = "stitch-kimi-k25-2layer-nvfp4"
 DELTA_VOLUME_NAME = "stitch-delta-kimi-k25-2layer-nvfp4"
 DELTA_BULLETIN_ROOT = "/delta-bulletin"
 LOCAL_CHECKPOINT_PATH = "/local-checkpoint"
 
 SOURCE_MODEL = "CharyZeng/Kimi-K2.5-2layer"  # INT4, KimiK25 arch, 2 layers
-MODEL_TAG = "kimi-k25-2layer-nvfp4"
+MODEL_TAG = "kimi-k25-2layer"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
+SGLANG_DELTA_UPDATE_MODE = "disk"
 # R3 routing-replay needs the dropless Megatron dispatch fix at startup.
 MEGATRON_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
@@ -28,8 +28,10 @@ MEGATRON_RUNTIME_PATCHES = [
 
 
 SGLANG_SERVER_ARGS = {
-    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
+    "--model-loader-extra-config": '{"enable_gds":false}',
+    "--weight-loader-drop-cache-after-load": "",
     "--tool-call-parser": "kimi_k2",
     "--reasoning-parser": "kimi_k2",
     "--dist-timeout": "3600",
@@ -40,8 +42,6 @@ SGLANG_SERVER_ARGS = {
     "--skip-server-warmup": "",
     "--enable-return-routed-experts": "",
 }
-
-SGLANG_ENV = {"SGLANG_ENABLE_RELOAD_LOAD_PLAN": "1"}  # NVFP4: load-plan replay + O(delta) partial reload
 
 modal = ModalConfig(
     gpu="B200",

--- a/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
@@ -9,18 +9,18 @@ from cookbook.common.config import ModalConfig
 from cookbook.common.constants import DATA_PATH, PREP_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
-
 APP_NAME = "stitch-kimi-k2-6-nvfp4"
 DELTA_VOLUME_NAME = "stitch-delta-kimi-k2-6-nvfp4"
 DELTA_BULLETIN_ROOT = "/delta-bulletin"
-LOCAL_CHECKPOINT_PATH = "/local-checkpoint"
+LOCAL_CHECKPOINT_PATH = None
 
 # SOURCE_MODEL (INT4) -> dequant -> bf16 masters -> convert -> served NVFP4 base.
 SOURCE_MODEL = "moonshotai/Kimi-K2.6"
-MODEL_TAG = "kimi-k2-6-nvfp4"
+MODEL_TAG = "kimi-k2-6"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
+SGLANG_DELTA_UPDATE_MODE = "cpu"
 # R3 routing-replay needs the dropless Megatron dispatch fix at startup.
 MEGATRON_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
@@ -29,8 +29,12 @@ MEGATRON_RUNTIME_PATCHES = [
 
 # mem-fraction / context-length are starting points — measure on a warm B200:4.
 SGLANG_SERVER_ARGS = {
-    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
+    "--model-loader-extra-config": '{"enable_gds":false}',
+    "--enable-cpu-weight-cache": "",
+    "--cpu-weight-cache-max-compile-group-gb": "8",
+    "--weight-loader-drop-cache-after-load": "",
     "--tool-call-parser": "kimi_k2",
     "--reasoning-parser": "kimi_k2",
     "--dist-timeout": "3600",
@@ -41,27 +45,23 @@ SGLANG_SERVER_ARGS = {
     "--chunked-prefill-size": "16384",
     "--schedule-conservativeness": "0.5",
     "--schedule-policy": "lpm",
-    "--enable-hierarchical-cache": "",
-    "--hicache-ratio": "2",
-    "--hicache-io-backend": "kernel",
-    "--hicache-mem-layout": "page_first",
-    "--hicache-write-policy": "write_through",
     "--skip-server-warmup": "",
     "--enable-return-routed-experts": "",
 }
 
-SGLANG_ENV = {"SGLANG_ENABLE_RELOAD_LOAD_PLAN": "1"}  # NVFP4: load-plan replay + O(delta) partial reload
-
 modal = ModalConfig(
     gpu="B200",
     region="us",
-    memory=(1024, int(2 * 1024 * 1024)),
-    # Small pool (2x B200:4) so the 64-GPU trainer gang can co-schedule; min==max pins it.
-    rollout_min_containers=4,  # 4 B200:4 engines is enough for this rollout load
+    trainer_memory_mib=(1024, 2 * 1024 * 1024),
+    # Four fixed B200:4 engines leave capacity for the trainer gang.
+    rollout_min_containers=4,
     rollout_max_containers=4,
     rollout_target_inputs=32,
     proxy_regions=["us-west"],
-    rollout_ephemeral_disk_mib=819_200,  # ~591 GB base copy + delta-apply headroom
+    # Local disk holds runtime files and spill; CPU delta updates do not
+    # materialize a target checkpoint.
+    rollout_ephemeral_disk_mib=524_288,
+    rollout_memory_mib=(1024 * 1024, 3 * 1024 * 1024),
     trainer_ephemeral_disk_mib=2_097_152,  # Ray logs + object spill need the headroom
     torch_dist_prep_nodes=8,
     torch_dist_prep_gpus_per_node=8,
@@ -144,8 +144,8 @@ class _Miles(MilesConfig):
         },
     }
     num_layers_at_start_in_bf16 = 1
-    # END must stay 0: SGLang's fused-MoE reload allocates NVFP4 for every expert layer,
-    # so a bf16 last layer can't reload.
+    # END must stay 0: SGLang's fused-MoE weight update allocates NVFP4 for every
+    # expert layer, so a bf16 last layer cannot be updated.
     num_layers_at_end_in_bf16 = 0
 
     update_weight_transfer_mode = "disk-delta"

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4.py
@@ -9,18 +9,18 @@ from cookbook.common.config import ModalConfig
 from cookbook.common.constants import DATA_PATH, PREP_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
-
 APP_NAME = "stitch-moonlight-nvfp4"
 DELTA_VOLUME_NAME = "stitch-delta-moonlight-nvfp4"
 DELTA_BULLETIN_ROOT = "/delta-bulletin"
 LOCAL_CHECKPOINT_PATH = "/local-checkpoint"
 
 SOURCE_MODEL = "moonshotai/Moonlight-16B-A3B-Instruct"
-MODEL_TAG = "moonlight-16b-nvfp4"
+MODEL_TAG = "moonlight-16b"
 
 # in_place applies weights without draining in-flight rollouts; stale KV isolated per version.
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
+SGLANG_DELTA_UPDATE_MODE = "disk"
 # R3 routing-replay needs the dropless Megatron dispatch fix at startup.
 MEGATRON_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
@@ -30,8 +30,10 @@ MEGATRON_RUNTIME_PATCHES = [
 # No --quantization flag — NVFP4 comes from the served checkpoint's quant config.
 # mem-fraction / context-length are starting points; measure.
 SGLANG_SERVER_ARGS = {
-    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
+    "--model-loader-extra-config": '{"enable_gds":false}',
+    "--weight-loader-drop-cache-after-load": "",
     "--attention-backend": "tokenspeed_mla",
     "--kv-cache-dtype": "fp8_e4m3",  # tokenspeed_mla requires this
     "--context-length": "8192",  # Moonlight's max_position_embeddings
@@ -41,8 +43,6 @@ SGLANG_SERVER_ARGS = {
     # routing replay: pool emits per-token routed experts for the trainer to replay.
     "--enable-return-routed-experts": "",
 }
-
-SGLANG_ENV = {"SGLANG_ENABLE_RELOAD_LOAD_PLAN": "1"}  # NVFP4: load-plan replay + O(delta) partial reload
 
 modal = ModalConfig(
     gpu="B200",

--- a/cookbook/miles_disagg/prep.py
+++ b/cookbook/miles_disagg/prep.py
@@ -14,7 +14,11 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from cookbook.common.constants import PREP_PATH
-from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT, TORCH_DIST_CONVERT_WRAPPER
+from cookbook.miles_disagg.trainer_image import (
+    MEGATRON_PATH,
+    MILES_ROOT,
+    TORCH_DIST_CONVERT_WRAPPER,
+)
 
 
 def prepare_checkpoints(exp, prep_volume) -> None:

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -18,9 +18,9 @@ from cookbook.common import trainer_image as common_trainer_image
 
 # Dated tag, never `latest`: Modal caches from_registry per tag string and won't re-pull
 # a moved mutable tag, so `latest` silently serves whatever was first pulled.
-MILES_IMAGE_TAG = "radixark/miles:dev-202607182122"  # base Megatron/TE; match the upstream main stitch-miles is on
+MILES_IMAGE_TAG = "radixark/miles:dev-202607260602"
 MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
-MILES_REPO_REF = "15cf7ed0344850affa354b8b81ad3acbda11474b"  # branch stitch-miles; see MILES_FORK.md
+MILES_REPO_REF = "d814b87c32d3de528ec1536700e79406ee40bf20"  # stitch-weight-sync-v0516
 
 MILES_ROOT = "/root/miles"
 MEGATRON_PATH = "/root/Megatron-LM"  # source-only megatron.training must be on PYTHONPATH
@@ -36,6 +36,9 @@ def build_trainer_image(*, hf_cache_path: str, experiment: str, run_id: str | No
     image = (
         modal.Image.from_registry(MILES_IMAGE_TAG)
         .entrypoint([])
+        # TransformerEngine 2.17 declares this dependency, but the dated Miles
+        # image installs its TE wheels with --no-deps.
+        .pip_install("onnxscript==0.7.1")
         # RDMA/EFA userspace so multi-node NCCL binds EFA under rdma=True instead of TCP.
         .apt_install("libibverbs-dev", "libibverbs1", "libhwloc-dev", "libnl-route-3-200")
         .run_commands(f"rm -rf {hf_cache_path}")  # baked HF cache must not shadow the mounted volume

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -30,15 +30,21 @@ from typing import Any
 import modal
 import modal.experimental
 
-from stitch.pools.modal_flash import ModalFlashPool
-
-from cookbook.common import launch, ray_cluster, serving_image, server, smoke
+from cookbook.common import launch, ray_cluster, server, serving_image
 from cookbook.common.constants import (
-    CHECKPOINTS_PATH, DATA_PATH, HF_CACHE_PATH, MINUTES, RAY_PORT, SERVER_STARTUP_TIMEOUT, SIDECAR_PORT,
+    CHECKPOINTS_PATH,
+    DATA_PATH,
+    HF_CACHE_PATH,
+    MINUTES,
+    RAY_PORT,
+    SERVER_STARTUP_TIMEOUT,
+    SGLANG_CACHE_PATH,
+    SIDECAR_PORT,
 )
 from cookbook.slime_disagg import trainer_image
-from cookbook.slime_disagg.config import SlimeConfig, YAML_CONFIG_FIELDS
+from cookbook.slime_disagg.config import YAML_CONFIG_FIELDS, SlimeConfig
 from cookbook.slime_disagg.trainer_image import SLIME_ROOT
+from stitch.pools.modal_flash import ModalFlashPool
 
 EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]  # required; a default would silently serve the wrong experiment
 SLIME_LOCAL_DIR = os.environ.get("SLIME_LOCAL_DIR")  # optional dev overlay of a local slime checkout
@@ -66,6 +72,7 @@ if SLIME_LOCAL_DIR:
 hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=True, version=2)
 data_volume = modal.Volume.from_name("slime-data", create_if_missing=True, version=2)
 checkpoints_volume = modal.Volume.from_name("slime-checkpoints", create_if_missing=True, version=2)
+sglang_cache_volume = modal.Volume.from_name("sglang-cache", create_if_missing=True, version=2)
 delta_volume = modal.Volume.from_name(exp.DELTA_VOLUME_NAME, create_if_missing=True, version=2)
 
 train_volumes = {
@@ -83,7 +90,6 @@ SGLANG_SERVER_ARGS = {
     "--cuda-graph-max-bs-decode": str(ROLLOUT_CONCURRENCY),
     "--max-running-requests": str(ROLLOUT_CONCURRENCY),
     "--trust-remote-code": "",
-    "--custom-pull-weights-pre-read-hook": "stitch.stores.modal_volume.pull_weights_pre_read_hook",
     **exp.SGLANG_SERVER_ARGS,
 }
 
@@ -94,7 +100,11 @@ SGLANG_SERVER_ARGS = {
     image=server_image,
     gpu=f"{modal_cfg.gpu}:{slime_cfg.rollout_num_gpus_per_engine}",
     cloud=modal_cfg.cloud, region=modal_cfg.region,
-    volumes={str(HF_CACHE_PATH): hf_cache_volume, exp.DELTA_BULLETIN_ROOT: delta_volume},
+    volumes={
+        str(HF_CACHE_PATH): hf_cache_volume,
+        SGLANG_CACHE_PATH: sglang_cache_volume,
+        exp.DELTA_BULLETIN_ROOT: delta_volume,
+    },
     min_containers=modal_cfg.rollout_min_containers, max_containers=modal_cfg.rollout_max_containers,
     timeout=40 * MINUTES, scaledown_window=15 * MINUTES,
     ephemeral_disk=modal_cfg.rollout_ephemeral_disk_mib, memory=modal_cfg.rollout_memory_mib,
@@ -111,10 +121,12 @@ class Server:
         server.serve_startup(
             self, model_name=slime_cfg.hf_checkpoint, sglang_args=SGLANG_SERVER_ARGS,
             tp=slime_cfg.rollout_num_gpus_per_engine, concurrency=ROLLOUT_CONCURRENCY,
-            bulletin_root=BULLETIN_ROOT, local_checkpoint_dir=exp.LOCAL_CHECKPOINT_PATH,
+            bulletin_root=BULLETIN_ROOT,
+            local_checkpoint_dir=exp.LOCAL_CHECKPOINT_PATH,
+            delta_update_mode=exp.SGLANG_DELTA_UPDATE_MODE,
             volume_name=exp.DELTA_VOLUME_NAME, commit_mode=exp.SIDECAR_COMMIT_MODE,
             flush_cache_on_commit=exp.SIDECAR_FLUSH_CACHE_ON_COMMIT,
-            startup_timeout=SERVER_STARTUP_TIMEOUT, sglang_env=getattr(exp, "SGLANG_ENV", {}),
+            startup_timeout=SERVER_STARTUP_TIMEOUT,
         )
 
     @modal.exit()
@@ -131,7 +143,7 @@ _MULTINODE = slime_cfg.n_train_nodes > 1
 @app.cls(
     image=image,
     gpu=f"{modal_cfg.gpu}:{slime_cfg.actor_num_gpus_per_node}",
-    memory=modal_cfg.memory,
+    memory=modal_cfg.trainer_memory_mib,
     cloud=modal_cfg.cloud, region=modal_cfg.region,
     volumes=train_volumes,
     ephemeral_disk=modal_cfg.trainer_ephemeral_disk_mib,
@@ -210,14 +222,5 @@ def launch_train() -> None:
         raise SystemExit(
             f"App {APP_NAME!r} is not deployed. Launch a fresh run with:\n"
             f"  EXPERIMENT_CONFIG={EXPERIMENT} uv run --extra modal python -m cookbook.slime_disagg.launch"
-        )
+        ) from None
     print(f"stop this run when done: modal app stop {APP_NAME}")
-
-
-@app.local_entrypoint()
-def smoke_flash_pool(weight_version: int = 0, timeout_seconds: int = 30 * MINUTES) -> None:
-    """Check the deployed Flash pool serves completions at the expected weight version."""
-    smoke.smoke_flash_pool(
-        app_name=APP_NAME, cls_name="Server", model_name=slime_cfg.hf_checkpoint,
-        weight_version=weight_version, timeout_seconds=timeout_seconds,
-    )

--- a/cookbook/slime_disagg/config.py
+++ b/cookbook/slime_disagg/config.py
@@ -83,7 +83,7 @@ class SlimeConfig:
         }
 
     @classmethod
-    def from_payload(cls, payload: dict[str, Any]) -> "SlimeConfig":
+    def from_payload(cls, payload: dict[str, Any]) -> SlimeConfig:
         cfg = cls(**payload["fields"])
         cfg.environment = dict(payload["environment"])
         cfg.async_mode = payload["async_mode"]

--- a/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
+++ b/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
@@ -20,10 +20,13 @@ INT4_GROUP_SIZE = "32"
 # in_place applies weights without draining in-flight rollouts; stale KV isolated per version.
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
+SGLANG_DELTA_UPDATE_MODE = "disk"
 
 SGLANG_SERVER_ARGS = {
-    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
+    "--model-loader-extra-config": '{"enable_gds":false}',
+    "--weight-loader-drop-cache-after-load": "",
     "--tool-call-parser": "kimi_k2",
     "--reasoning-parser": "kimi_k2",
     "--dist-timeout": "3600",

--- a/cookbook/slime_disagg/configs/moonlight.py
+++ b/cookbook/slime_disagg/configs/moonlight.py
@@ -9,7 +9,6 @@ from cookbook.common.config import ModalConfig
 from cookbook.common.constants import DATA_PATH
 from cookbook.slime_disagg.config import SlimeConfig
 
-
 APP_NAME = "stitch-moonlight"
 DELTA_VOLUME_NAME = "stitch-delta-moonlight"
 DELTA_BULLETIN_ROOT = "/delta-bulletin"
@@ -18,11 +17,14 @@ LOCAL_CHECKPOINT_PATH = "/local-checkpoint"
 # in_place applies weights without draining in-flight rollouts; stale KV isolated per version.
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
+SGLANG_DELTA_UPDATE_MODE = "disk"
 
 # mem-fraction-static is a starting point -- measure on a warm container.
 SGLANG_SERVER_ARGS = {
-    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
+    "--model-loader-extra-config": '{"enable_gds":false}',
+    "--weight-loader-drop-cache-after-load": "",
     "--context-length": "8192",
     "--mem-fraction-static": "0.85",
     # routing replay: set here since slime launches no engine in publish-only mode.

--- a/cookbook/slime_disagg/configs/moonlight_int4.py
+++ b/cookbook/slime_disagg/configs/moonlight_int4.py
@@ -11,7 +11,6 @@ from cookbook.common.config import ModalConfig
 from cookbook.common.constants import DATA_PATH
 from cookbook.slime_disagg.config import SlimeConfig
 
-
 APP_NAME = "stitch-moonlight-int4"
 DELTA_VOLUME_NAME = "stitch-delta-moonlight-int4"
 DELTA_BULLETIN_ROOT = "/delta-bulletin"
@@ -21,11 +20,14 @@ INT4_GROUP_SIZE = "128"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
+SGLANG_DELTA_UPDATE_MODE = "disk"
 
 # The pool reuses the trainer image (its SGLang serves native INT4; no Blackwell fork).
 SGLANG_SERVER_ARGS = {
-    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
+    "--model-loader-extra-config": '{"enable_gds":false}',
+    "--weight-loader-drop-cache-after-load": "",
     "--context-length": "16384",
     "--mem-fraction-static": "0.85",
     "--enable-return-routed-experts": "",  # routing replay

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
@@ -6,7 +6,6 @@ from cookbook.common.config import ModalConfig
 from cookbook.common.constants import DATA_PATH
 from cookbook.slime_disagg.config import SlimeConfig
 
-
 APP_NAME = "stitch-qwen3-4b"
 DELTA_VOLUME_NAME = "stitch-delta-qwen3-4b"
 DELTA_BULLETIN_ROOT = "/delta-bulletin"
@@ -15,10 +14,13 @@ LOCAL_CHECKPOINT_PATH = "/local-checkpoint"
 # in_place applies weights without draining; stale KV isolated per version via extra_key.
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
+SGLANG_DELTA_UPDATE_MODE = "disk"
 
 SGLANG_SERVER_ARGS = {
-    # fastsafetensors: per-rank O_DIRECT read (~1/tp bytes/rank), no gVisor mmap tax; reload inherits it. nogds set in image.
+    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
+    "--model-loader-extra-config": '{"enable_gds":false}',
+    "--weight-loader-drop-cache-after-load": "",
     "--reasoning-parser": "qwen3",
     "--context-length": "16384",
     "--mem-fraction-static": "0.84",

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash_hillclimb.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash_hillclimb.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from cookbook.slime_disagg.configs import qwen3_4b_delta_flash as _base
 
-
 APP_NAME = "stitch-qwen3-4b-hillclimb"
 DELTA_VOLUME_NAME = "stitch-delta-qwen3-4b-hillclimb"
 DELTA_BULLETIN_ROOT = _base.DELTA_BULLETIN_ROOT
 LOCAL_CHECKPOINT_PATH = "/local-checkpoint"
 SIDECAR_COMMIT_MODE = _base.SIDECAR_COMMIT_MODE
 SIDECAR_FLUSH_CACHE_ON_COMMIT = _base.SIDECAR_FLUSH_CACHE_ON_COMMIT
+SGLANG_DELTA_UPDATE_MODE = _base.SGLANG_DELTA_UPDATE_MODE
 SGLANG_SERVER_ARGS = _base.SGLANG_SERVER_ARGS
 
 modal = _base.modal


### PR DESCRIPTION
## Stack

Depends on #72. This layer wires the core into the shared Miles and Slime deployments.

## Summary

- start SGLang from the immutable base and initialize disk or CPU update destinations in the background
- validate CPU-cache flags against the selected delta mode
- pass the staged-update arguments through the shared server and sidecar
- reuse one serving-image builder for volume and non-volume Store backends
- add backend package/environment extension points without duplicating image construction
- update Miles and Slime recipes to the pinned SGLang/Miles revisions
- add the GLM-4.5-Air FP8 disk-mode comparison recipe
- run rollout smoke requests as ordinary clients

## Validation

- uv run pytest -q — 70 passed
- uv run ruff check cookbook
