### PR TITLE
Weight sync 2/6: durable trainer hooks and affinity

### DIFF
--- a/cookbook/common/hooks.py
+++ b/cookbook/common/hooks.py
@@ -27,23 +27,43 @@ from . import process
 logger = logging.getLogger(__name__)
 
 
+def sample_affinity_key(sample: Any) -> str | None:
+    """Return one stable routing key for a rollout trajectory or GRPO group."""
+    group_index = getattr(sample, "group_index", None)
+    if group_index is not None:
+        return f"group-{group_index}"
+    for name in ("routing_key", "session_id"):
+        value = getattr(sample, name, None)
+        if value is not None:
+            return str(value)
+    return None
+
+
 # ── publish ────────────────────────────────────────────────────────────────────
 def commit_and_wake(args: Any, published_dir: str, rollout_engines: Any = None) -> None:
     """Bridge the framework's disk-delta publish to the stitch store. The framework fires this
     at each durability boundary: a version dir (``weight_vNNNNNN``, holding the HF index) and —
-    at baseline/pointer commit — the run dir. Every rank flushes its writes; rank 0 publishes
-    only when handed a version dir. Keying on the dir name (not on reading an index) keeps the
-    run-dir calls a clean no-op, not a missing-file crash."""
+    at baseline/pointer commit — the run dir. Every rank flushes its writes, then version-dir
+    calls rendezvous before rank 0 advances the pointer. Keying on the dir name (not on reading
+    an index) keeps run-dir calls a clean no-op, not a missing-file crash."""
     del rollout_engines
     store = _store(args)
     store.commit()
-    if process.dist_rank() not in (None, 0) or not Path(published_dir).name.startswith("weight_v"):
+    if not Path(published_dir).name.startswith("weight_v"):
+        return
+    # A successful Volume commit makes only this trainer rank's writes durable.
+    # Do not expose an index that names another rank's shard until every rank's
+    # commit has returned.
+    process.dist_barrier()
+    if process.dist_rank() not in (None, 0):
         return
     try:
         publish_version(store, _pool(args), published_dir, run_id=_run_id(args))
     except PointerRewind:
         # A same-run republish (e.g. a retried step) — drop it rather than serve stale.
-        logger.warning("publish of %s would rewind latest; dropping", published_dir, exc_info=True)
+        logger.warning(
+            "publish of %s would rewind latest; dropping", published_dir, exc_info=True
+        )
 
 
 def claim_pool(args: Any) -> None:
@@ -55,14 +75,17 @@ def claim_pool(args: Any) -> None:
 
 
 # ── staleness-gated rollout requests ────────────────────────────────────────────
-async def gated_rollout_request_hook(args: Any, sample: Any, request: dict[str, Any]) -> None:
+async def gated_rollout_request_hook(
+    args: Any, sample: Any, request: dict[str, Any]
+) -> None:
     """Pin each request to a bounded-staleness version, so a too-stale replica returns a
     retryable 409 (nudging it to sync) instead of the trainer spending rollout compute on
     weights beyond its lag bound."""
     payload, headers = request["payload"], dict(request.get("headers") or {})
     mode = str(getattr(args, "rollout_request_weight_version_mode", "min"))
-    affinity = str(getattr(args, "rollout_session_affinity_header", "x-session-affinity"))
-    session_id = getattr(sample, "session_id", None)
+    affinity = str(
+        getattr(args, "rollout_session_affinity_header", "x-session-affinity")
+    )
 
     latest = exact = None
     lag = 0
@@ -74,12 +97,21 @@ async def gated_rollout_request_hook(args: Any, sample: Any, request: dict[str, 
         else:
             latest = floor
     constrain_request(
-        payload, headers, latest=latest, lag=lag, exact=exact,
-        session_id=session_id, affinity_header=affinity,
+        payload,
+        headers,
+        latest=latest,
+        lag=lag,
+        exact=exact,
+        session_id=sample_affinity_key(sample),
+        affinity_header=affinity,
     )
     request["headers"] = headers
-    request["max_retries"] = int(getattr(args, "rollout_request_retry_attempts", request.get("max_retries", 60)))
-    request["retry_sleep"] = float(getattr(args, "rollout_request_retry_sleep", request.get("retry_sleep", 1.0)))
+    request["max_retries"] = int(
+        getattr(args, "rollout_request_retry_attempts", request.get("max_retries", 60))
+    )
+    request["retry_sleep"] = float(
+        getattr(args, "rollout_request_retry_sleep", request.get("retry_sleep", 1.0))
+    )
 
 
 class _CachedPointer:
@@ -94,17 +126,29 @@ class _CachedPointer:
 
     async def get(self, args: Any, ttl: float = 2.0) -> int:
         store = self._store
-        if store is None:
+        root = Path(_transport_root(args))
+        volume = getattr(
+            args, "update_weight_delta_volume_name", None
+        ) or os.environ.get("DELTA_VOLUME_NAME")
+        if store is None or store.root != root or store.volume_name != (volume or None):
             store = self._store = _store(args)
+            self._version = 0
+            self._at = -1e9
         now = time.monotonic()
         if now - self._at >= ttl:
             self._at = now
             try:
-                await asyncio.to_thread(store.refresh)  # reload is blocking; keep the loop free
+                await asyncio.to_thread(
+                    store.refresh
+                )  # reload is blocking; keep the loop free
                 pointer = store.read_pointer()
                 self._version = pointer.version if pointer else 0
             except Exception:  # noqa: BLE001
-                logger.warning("gate: could not read latest; using cached %s", self._version, exc_info=True)
+                logger.warning(
+                    "gate: could not read latest; using cached %s",
+                    self._version,
+                    exc_info=True,
+                )
         return self._version
 
 
@@ -113,26 +157,34 @@ _latest = _CachedPointer()
 
 # ── args → run coordinates ───────────────────────────────────────────────────────
 def _store(args: Any) -> ModalVolumeStore:
-    volume = getattr(args, "update_weight_delta_volume_name", None) or os.environ.get("DELTA_VOLUME_NAME")
+    volume = getattr(args, "update_weight_delta_volume_name", None) or os.environ.get(
+        "DELTA_VOLUME_NAME"
+    )
     return ModalVolumeStore(_transport_root(args), volume_name=volume or None)
 
 
 def _pool(args: Any) -> ModalFlashPool:
-    app = getattr(args, "rollout_modal_flash_app_name", None) or os.environ.get("DELTA_APP_NAME")
-    cls = getattr(args, "rollout_modal_flash_server_cls_name", None) or os.environ.get("DELTA_SERVER_CLS_NAME", "Server")
+    app = getattr(args, "rollout_modal_flash_app_name", None) or os.environ.get(
+        "DELTA_APP_NAME"
+    )
+    cls = getattr(args, "rollout_modal_flash_server_cls_name", None) or os.environ.get(
+        "DELTA_SERVER_CLS_NAME", "Server"
+    )
     return ModalFlashPool(app, cls)
 
 
 def _transport_root(args: Any) -> str:
     # The trainer writes version dirs under <root>/<run_id>; the Store is rooted at <root>.
-    write_dir = getattr(args, "update_weight_disk_dir", None) or os.environ.get("DELTA_BULLETIN_ROOT", "/delta-bulletin")
+    write_dir = getattr(args, "update_weight_disk_dir", None) or os.environ.get(
+        "DELTA_BULLETIN_ROOT", "/delta-bulletin"
+    )
     return str(Path(write_dir).parent)
 
 
 def _run_id(args: Any) -> str:
     run_id = getattr(args, "run_id", None)
     if not run_id:
-        raise ValueError("run_id is required (pass it via custom_config_path) — it is the run's fence token")
+        raise ValueError(
+            "run_id is required (pass it via custom_config_path) — it is the run's fence token"
+        )
     return str(run_id)
-
-

--- a/cookbook/common/hooks_test.py
+++ b/cookbook/common/hooks_test.py
@@ -31,14 +31,21 @@ class _FakePool:
 
 def _args(root: str, run_id: str = "run-abc", **extra):
     # transport root = parent of update_weight_disk_dir, so the Store roots at `root`.
-    return SimpleNamespace(update_weight_disk_dir=f"{root}/{run_id}", run_id=run_id, **extra)
+    return SimpleNamespace(
+        update_weight_disk_dir=f"{root}/{run_id}", run_id=run_id, **extra
+    )
 
 
 def _write_version(root: Path, ref: VersionRef) -> str:
     d = root / ref.identity
     d.mkdir(parents=True)
     (d / "model.safetensors.index.json").write_text(
-        json.dumps({"metadata": {"version": ref.version}, "weight_map": {"w": "model-00001.safetensors"}})
+        json.dumps(
+            {
+                "metadata": {"version": ref.version},
+                "weight_map": {"w": "model-00001.safetensors"},
+            }
+        )
     )
     return str(d)
 
@@ -47,9 +54,31 @@ def test_commit_and_wake_publishes() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         pool = _FakePool()
+        events = []
+        original_barrier = hooks.process.dist_barrier
+        original_publish = hooks.publish_version
+        original_commit = ModalVolumeStore.commit
+
+        def publish_after_barrier(*args, **kwargs):
+            events.append("publish")
+            return original_publish(*args, **kwargs)
+
+        def commit_before_barrier(store):
+            events.append("commit")
+            return original_commit(store)
+
         hooks._pool = lambda args: pool  # rank is None in tests -> treated as writer
-        vdir = _write_version(root, VersionRef("run-abc", 1))
-        hooks.commit_and_wake(_args(str(root)), vdir)
+        hooks.process.dist_barrier = lambda: events.append("barrier")
+        hooks.publish_version = publish_after_barrier
+        ModalVolumeStore.commit = commit_before_barrier
+        try:
+            vdir = _write_version(root, VersionRef("run-abc", 1))
+            hooks.commit_and_wake(_args(str(root)), vdir)
+        finally:
+            hooks.process.dist_barrier = original_barrier
+            hooks.publish_version = original_publish
+            ModalVolumeStore.commit = original_commit
+        assert events == ["commit", "barrier", "publish"]
         assert ModalVolumeStore(root).read_pointer() == VersionRef("run-abc", 1)
         assert pool.woke == [VersionRef("run-abc", 1)]
 
@@ -62,7 +91,16 @@ def test_commit_and_wake_baseline_is_noop() -> None:
         hooks._pool = lambda args: pool
         run_dir = root / "run-abc"
         run_dir.mkdir(parents=True)
-        hooks.commit_and_wake(_args(str(root)), str(run_dir))
+        original_barrier = hooks.process.dist_barrier
+
+        def unexpected_barrier() -> None:
+            raise AssertionError("run-directory commit must not rendezvous")
+
+        hooks.process.dist_barrier = unexpected_barrier
+        try:
+            hooks.commit_and_wake(_args(str(root)), str(run_dir))
+        finally:
+            hooks.process.dist_barrier = original_barrier
         assert ModalVolumeStore(root).read_pointer() is None
         assert pool.woke == []
 
@@ -79,15 +117,40 @@ def test_claim_pool_resets_to_base() -> None:
 def test_request_hook_min_lag() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        ModalVolumeStore(root).advance_pointer(VersionRef("run-abc", 10))  # published latest
+        ModalVolumeStore(root).advance_pointer(
+            VersionRef("run-abc", 10)
+        )  # published latest
         hooks._latest = hooks._CachedPointer()  # fresh cache reading this store
-        args = _args(str(root), rollout_request_weight_version_lag=2,
-                     rollout_request_retry_attempts=900, rollout_session_affinity_header="Modal-Session-ID")
+        args = _args(
+            str(root),
+            rollout_request_weight_version_lag=2,
+            rollout_request_retry_attempts=900,
+            rollout_session_affinity_header="Modal-Session-ID",
+        )
         request = {"payload": {}}
-        asyncio.run(hooks.gated_rollout_request_hook(args, SimpleNamespace(session_id="grp-1"), request))
-        assert request["payload"]["weight_version"] == {"min_version": 8, "exact_version": None}
-        assert request["headers"]["Modal-Session-ID"] == "grp-1"
+        asyncio.run(
+            hooks.gated_rollout_request_hook(
+                args,
+                SimpleNamespace(group_index=1, routing_key="sample-key"),
+                request,
+            )
+        )
+        assert request["payload"]["weight_version"] == {
+            "min_version": 8,
+            "exact_version": None,
+        }
+        assert request["headers"]["Modal-Session-ID"] == "group-1"
         assert request["max_retries"] == 900
+
+
+def test_sample_affinity_key_fallbacks() -> None:
+    assert hooks.sample_affinity_key(SimpleNamespace(group_index=7)) == "group-7"
+    assert (
+        hooks.sample_affinity_key(SimpleNamespace(routing_key="trajectory"))
+        == "trajectory"
+    )
+    assert hooks.sample_affinity_key(SimpleNamespace(session_id="legacy")) == "legacy"
+    assert hooks.sample_affinity_key(SimpleNamespace()) is None
 
 
 def test_request_hook_exact_and_none() -> None:
@@ -96,17 +159,57 @@ def test_request_hook_exact_and_none() -> None:
         ModalVolumeStore(root).advance_pointer(VersionRef("run-abc", 10))
         hooks._latest = hooks._CachedPointer()
         exact_req = {"payload": {}}
-        asyncio.run(hooks.gated_rollout_request_hook(
-            _args(str(root), rollout_request_weight_version_mode="exact", rollout_request_weight_version_lag=1),
-            SimpleNamespace(session_id=None), exact_req))
-        assert exact_req["payload"]["weight_version"] == {"min_version": None, "exact_version": 9}
+        asyncio.run(
+            hooks.gated_rollout_request_hook(
+                _args(
+                    str(root),
+                    rollout_request_weight_version_mode="exact",
+                    rollout_request_weight_version_lag=1,
+                ),
+                SimpleNamespace(session_id=None),
+                exact_req,
+            )
+        )
+        assert exact_req["payload"]["weight_version"] == {
+            "min_version": None,
+            "exact_version": 9,
+        }
 
         hooks._latest = hooks._CachedPointer()
         none_req = {"payload": {}}
-        asyncio.run(hooks.gated_rollout_request_hook(
-            _args(str(root), rollout_request_weight_version_mode="none"),
-            SimpleNamespace(session_id=None), none_req))
-        assert none_req["payload"]["weight_version"] == {"min_version": None, "exact_version": None}
+        asyncio.run(
+            hooks.gated_rollout_request_hook(
+                _args(str(root), rollout_request_weight_version_mode="none"),
+                SimpleNamespace(session_id=None),
+                none_req,
+            )
+        )
+        assert none_req["payload"]["weight_version"] == {
+            "min_version": None,
+            "exact_version": None,
+        }
+
+
+def test_request_hook_cache_switches_runs() -> None:
+    with (
+        tempfile.TemporaryDirectory() as first,
+        tempfile.TemporaryDirectory() as second,
+    ):
+        ModalVolumeStore(first).advance_pointer(VersionRef("run-a", 7))
+        ModalVolumeStore(second).advance_pointer(VersionRef("run-b", 3))
+        hooks._latest = hooks._CachedPointer()
+
+        async def read(root: str) -> dict:
+            request = {"payload": {}}
+            await hooks.gated_rollout_request_hook(
+                _args(root, rollout_request_weight_version_lag=0),
+                SimpleNamespace(session_id=None),
+                request,
+            )
+            return request["payload"]["weight_version"]
+
+        assert asyncio.run(read(first)) == {"min_version": 7, "exact_version": None}
+        assert asyncio.run(read(second)) == {"min_version": 3, "exact_version": None}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replacement landing PR for #72.

#72 was reviewed and merged with its stacked base still set to weight-sync-01-core, so that commit did not enter main. #71 is already on main; this PR now shows only the intended trainer-hook layer.

Summary:
- commit every trainer rank's output before publishing a multi-rank checkpoint
- barrier only version-directory callbacks, keeping baseline callbacks as no-ops
- reset the cached pointer when a hook process switches store/run coordinates
- derive stable rollout affinity from group_index, then routing_key/session_id fallbacks
- retain bounded-staleness request constraints and retry behavior

Validation:
- uv run pytest -q — 68 passed at this stack layer
- uv run ruff check cookbook/common/hooks.py cookbook/common/hooks_test.py

Merge with Create a merge commit. After merging, retarget #73 to main before merging it.