### PR TITLE
cookbook: enable bundled MTP for GLM rollouts

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -12,7 +12,7 @@ loading for quantized rollout models.
 SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.16"
 SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
 SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.16"
-SGLANG_FORK_COMMIT = "e8d7dee6106fa79bb064f5e1822608ef39898e02"
+SGLANG_FORK_COMMIT = "6307bce368456caebda3535e63d17f9d7c287127"
 ```
 
 The branch is upstream v0.5.16 plus:
@@ -23,11 +23,11 @@ The branch is upstream v0.5.16 plus:
 | `5f6e1e613f` | Materialize and verify complete targets on host-local disk. |
 | `a7e20596ba` | Restore checkpoint-facing quantized layouts for complete weight loading. |
 | `c867782f3e` | Build verified, rank-ready CPU weight images from canonical targets. |
-| `a8e66a00f3` | Expose asynchronous disk/CPU staging and CPU-to-GPU commit APIs. |
-| `0581bd9920` | Stream CPU delta lineages through bounded memory. |
-| `2625e5ed2a` | Fold disk XOR lineages with bounded positional I/O. |
-| `418b2fb499` | Fail cache-flushing CPU commits before GPU mutation when the engine is busy. |
-| `e8d7dee610` | Keep speculative draft weights fixed during CPU-staged target updates. |
+| `111a804d2e` | Expose asynchronous disk/CPU staging and CPU-to-GPU target-model commit APIs. |
+| `e0859b7390` | Stream CPU delta lineages through bounded memory. |
+| `77eca472e6` | Fold disk XOR lineages with bounded positional I/O. |
+| `526e0ddca2` | Fail cache-flushing CPU commits before GPU mutation when the engine is busy. |
+| `6307bce368` | Normalize ModelOpt FP4 expert tensors through their native loader path. |
 
 The image and branch must use the same SGLang release because Stitch overlays
 Python code onto the image’s existing CUDA and C++ extensions.
@@ -170,8 +170,9 @@ workarounds.
 
 Every TP rank must pass preflight before commit starts. A rank-local copy failure
 after that point is fatal because continuing with mixed rank versions would be
-incorrect. Speculative draft models remain rejected until target and draft
-weights can be committed atomically.
+incorrect. With a fixed speculative draft, CPU staging and commit cover the
+target model only. Updating target and draft weights together is unsupported
+because they cannot yet be committed atomically.
 
 ## Re-porting
 

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -19,7 +19,7 @@ import modal
 SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.16"
 SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
 SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.16"
-SGLANG_FORK_COMMIT = "e8d7dee6106fa79bb064f5e1822608ef39898e02"
+SGLANG_FORK_COMMIT = "6307bce368456caebda3535e63d17f9d7c287127"
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent
 

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -66,7 +66,13 @@ ROLLOUT_CONCURRENCY = modal_cfg.rollout_target_inputs or miles_cfg.sglang_server
 # EXPERIMENT_CONFIG + RUN are baked into both images so a container's re-import rebuilds the same
 # app name and transport paths as the deploy, not the defaults.
 image = trainer_image.build_trainer_image(hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, run_id=RUN_ID, miles_local=MILES_LOCAL_DIR)
-server_image = serving_image.build_serving_image(hf_cache_path=str(HF_CACHE_PATH), delta_volume_name=exp.DELTA_VOLUME_NAME, experiment=EXPERIMENT, run_id=RUN_ID)
+server_image = serving_image.build_serving_image(
+    hf_cache_path=str(HF_CACHE_PATH),
+    delta_volume_name=exp.DELTA_VOLUME_NAME,
+    experiment=EXPERIMENT,
+    run_id=RUN_ID,
+    extra_env=getattr(exp, "SGLANG_SERVER_ENV", None),
+)
 if MILES_LOCAL_DIR:
     server_image = server_image.add_local_dir(MILES_LOCAL_DIR, remote_path=MILES_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])
 

--- a/cookbook/miles_disagg/configs/glm45_air_fp8.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8.py
@@ -13,6 +13,11 @@ LOCAL_CHECKPOINT_PATH = None
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 SGLANG_DELTA_UPDATE_MODE = "cpu"
+SGLANG_SERVER_ENV = {
+    # SGLang v0.5.16's FA3 backend lacks EAGLE's post-draft overlap-plan hook.
+    # Prepare verification metadata on the main stream while keeping EAGLE enabled.
+    "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
+}
 
 MODEL_TAG = "glm45-air"
 SOURCE_MODEL = "zai-org/GLM-4.5-Air"
@@ -32,9 +37,16 @@ SGLANG_SERVER_ARGS = {
     "--cpu-weight-cache-max-compile-group-gb": "8",
     "--weight-loader-drop-cache-after-load": "",
     "--dtype": "auto",
+    # Run the checkpoint's bundled MTP head for a three-step EAGLE draft.
+    "--speculative-algorithm": "EAGLE",
+    "--speculative-num-steps": "3",
+    "--speculative-eagle-topk": "1",
+    "--speculative-num-draft-tokens": "4",
     "--reasoning-parser": "glm45",
     "--tool-call-parser": "glm",
     "--dist-timeout": "3600",
+    "--kv-cache-dtype": "fp8_e4m3",  # Lower decode bandwidth; slightly changes KV numerics.
+    "--disable-shared-experts-fusion": "",  # Recommended for GLM-4.5 FP8.
     "--context-length": "32768",
     "--mem-fraction-static": "0.7",
     "--chunked-prefill-size": "8192",

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -32,6 +32,11 @@ SGLANG_SERVER_ARGS = {
     "--load-format": "fastsafetensors",
     "--model-loader-extra-config": '{"enable_gds":false}',
     "--weight-loader-drop-cache-after-load": "",
+    # Run the checkpoint's bundled MTP head for a three-step EAGLE draft.
+    "--speculative-algorithm": "EAGLE",
+    "--speculative-num-steps": "3",
+    "--speculative-eagle-topk": "1",
+    "--speculative-num-draft-tokens": "4",
     # The pinned SGLang has no GLM-5.2 parser; these are the closest available formats.
     "--reasoning-parser": "glm45",
     "--tool-call-parser": "glm47",


### PR DESCRIPTION
## Summary

- enable the bundled MTP head for GLM-4.5-Air FP8 and GLM-5.2 NVFP4 rollouts
- use the three-step, top-k-one EAGLE configuration supported by SGLang for both checkpoints
- allow model recipes to override SGLang server environment settings through the existing image builder
- keep GLM-4.5 verification planning on the main stream because SGLang v0.5.16's FA3 path lacks the post-draft overlap hook

## Validation

- `uv run ruff check .`
- `uv run pytest` (79 passed)
- GLM-4.5-Air FP8: ten weight updates plus a mid-run replica join; fluent generation and EAGLE acceptance continued across CPU-staged target commits
- GLM-5.2 NVFP4 GPU validation pending

This is stacked on #79 so the GLM-5.2 recipe uses the finalized SGLang fork pin.
