### PR TITLE
Serve GLM-5.2 from NVIDIA NVFP4 checkpoint

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -12,7 +12,7 @@ loading for quantized rollout models.
 SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.16"
 SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
 SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.16"
-SGLANG_FORK_COMMIT = "6307bce368456caebda3535e63d17f9d7c287127"
+SGLANG_FORK_COMMIT = "40800da7a23016b9dba7d37642d92857926b1ad6"
 ```
 
 The branch is upstream v0.5.16 plus:
@@ -27,7 +27,7 @@ The branch is upstream v0.5.16 plus:
 | `e0859b7390` | Stream CPU delta lineages through bounded memory. |
 | `77eca472e6` | Fold disk XOR lineages with bounded positional I/O. |
 | `526e0ddca2` | Fail cache-flushing CPU commits before GPU mutation when the engine is busy. |
-| `6307bce368` | Normalize ModelOpt FP4 expert tensors through their native loader path. |
+| `40800da7a2` | Load native ModelOpt FP4 expert tensors through their existing loader path. |
 
 The image and branch must use the same SGLang release because Stitch overlays
 Python code onto the image’s existing CUDA and C++ extensions.

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -19,7 +19,7 @@ import modal
 SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.16"
 SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
 SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.16"
-SGLANG_FORK_COMMIT = "6307bce368456caebda3535e63d17f9d7c287127"
+SGLANG_FORK_COMMIT = "40800da7a23016b9dba7d37642d92857926b1ad6"
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent
 

--- a/cookbook/miles_disagg/MILES_FORK.md
+++ b/cookbook/miles_disagg/MILES_FORK.md
@@ -7,11 +7,11 @@ executable source of truth:
 ```python
 MILES_IMAGE_TAG = "radixark/miles:dev-202607260602"
 MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
-MILES_REPO_REF = "d814b87c32d3de528ec1536700e79406ee40bf20"
+MILES_REPO_REF = "1eb752001dd719fbb111e844a291918bb896e2df"
 ```
 
 The branch `stitch-weight-sync-v0516` is upstream `radixark/miles` main at
-`52403d0e3` plus five commits:
+`52403d0e3` plus six commits:
 
 | Commit | Responsibility |
 | --- | --- |
@@ -20,6 +20,7 @@ The branch `stitch-weight-sync-v0516` is upstream `radixark/miles` main at
 | `cf56d32b0` | Encode zero-dimensional quantization scalars by flattening before their byte view. |
 | `748f1724a` | Use SGLang’s staged checkpoint API for Miles-managed disk-delta engines. |
 | `d814b87c3` | Replace the unused delta progress bar with an explicit baseline-snapshot log. |
+| `1eb752001` | Honor ModelOpt glob exclusions when exporting NVFP4 weights. |
 
 The dated base image supplies Megatron-LM, TransformerEngine, CUDA, and the
 other compiled dependencies. The fork is installed over it with `--no-deps`;
@@ -50,7 +51,7 @@ layouts as the base checkpoint.
 When updating Miles:
 
 1. create a new branch from the desired `radixark/miles` main;
-2. reapply the five responsibilities separately, dropping code already
+2. reapply the six responsibilities separately, dropping code already
    available upstream;
 3. keep canonical checkpoint layout changes scoped to `disk-delta`;
 4. use a dated Miles image whose Megatron and TransformerEngine match that

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -14,8 +14,12 @@ DELTA_VOLUME_NAME = "stitch-delta-glm5-2-nvfp4"
 DELTA_BULLETIN_ROOT = "/delta-bulletin"
 LOCAL_CHECKPOINT_PATH = "/local-checkpoint"
 
-# GLM-5.2 ships bf16 (unlike Kimi's INT4): the bf16 masters ARE the source, no dequant.
+# GLM-5.2 ships BF16 training masters and an NVIDIA NVFP4 rollout checkpoint.
 SOURCE_MODEL = "zai-org/GLM-5.2"
+ROLLOUT_SOURCE_MODEL = "nvidia/GLM-5.2-NVFP4"
+ROLLOUT_SOURCE_REVISION = "aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa"
+SERVED_CHECKPOINT_FORMAT = "nvfp4"
+CHECKPOINT_PREP_REQUIRES_GPU = False
 MODEL_TAG = "glm5-2"
 
 SIDECAR_COMMIT_MODE = "in_place"
@@ -32,11 +36,6 @@ SGLANG_SERVER_ARGS = {
     "--load-format": "fastsafetensors",
     "--model-loader-extra-config": '{"enable_gds":false}',
     "--weight-loader-drop-cache-after-load": "",
-    # Run the checkpoint's bundled MTP head for a three-step EAGLE draft.
-    "--speculative-algorithm": "EAGLE",
-    "--speculative-num-steps": "3",
-    "--speculative-eagle-topk": "1",
-    "--speculative-num-draft-tokens": "4",
     # The pinned SGLang has no GLM-5.2 parser; these are the closest available formats.
     "--reasoning-parser": "glm45",
     "--tool-call-parser": "glm47",
@@ -48,11 +47,6 @@ SGLANG_SERVER_ARGS = {
     "--chunked-prefill-size": "16384",
     "--schedule-conservativeness": "0.5",
     "--schedule-policy": "lpm",
-    "--enable-hierarchical-cache": "",
-    "--hicache-ratio": "2",
-    "--hicache-io-backend": "kernel",
-    "--hicache-mem-layout": "page_first",
-    "--hicache-write-policy": "write_through",
     "--skip-server-warmup": "",
     "--enable-return-routed-experts": "",  # routing replay (DeepSeek-V3-arch MoE)
 }

--- a/cookbook/miles_disagg/prep.py
+++ b/cookbook/miles_disagg/prep.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import threading
 import time
@@ -25,8 +26,8 @@ def prepare_checkpoints(exp, prep_volume) -> None:
     """Build the bf16 masters (trainer arch source) + the served base on a GPU.
 
     masters (bf16): a quantized source (Kimi INT4) is dequantized; a bf16 source IS the
-    masters. served base: bf16 = masters; fp8 = the published ROLLOUT_SOURCE_MODEL; nvfp4 =
-    miles' TE-direct quantizer over the masters (packing == the trainer's export packing).
+    masters. served base: bf16 = masters; a published ROLLOUT_SOURCE_MODEL is copied
+    directly; otherwise NVFP4 is built with Miles' TE-direct quantizer over the masters.
     """
     if getattr(exp, "DISABLE_HF_XET", False):
         os.environ["HF_HUB_DISABLE_XET"] = "1"
@@ -61,14 +62,26 @@ def prepare_checkpoints(exp, prep_volume) -> None:
         print(f"Prepared masters={bf16_dir} served_base={bf16_dir}")
         return
 
-    if served_format == "fp8":
-        fp8_source = getattr(exp, "ROLLOUT_SOURCE_MODEL", None)
-        if not fp8_source:
-            raise SystemExit("SERVED_CHECKPOINT_FORMAT='fp8' requires ROLLOUT_SOURCE_MODEL")
-        _staged(fp8_dir, lambda out: _copy_tree("fp8 served base", snapshot_download(fp8_source), out))
+    rollout_source = getattr(exp, "ROLLOUT_SOURCE_MODEL", None)
+    if rollout_source:
+        rollout_revision = getattr(exp, "ROLLOUT_SOURCE_REVISION", None)
+        served_dir = fp8_dir if served_format == "fp8" else nvfp4_dir
+
+        def _download_rollout_checkpoint(out: str) -> None:
+            snapshot_download(
+                rollout_source,
+                revision=rollout_revision,
+                local_dir=out,
+            )
+            shutil.rmtree(os.path.join(out, ".cache"), ignore_errors=True)
+
+        _staged(served_dir, _download_rollout_checkpoint, resume=True)
         prep_volume.commit()
-        print(f"Prepared masters={bf16_dir} served_base={fp8_dir}")
+        print(f"Prepared masters={bf16_dir} served_base={served_dir}")
         return
+
+    if served_format == "fp8":
+        raise SystemExit("SERVED_CHECKPOINT_FORMAT='fp8' requires ROLLOUT_SOURCE_MODEL")
 
     # nvfp4: miles' TE-direct quantizer. bf16 carve-outs must match the trainer's
     # --num-layers-at-start/end-in-bf16 so the served base == the export layout.
@@ -157,14 +170,15 @@ def _copy_tree(label: str, src: str, dst: str) -> None:
     print(f"copied {label}: {total_gb:.0f} GB", flush=True)
 
 
-def _staged(final_dir: str, build) -> None:
+def _staged(final_dir: str, build, *, resume: bool = False) -> None:
     """Build into a .partial sibling and atomically rename, so an interrupted step never
     leaves a half-built dir the reuse check mistakes for complete."""
     if os.path.isdir(final_dir) and os.listdir(final_dir):
         print(f"reusing existing {final_dir}")
         return
     partial = f"{final_dir}.partial"
-    subprocess.run(["rm", "-rf", partial], check=True)
+    if not resume:
+        subprocess.run(["rm", "-rf", partial], check=True)
     os.makedirs(partial, exist_ok=True)
     build(partial)
     os.rename(partial, final_dir)

--- a/cookbook/miles_disagg/prep_app.py
+++ b/cookbook/miles_disagg/prep_app.py
@@ -37,11 +37,17 @@ data_volume = modal.Volume.from_name("miles-data", create_if_missing=True, versi
 prep_volume = modal.Volume.from_name("miles-prep-checkpoints", create_if_missing=True, version=2)
 
 app = modal.App(f"{exp.APP_NAME}-prep")
+checkpoint_gpu = (
+    f"{modal_cfg.gpu}:1"
+    if getattr(exp, "CHECKPOINT_PREP_REQUIRES_GPU", True)
+    else None
+)
 
 
 @app.function(
-    image=image, gpu=f"{modal_cfg.gpu}:1",
+    image=image, gpu=checkpoint_gpu,
     volumes={str(HF_CACHE_PATH): hf_cache_volume, str(PREP_PATH): prep_volume},
+    memory=modal_cfg.trainer_memory_mib,
     timeout=6 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
 )
 def prepare_checkpoints() -> None:

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -20,7 +20,7 @@ from cookbook.common import trainer_image as common_trainer_image
 # a moved mutable tag, so `latest` silently serves whatever was first pulled.
 MILES_IMAGE_TAG = "radixark/miles:dev-202607260602"
 MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
-MILES_REPO_REF = "d814b87c32d3de528ec1536700e79406ee40bf20"  # stitch-weight-sync-v0516
+MILES_REPO_REF = "1eb752001dd719fbb111e844a291918bb896e2df"  # stitch-weight-sync-v0516
 
 MILES_ROOT = "/root/miles"
 # Source-only megatron.training must be on PYTHONPATH.


### PR DESCRIPTION
## What changed

- pin Miles glob-aware ModelOpt exclusions so NVFP4 exports preserve the vendor BF16 shared-expert layout
- let checkpoint preparation stage a pinned published FP8 or NVFP4 rollout checkpoint directly and resume interrupted downloads
- serve GLM-5.2 from NVIDIA's pinned NVFP4 checkpoint while retaining the BF16 training master and torch-distributed trainer checkpoint
- pin the narrowed SGLang native-FP4 expert loader fix
- remove HiCache and speculative decoding from the GLM-5.2 rollout recipe

## Why

The rollout checkpoint is a distinct artifact from the BF16 training master. Downloading the published quantized artifact preserves its exact ModelOpt layout and avoids an unnecessary local reconversion. The preparation path remains shared by published FP8 and NVFP4 checkpoints, while converter-built NVFP4 remains available for models without a published rollout target.

## Validation

- `uv run pytest -q`: 79 passed
- `uv run ruff check .`: passed
- SGLang repository pre-commit checks and native ModelOpt FP4 loader unit tests: passed
- Miles repository pre-commit checks: passed
- official preparation completed for the pinned 464.8 GB NVIDIA checkpoint; its index contains 232,385 tensors
- target-model loading completed on 4x B300
