### PR TITLE
Cookbook: support external speculative draft volumes

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -24,6 +24,14 @@ See the paired
 Memory sizing and SGLang implementation details are in
 [`SGLANG_FORK.md`](common/SGLANG_FORK.md).
 
+## External speculative drafts
+
+Set `modal.draft_volume` and, for a volume in another Modal environment,
+`modal.draft_volume_env`. The rollout server mounts the volume at `/draft`;
+point `--speculative-draft-model-path` at the checkpoint beneath it. Draft
+weights are loaded at startup and remain fixed across target-weight updates.
+Bundled MTP heads do not need a separate volume.
+
 ## Prepare and launch
 
 Miles:

--- a/cookbook/common/config.py
+++ b/cookbook/common/config.py
@@ -19,6 +19,8 @@ class ModalConfig:
     trainer_memory_mib: tuple[int, int] | None = None
     cloud: str | None = None
     region: str | None = None
+    draft_volume: str | None = None
+    draft_volume_env: str | None = None
     rollout_min_containers: int = 2
     rollout_max_containers: int | None = None
     # Flash autoscaler target: keep well below sglang engine concurrency so Flash adds

--- a/cookbook/common/constants.py
+++ b/cookbook/common/constants.py
@@ -12,6 +12,7 @@ HF_CACHE_PATH = Path("/root/.cache/huggingface")
 DATA_PATH = Path("/data")
 CHECKPOINTS_PATH = Path("/checkpoints")
 PREP_PATH = Path("/prep")  # <PREP>/<tag>/{bf16 masters, served base, torch_dist ref_load}
+DRAFT_PATH = Path("/draft")
 SGLANG_CACHE_PATH = "/root/.cache/sglang"  # sglang kernel/JIT cache; survives cold starts
 
 # Ports.

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -34,6 +34,7 @@ from cookbook.common import launch, ray_cluster, server, serving_image
 from cookbook.common.constants import (
     CHECKPOINTS_PATH,
     DATA_PATH,
+    DRAFT_PATH,
     HF_CACHE_PATH,
     MINUTES,
     PREP_PATH,
@@ -82,6 +83,15 @@ checkpoints_volume = modal.Volume.from_name("miles-checkpoints", create_if_missi
 prep_volume = modal.Volume.from_name("miles-prep-checkpoints", create_if_missing=True, version=2)
 sglang_cache_volume = modal.Volume.from_name("sglang-cache", create_if_missing=True, version=2)  # survives cold starts
 delta_volume = modal.Volume.from_name(exp.DELTA_VOLUME_NAME, create_if_missing=True, version=2)
+draft_volume = (
+    modal.Volume.from_name(
+        modal_cfg.draft_volume,
+        environment_name=modal_cfg.draft_volume_env,
+        version=2,
+    )
+    if modal_cfg.draft_volume
+    else None
+)
 
 train_volumes = {
     str(HF_CACHE_PATH): hf_cache_volume,
@@ -113,6 +123,7 @@ SGLANG_SERVER_ARGS = {
         str(PREP_PATH): prep_volume,
         SGLANG_CACHE_PATH: sglang_cache_volume,
         exp.DELTA_BULLETIN_ROOT: delta_volume,
+        **({str(DRAFT_PATH): draft_volume} if draft_volume is not None else {}),
     },
     min_containers=modal_cfg.rollout_min_containers, max_containers=modal_cfg.rollout_max_containers,
     timeout=40 * MINUTES, scaledown_window=15 * MINUTES,

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -34,6 +34,7 @@ from cookbook.common import launch, ray_cluster, server, serving_image
 from cookbook.common.constants import (
     CHECKPOINTS_PATH,
     DATA_PATH,
+    DRAFT_PATH,
     HF_CACHE_PATH,
     MINUTES,
     RAY_PORT,
@@ -74,6 +75,15 @@ data_volume = modal.Volume.from_name("slime-data", create_if_missing=True, versi
 checkpoints_volume = modal.Volume.from_name("slime-checkpoints", create_if_missing=True, version=2)
 sglang_cache_volume = modal.Volume.from_name("sglang-cache", create_if_missing=True, version=2)
 delta_volume = modal.Volume.from_name(exp.DELTA_VOLUME_NAME, create_if_missing=True, version=2)
+draft_volume = (
+    modal.Volume.from_name(
+        modal_cfg.draft_volume,
+        environment_name=modal_cfg.draft_volume_env,
+        version=2,
+    )
+    if modal_cfg.draft_volume
+    else None
+)
 
 train_volumes = {
     str(HF_CACHE_PATH): hf_cache_volume,
@@ -104,6 +114,7 @@ SGLANG_SERVER_ARGS = {
         str(HF_CACHE_PATH): hf_cache_volume,
         SGLANG_CACHE_PATH: sglang_cache_volume,
         exp.DELTA_BULLETIN_ROOT: delta_volume,
+        **({str(DRAFT_PATH): draft_volume} if draft_volume is not None else {}),
     },
     min_containers=modal_cfg.rollout_min_containers, max_containers=modal_cfg.rollout_max_containers,
     timeout=40 * MINUTES, scaledown_window=15 * MINUTES,


### PR DESCRIPTION
## Summary

- add optional draft-volume configuration to shared Modal infrastructure
- mount external draft checkpoints at `/draft` in Miles and Slime rollout servers
- document how model recipes select a checkpoint with `--speculative-draft-model-path`

Draft weights remain fixed while Stitch updates target-model weights. Existing recipes keep their current behavior.

## Validation

- `uv run pytest -q` — 79 passed
- `uv run ruff check cookbook/common/config.py cookbook/common/constants.py cookbook/miles_disagg/app.py cookbook/slime_disagg/app.py`
- `git diff --check`