### PR TITLE
cookbook: validate quantized and speculative weight updates

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -30,7 +30,9 @@ Set `modal.draft_volume` and, for a volume in another Modal environment,
 `modal.draft_volume_env`. The rollout server mounts the volume at `/draft`;
 point `--speculative-draft-model-path` at the checkpoint beneath it. Draft
 weights are loaded at startup and remain fixed across target-weight updates.
-Bundled MTP heads do not need a separate volume.
+The draft acceptance rate may change as the target evolves; changing both
+models requires restarting the replica because they cannot yet be committed
+atomically. Bundled MTP heads do not need a separate volume.
 
 ## Prepare and launch
 
@@ -99,4 +101,7 @@ uv run --extra modal modal run -d \
 ```
 
 They exercise generation during staging, commit the prepared target, validate
-post-update generation, and report timing and resource usage.
+post-update generation, and report timing and resource usage. On the pinned
+SGLang, DFlash and DSPARK reject logprob-returning generation requests while
+speculation is enabled. The profiler therefore checks repeated deterministic
+text for those algorithms and uses token IDs plus logprobs otherwise.

--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -12,7 +12,7 @@ loading for quantized rollout models.
 SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.16"
 SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
 SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.16"
-SGLANG_FORK_COMMIT = "40800da7a23016b9dba7d37642d92857926b1ad6"
+SGLANG_FORK_COMMIT = "a562908a10fb67509a906c7c9ed8d7ff105c7a28"
 ```
 
 The branch is upstream v0.5.16 plus:
@@ -27,7 +27,7 @@ The branch is upstream v0.5.16 plus:
 | `e0859b7390` | Stream CPU delta lineages through bounded memory. |
 | `77eca472e6` | Fold disk XOR lineages with bounded positional I/O. |
 | `526e0ddca2` | Fail cache-flushing CPU commits before GPU mutation when the engine is busy. |
-| `40800da7a2` | Load native ModelOpt FP4 expert tensors through their existing loader path. |
+| `a562908a10` | Normalize native ModelOpt FP4 expert tensors through their existing loader path. |
 
 The image and branch must use the same SGLang release because Stitch overlays
 Python code onto the image’s existing CUDA and C++ extensions.

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -19,7 +19,7 @@ import modal
 SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.16"
 SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
 SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.16"
-SGLANG_FORK_COMMIT = "40800da7a23016b9dba7d37642d92857926b1ad6"
+SGLANG_FORK_COMMIT = "a562908a10fb67509a906c7c9ed8d7ff105c7a28"
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent
 

--- a/cookbook/miles_disagg/MILES_FORK.md
+++ b/cookbook/miles_disagg/MILES_FORK.md
@@ -7,7 +7,7 @@ executable source of truth:
 ```python
 MILES_IMAGE_TAG = "radixark/miles:dev-202607260602"
 MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
-MILES_REPO_REF = "1eb752001dd719fbb111e844a291918bb896e2df"
+MILES_REPO_REF = "1eb7520018446cb94b7406715f66dff1a271b53b"
 ```
 
 The branch `stitch-weight-sync-v0516` is upstream `radixark/miles` main at

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -39,9 +39,11 @@ SGLANG_SERVER_ARGS = {
     # The pinned SGLang has no GLM-5.2 parser; these are the closest available formats.
     "--reasoning-parser": "glm45",
     "--tool-call-parser": "glm47",
+    "--trust-remote-code": "",
+    "--quantization": "modelopt_fp4",
+    "--moe-runner-backend": "flashinfer_trtllm",
     "--dist-timeout": "3600",
     "--kv-cache-dtype": "fp8_e4m3",
-    "--attention-backend": "tokenspeed_mla",
     "--context-length": "32768",
     "--mem-fraction-static": "0.85",
     "--chunked-prefill-size": "16384",
@@ -86,7 +88,8 @@ class _Miles(MilesConfig):
     num_gpus_per_node = 8
     colocate = False
     rollout_num_gpus = 0
-    rollout_num_gpus_per_engine = 4  # TODO(glm5.2): B200s per rollout engine (fit the base)
+    # TODO(glm5.2): Size B200s per rollout engine to the served checkpoint.
+    rollout_num_gpus_per_engine = 4
     rollout_endpoint_url = None
     use_miles_router = True
 

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -20,7 +20,7 @@ from cookbook.common import trainer_image as common_trainer_image
 # a moved mutable tag, so `latest` silently serves whatever was first pulled.
 MILES_IMAGE_TAG = "radixark/miles:dev-202607260602"
 MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
-MILES_REPO_REF = "1eb752001dd719fbb111e844a291918bb896e2df"  # stitch-weight-sync-v0516
+MILES_REPO_REF = "1eb7520018446cb94b7406715f66dff1a271b53b"  # stitch-weight-sync-v0516
 
 MILES_ROOT = "/root/miles"
 # Source-only megatron.training must be on PYTHONPATH.

--- a/tools/profiling/_delta_weight_update.py
+++ b/tools/profiling/_delta_weight_update.py
@@ -1,4 +1,4 @@
-"""Private shared runner for the two SGLang delta weight-update profilers.
+"""Shared runner for SGLang delta weight-update profilers.
 
 Model-specific Modal apps supply the checkpoint paths, recorded delta, GPU
 shape, and direct SGLang arguments. This module owns the benchmark sequence:
@@ -86,25 +86,68 @@ def _post(
     return body
 
 
-def _generate(url: str, *, fingerprint: bool = False) -> dict[str, Any]:
+def _generate(
+    url: str,
+    *,
+    fingerprint: bool = False,
+    fingerprint_logprobs: bool = True,
+) -> dict[str, Any]:
     import httpx
 
     started = time.perf_counter()
+    models_response = httpx.get(
+        f"{url}/v1/models",
+        timeout=30,
+        trust_env=False,
+    )
+    models_response.raise_for_status()
+    model = models_response.json()["data"][0]["id"]
+    messages = [
+        {
+            "role": "user",
+            "content": "Explain in exactly three short clauses why the Moon has phases.",
+        }
+    ]
+    if not fingerprint or not fingerprint_logprobs:
+        response = httpx.post(
+            f"{url}/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": messages,
+                "temperature": 0,
+                "max_tokens": 96 if fingerprint else 80,
+            },
+            timeout=300,
+            trust_env=False,
+        )
+        response.raise_for_status()
+        body = response.json()
+        message = body["choices"][0]["message"]
+        text = message.get("content") or message.get("reasoning_content") or ""
+        if len(text.split()) < 8 or sum(character.isalpha() for character in text) < 25:
+            raise RuntimeError(f"completion was not plausibly fluent: {text!r}")
+        result = {
+            "wall_s": round(time.perf_counter() - started, 6),
+            "text": text,
+            "weight_version": (body.get("metadata") or {}).get("weight_version"),
+        }
+        if fingerprint:
+            result["output_ids"] = []
+            result["output_logprobs"] = []
+        return result
+
     response = httpx.post(
         f"{url}/generate",
         json={
-            "text": (
-                "Correctness probe 7f31c9: Explain in exactly three short "
-                "clauses why the Moon has phases."
-            ),
+            "text": "Explain why the Moon has phases in exactly three short clauses.",
             "sampling_params": {
                 "temperature": 0,
                 "max_new_tokens": 48 if fingerprint else 80,
                 "ignore_eos": fingerprint,
             },
-            "return_logprob": fingerprint,
+            "return_logprob": fingerprint and fingerprint_logprobs,
             "return_text_in_logprobs": False,
-            "top_logprobs_num": 1 if fingerprint else 0,
+            "top_logprobs_num": 1 if fingerprint and fingerprint_logprobs else 0,
             "logprob_start_len": -1,
             "stream": False,
         },
@@ -114,8 +157,6 @@ def _generate(url: str, *, fingerprint: bool = False) -> dict[str, Any]:
     response.raise_for_status()
     body = response.json()
     text = body.get("text") or ""
-    if len(text.split()) < 8 or sum(character.isalpha() for character in text) < 25:
-        raise RuntimeError(f"completion was not plausibly fluent: {text!r}")
     result = {
         "wall_s": round(time.perf_counter() - started, 6),
         "text": text,
@@ -128,10 +169,12 @@ def _generate(url: str, *, fingerprint: bool = False) -> dict[str, Any]:
             float(item[0] if isinstance(item, (list, tuple)) else item)
             for item in raw_logprobs
         ]
-        if not result["output_ids"] or len(result["output_ids"]) != len(
+        if fingerprint_logprobs and not result["output_ids"]:
+            raise RuntimeError("fingerprint token IDs are incomplete")
+        if fingerprint_logprobs and len(result["output_ids"]) != len(
             result["output_logprobs"]
         ):
-            raise RuntimeError("fingerprint token IDs/logprobs are incomplete")
+            raise RuntimeError("fingerprint logprobs are incomplete")
     return result
 
 
@@ -143,38 +186,46 @@ def _assert_repeat_consistency(
         raise RuntimeError("repeated fingerprint token IDs differ")
     if first["text"] != second["text"]:
         raise RuntimeError("repeated fingerprint text differs")
-    max_logprob_difference = max(
-        (
-            abs(left - right)
-            for left, right in zip(
-                first["output_logprobs"],
-                second["output_logprobs"],
-                strict=True,
-            )
-        ),
-        default=0.0,
+    max_logprob_difference = (
+        max(
+            (
+                abs(left - right)
+                for left, right in zip(
+                    first["output_logprobs"],
+                    second["output_logprobs"],
+                    strict=True,
+                )
+            ),
+            default=0.0,
+        )
+        if first["output_logprobs"]
+        else None
     )
-    return {
-        "exact_token_ids": True,
+    result = {
         "exact_text": True,
-        "tokens": len(first["output_ids"]),
-        "repeat_max_logprob_abs_diff": max_logprob_difference,
         **_fingerprint_hashes(first),
     }
+    if first["output_ids"]:
+        result["exact_token_ids"] = True
+        result["tokens"] = len(first["output_ids"])
+    if max_logprob_difference is not None:
+        result["repeat_max_logprob_abs_diff"] = max_logprob_difference
+    return result
 
 
 def _fingerprint_hashes(fingerprint: dict[str, Any]) -> dict[str, str]:
     token_ids = fingerprint["output_ids"]
     output_logprobs = fingerprint["output_logprobs"]
-    return {
-        "token_ids_sha256": hashlib.sha256(
+    hashes = {"text_sha256": hashlib.sha256(fingerprint["text"].encode()).hexdigest()}
+    if token_ids:
+        hashes["token_ids_sha256"] = hashlib.sha256(
             struct.pack(f"<{len(token_ids)}q", *token_ids)
-        ).hexdigest(),
-        "text_sha256": hashlib.sha256(fingerprint["text"].encode()).hexdigest(),
-        "logprobs_sha256": hashlib.sha256(
+        ).hexdigest()
+    if output_logprobs:
+        hashes["logprobs_sha256"] = hashlib.sha256(
             struct.pack(f"<{len(output_logprobs)}d", *output_logprobs)
-        ).hexdigest(),
-    }
+        ).hexdigest()
+    return hashes
 
 
 def _assert_target_changed(
@@ -183,7 +234,9 @@ def _assert_target_changed(
 ) -> dict[str, Any]:
     token_ids_changed = baseline["output_ids"] != target["output_ids"]
     text_changed = baseline["text"] != target["text"]
-    if len(baseline["output_logprobs"]) == len(target["output_logprobs"]):
+    if baseline["output_logprobs"] and len(baseline["output_logprobs"]) == len(
+        target["output_logprobs"]
+    ):
         max_logprob_difference = max(
             (
                 abs(left - right)
@@ -197,7 +250,9 @@ def _assert_target_changed(
         )
     else:
         max_logprob_difference = None
-    logprobs_changed = max_logprob_difference is None or max_logprob_difference > 0.0
+    logprobs_changed = (
+        max_logprob_difference is not None and max_logprob_difference > 0.0
+    )
     if not (token_ids_changed or text_changed or logprobs_changed):
         raise RuntimeError("post-update fingerprint is identical to the base model")
     return {
@@ -362,10 +417,7 @@ def _print_profile_summary(results: dict[str, Any]) -> None:
         if key in results
     }
     summary["critical_rank_stage_s"] = max(
-        (
-            rank.get("wall_s", rank.get("total_wall_s", 0.0))
-            for rank in stage_ranks
-        ),
+        (rank.get("wall_s", rank.get("total_wall_s", 0.0)) for rank in stage_ranks),
         default=None,
     )
     destination_init_ranks = results.get("destination_init_rank_stats") or []
@@ -440,7 +492,27 @@ def run_delta_weight_update(
         )
         results["memory_after_initial_load"] = _memory_snapshot()
         results["generation_before"] = _generate(url)
-        baseline_fingerprint = _generate(url, fingerprint=True)
+        speculative_algorithm = spec.server_args.get(
+            "--speculative-algorithm", ""
+        ).upper()
+        # These SGLang speculative workers reject return_logprob requests.
+        fingerprint_logprobs = speculative_algorithm not in {"DFLASH", "DSPARK"}
+        baseline_fingerprint = _generate(
+            url,
+            fingerprint=True,
+            fingerprint_logprobs=fingerprint_logprobs,
+        )
+        if not fingerprint_logprobs:
+            _assert_repeat_consistency(
+                [
+                    baseline_fingerprint,
+                    _generate(
+                        url,
+                        fingerprint=True,
+                        fingerprint_logprobs=False,
+                    ),
+                ]
+            )
         results["fingerprint_before"] = {
             "wall_s": baseline_fingerprint["wall_s"],
             "weight_version": baseline_fingerprint["weight_version"],
@@ -484,8 +556,8 @@ def run_delta_weight_update(
                     f"{generation.summary()}"
                 )
             if update_mode == "disk":
-                results["destination_init_cache_drop"] = (
-                    _drop_checkpoint_page_cache(spec.local_target_checkpoint_dir)
+                results["destination_init_cache_drop"] = _drop_checkpoint_page_cache(
+                    spec.local_target_checkpoint_dir
                 )
 
             stage_started = time.perf_counter()
@@ -518,8 +590,7 @@ def run_delta_weight_update(
             results["memory_after_stage"] = _memory_snapshot()
             if generation.errors or not generation.samples:
                 raise RuntimeError(
-                    "generation was not healthy during staging: "
-                    f"{generation.summary()}"
+                    f"generation was not healthy during staging: {generation.summary()}"
                 )
 
             commit_started = time.perf_counter()
@@ -561,8 +632,16 @@ def run_delta_weight_update(
 
         results["generation_after"] = _generate(url)
         fingerprints = [
-            _generate(url, fingerprint=True),
-            _generate(url, fingerprint=True),
+            _generate(
+                url,
+                fingerprint=True,
+                fingerprint_logprobs=fingerprint_logprobs,
+            ),
+            _generate(
+                url,
+                fingerprint=True,
+                fingerprint_logprobs=fingerprint_logprobs,
+            ),
         ]
         observed_versions = {
             results["generation_after"]["weight_version"],


### PR DESCRIPTION
## What changed

- pin the validated SGLang loader commit and the exact Miles checkpoint-export commit
- align the GLM-5.2 NVFP4 recipe with the official ModelOpt FP4 checkpoint
- make weight-update profiling verify fluent serving before, during, and after staging
- use token/logprob fingerprints where supported and deterministic text fingerprints for DFlash/DSPARK
- document that speculative draft weights remain fixed and that DFlash/DSPARK do not support logprob-returning probes on the pinned runtime

## Why

The native ModelOpt FP4 loader rewrite initially omitted the existing expert-scale name normalization, which left routed-expert scales unloaded. The finalized SGLang pin restores and tests both scale-name and packed-FP4 normalization. DFlash also rejects return-logprob requests while speculation is enabled, so the profiler needs a correctness path that does not mistake that API limitation for a failed weight update.

## Impact

The cookbook pins the exact stack validated with GLM-4.5-Air FP8, Kimi K2.6 NVFP4, GLM-5.2 NVFP4, and SWE-1.7 NVFP4 with DFlash. The profiler now fails on non-fluent generation, mixed versions, nondeterministic repeats, or an unchanged post-update fingerprint.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check` on all changed Python files
- `python -m py_compile` on all changed Python files
- GLM-4.5-Air: 10 training updates with a third rollout replica joining mid-run; all replicas reached version 10
- Kimi K2.6 NVFP4: real CPU-staged delta update passed
- GLM-5.2 NVFP4: controlled CPU-staged update passed
- SWE-1.7 NVFP4 + DFlash: controlled CPU-staged update passed with generation active during initialization and staging
