### PR TITLE
Clarify and consolidate README guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,36 @@
-# stitch
+# Stitch
 
 Stitch synchronizes policy weights from an RL trainer to an elastic rollout
 fleet.
 
-The trainer publishes immutable, versioned full checkpoints or deltas to a
-shared store. Every rollout replica independently converges to the published
-version, and every response reports which version generated it.
+## Guarantees
 
-## What Stitch provides
+- **Updates overlap serving.** Replicas stage and verify the next full
+  checkpoint or delta before briefly gating new requests for the engine commit.
+- **Rollouts are versioned.** Requests can require a minimum or exact version;
+  incompatible replicas return a retryable `409`, and responses report their
+  start and end versions.
+- **The fleet is elastic.** New replicas load the base, catch up to the current
+  version, and enter rotation without trainer coordination.
+- **Publication is failure-safe.** Checkpoint bytes become durable before the
+  shared pointer advances, and a replica reports a version only after its
+  engine commits it.
+- **Integrations are pluggable.** Stores, inference engines, and rollout pools
+  implement the separate `Store`, `Engine`, and `Pool` interfaces.
 
-- **Asynchronous weight updates.** Replicas stage and verify the next version
-  while serving. Only the final engine commit gates new requests.
-- **Version-correct rollouts.** Requests can require a minimum or exact weight
-  version. A replica that cannot satisfy the requirement returns a retryable
-  `409` instead of serving stale weights.
-- **Dynamic rollout fleets.** New replicas load the base checkpoint, catch up to
-  the current version, and enter rotation without trainer coordination.
-- **Failure-safe publication.** Checkpoint bytes become durable before the
-  shared pointer advances, and a replica reports a new version only after its
-  engine commits successfully.
-- **Pluggable infrastructure.** Trainers, stores, inference engines, and rollout
-  pools integrate through separate `Store`, `Engine`, and `Pool` interfaces.
+The trainer publishes immutable versions to a shared store. Replicas reconcile
+independently, so a missed notification delays an update but does not prevent
+convergence.
 
-## How it works
+## Integrations
 
-1. The trainer publishes `weight_vNNNNNN` and advances the shared `latest`
-   pointer.
-2. Each replica materializes and verifies the required full checkpoint or delta
-   lineage.
-3. The replica prepares the target while generation continues, then commits it
-   through a short admission gate.
-4. Requests and responses carry the weight-version information needed for
-   staleness control and sample attribution.
+Stitch includes Modal Volume and S3 stores, SGLang engines, Modal Flash pools,
+and reference Miles and Slime deployments.
 
-Replicas reconcile independently. A missed notification only delays an update:
-periodic reconciliation still converges the fleet to `latest`.
-
-## Included integrations
-
-- Modal Volume and S3 checkpoint stores
-- SGLang rollout engines
-- Modal Flash rollout pools
-- Miles and Slime deployment recipes
-
-The [`cookbook guide`](cookbook/README.md) covers configuration, launch,
-live scaling, and validation. Fork pins and re-porting guidance live in
-[`SGLANG_FORK.md`](cookbook/common/SGLANG_FORK.md) and
-[`MILES_FORK.md`](cookbook/miles_disagg/MILES_FORK.md).
+See the [cookbook](cookbook/README.md) to choose an update mode, launch a run,
+scale the rollout fleet, and validate an update. Fork pins and re-porting notes
+are in [SGLANG_FORK.md](cookbook/common/SGLANG_FORK.md) and
+[MILES_FORK.md](cookbook/miles_disagg/MILES_FORK.md).
 
 ## Development
 

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -1,38 +1,37 @@
 # Cookbook
 
 The cookbook contains working Modal deployments for Miles and Slime trainers
-with SGLang rollout engines. `EXPERIMENT_CONFIG` selects a config from the
-trainer’s `configs` directory.
+with SGLang rollout engines. Select a model through `EXPERIMENT_CONFIG`.
 
-## Weight update mode
+## Choose an update mode
 
-Each recipe sets `SGLANG_DELTA_UPDATE_MODE` explicitly:
+Each recipe sets `SGLANG_DELTA_UPDATE_MODE`:
 
-| Mode | Host state | Commit path | Use when |
+| Mode | Prepared state | Engine commit | Use when |
 | --- | --- | --- | --- |
-| `disk` | Mutable checkpoint on local storage | Load the complete checkpoint from disk | Host RAM is constrained, or the trainer publishes full checkpoints |
-| `cpu` | Canonical checkpoint plus rank-ready weight images in RAM | Copy prepared images to the GPUs | Deltas are used and the shortest engine pause is worth the RAM |
+| `disk` | Complete checkpoint on local storage | Reload from disk | Host RAM is constrained or the trainer publishes full checkpoints |
+| `cpu` | Canonical checkpoint and rank-ready weight images in RAM | Copy the images to GPU | Updates are deltas and minimizing the pause justifies the RAM |
 
-Both modes reconstruct and verify the complete target in canonical checkpoint
-space. CPU mode accepts deltas only; switching runs requires replacing the
-replica. Disk mode accepts full checkpoints and deltas and can reset a live
+Both modes reconstruct and checksum the complete target in canonical checkpoint
+space. CPU mode accepts deltas only and requires a new replica for a new
+lineage. Disk mode accepts full checkpoints and deltas and can reset a live
 replica.
 
 See the paired
 [`glm45_air_fp8`](miles_disagg/configs/glm45_air_fp8.py) and
 [`glm45_air_fp8_disk`](miles_disagg/configs/glm45_air_fp8_disk.py) configs.
-Memory sizing and SGLang implementation details are in
+Memory sizing and SGLang details are in
 [`SGLANG_FORK.md`](common/SGLANG_FORK.md).
 
 ## External speculative drafts
 
-Set `modal.draft_volume` and, for a volume in another Modal environment,
-`modal.draft_volume_env`. The rollout server mounts the volume at `/draft`;
-point `--speculative-draft-model-path` at the checkpoint beneath it. Draft
-weights are loaded at startup and remain fixed across target-weight updates.
-The draft acceptance rate may change as the target evolves; changing both
-models requires restarting the replica because they cannot yet be committed
-atomically. Bundled MTP heads do not need a separate volume.
+Set `modal.draft_volume` and, when needed, `modal.draft_volume_env`. The server
+mounts the volume at `/draft`; set `--speculative-draft-model-path` to the
+checkpoint below it.
+
+Draft weights remain fixed while target weights update. Their acceptance rate
+may change as the target evolves. Updating both atomically requires restarting
+the replica. Bundled MTP heads do not need a separate volume.
 
 ## Prepare and launch
 
@@ -60,24 +59,20 @@ EXPERIMENT_CONFIG=kimi_k2_6_int4 \
   uv run --extra modal python -m cookbook.slime_disagg.launch
 ```
 
-Preparation is idempotent. Each launch creates an isolated run, waits for the
-rollout pool to become ready, starts training, and prints the app name and stop
-command.
+Preparation is idempotent. The launcher creates an isolated run, waits for the
+rollout pool, starts training, and prints the app name and stop command.
 
-## Scale a running rollout fleet
-
-Use the app name printed by the launcher:
+## Scale and inspect a run
 
 ```bash
 uv run --extra modal python -c \
   "from stitch.pools.modal_flash import ModalFlashPool; ModalFlashPool('<app-name>', 'Server').scale(min=4, max=4)"
 ```
 
-New replicas stay out of rotation while loading the base checkpoint and catching
-up to `latest`. They join automatically when ready; the trainer does not need
-per-replica coordination.
-
-## Verify a running pool
+`min` is the number of rollout replicas kept running; `max` is the autoscaling
+ceiling. Setting both to `4` pins the fleet at four replicas. New replicas
+remain outside rotation until they load the base and catch up. Verify the
+gateway and every live replica with:
 
 ```bash
 uv run --extra modal python -m cookbook.common.smoke \
@@ -86,12 +81,9 @@ uv run --extra modal python -m cookbook.common.smoke \
   --weight-version 10
 ```
 
-The smoke check verifies generation and weight-version reporting through the
-pool gateway and every live replica.
+## Profile an update
 
-## Profile one weight update
-
-The GLM-4.5-Air FP8 and Kimi K2.6 NVFP4 profilers accept
+The GLM-4.5-Air FP8 and Kimi K2.6 NVFP4 profilers support
 `--update-mode disk|cpu`:
 
 ```bash
@@ -100,8 +92,7 @@ uv run --extra modal modal run -d \
   --update-mode cpu
 ```
 
-They exercise generation during staging, commit the prepared target, validate
-post-update generation, and report timing and resource usage. On the pinned
-SGLang, DFlash and DSPARK reject logprob-returning generation requests while
-speculation is enabled. The profiler therefore checks repeated deterministic
-text for those algorithms and uses token IDs plus logprobs otherwise.
+They generate during staging, commit the target, validate the new version, and
+report timing and resource use. SGLang rejects logprob-returning requests when
+DFlash or DSPARK is enabled, so those profiles compare repeated deterministic
+text instead of token IDs and logprobs.

--- a/tools/probes/README.md
+++ b/tools/probes/README.md
@@ -1,60 +1,42 @@
-# probes — pressure-test harness (dev-only, never pedagogical)
+# Rollout probes
 
-Disposable instrumentation for certifying the pool + weight-sync protocol under
-realistic and adversarial conditions. Unlike `cookbook/` (best-practice recipes),
-nothing here demonstrates how stitch *should* be used — probes exist to find where
-it breaks and to measure perf under pressure. Expect rough edges; harden a probe
-only when it graduates into the standing regression harness.
+This directory contains a development harness for load-testing a rollout pool
+and observing weight-version convergence. It is not a deployment example.
 
-## Design
+- `traffic.py` sends long-decode, long-prefill, agentic, or mixed traffic and
+  records version attribution.
+- `poller.py` records each replica's version, convergence lag, stage/commit
+  timing, and not-ready windows.
+- `app.py` runs both probes on Modal and stores JSONL results.
 
-A pool certification needs traffic plus replica-state observation:
+## Run
 
-- **`traffic.py`** — reward-free load shapes against the pool gateway:
-  `long_decode`, `long_prefill`, `agentic` (multi-turn sessions with growing
-  context, synthetic tool-result injections, session affinity), `mixed`. Responses
-  carry `weight_version_start/end`, so the generator doubles as the
-  straddle-attribution collector.
-- **`poller.py`** — scrapes every replica's `/server_info` into JSONL and
-  summarizes: applied-version timelines, per-version convergence lag,
-  stage/commit timings, not-ready windows.
-- **`app.py`** — Modal wrapper to run the probes from containers.
-
-## Conventions
-
-- **Environment:** everything probe-related lives in the `stitch-dev` Modal
-  environment (`modal environment create stitch-dev`, once). The target pool must
-  be deployed in the *same* environment — `ModalFlashPool` resolves names in the
-  caller's environment — so deploy the cookbook recipe with `-e stitch-dev` for
-  probe runs.
-- **Results:** JSONL baselines land on the `stitch-probe-results` Volume, one
-  directory per tagged run. Baselines are *recorded and human-judged*, not CI
-  gates — do not wire thresholds into CI.
-
-## Quickstart
+The probes and target pool must use the same Modal environment. Results are
+written under the run tag on the `stitch-probe-results` Volume.
 
 ```bash
-# once
 uv run --extra modal modal environment create stitch-dev
 
-# deploy the target pool (example: glm45_air_fp8) into stitch-dev
-EXPERIMENT_CONFIG=glm45_air_fp8 uv run --extra modal modal deploy -m cookbook.miles_disagg.app -e stitch-dev
+EXPERIMENT_CONFIG=glm45_air_fp8 \
+  uv run --extra modal modal deploy -m cookbook.miles_disagg.app -e stitch-dev
 
-# deploy the probe app
 uv run --extra modal modal deploy -m tools.probes.app -e stitch-dev
 
-# start the poller and traffic
-uv run --extra modal modal run -e stitch-dev -m tools.probes.app::poll --pool-app stitch-glm45-air-fp8 --tag demo &
-uv run --extra modal modal run -e stitch-dev -m tools.probes.app::traffic \
-  --pool-app stitch-glm45-air-fp8 --shape agentic --concurrency 32 --duration 1800 --tag demo &
+uv run --extra modal modal run -e stitch-dev \
+  -m tools.probes.app::poll \
+  --pool-app stitch-glm45-air-fp8 --tag demo
+
+uv run --extra modal modal run -e stitch-dev \
+  -m tools.probes.app::traffic \
+  --pool-app stitch-glm45-air-fp8 \
+  --shape agentic --concurrency 32 --duration 1800 --tag demo
 ```
 
-## Known limitations (skeleton)
+## Limits
 
-- **No TTFT.** The versioned proxy buffers responses (no streaming), so only
-  end-to-end latency is measurable. Revisit when the streaming-proxy decision lands.
-- **Synthetic filler text.** Prompt content is pseudo-text at controlled lengths;
-  swap in real document corpora when content realism starts to matter.
-- **Token counts are approximated** from word counts (~0.75 words/token).
-- Version floor tracking polls the gateway's `/server_info`, which answers from an
-  arbitrary replica — probe-grade, not exact.
+- The versioned proxy does not stream, so the harness measures end-to-end
+  latency but not time to first token.
+- Traffic uses synthetic text and approximate token counts.
+- Version-floor polling samples an arbitrary replica through `/server_info`;
+  use per-replica logs for exact attribution.
+- Recorded baselines are reviewed by humans and are not CI thresholds.


### PR DESCRIPTION
## Summary

- focus the root README on Stitch's guarantees and supported integrations
- keep update-mode, launch, scaling, validation, and profiling guidance in the cookbook README
- reduce the probe README to its purpose, runnable commands, and measurement limits
- define rollout replica scaling and CPU/disk lineage behavior explicitly

## Why

The existing READMEs repeated the same architecture in several forms and mixed product overview, operator instructions, and development tooling. Each README now has one audience and one responsibility while retaining correctness-critical constraints, including fixed speculative drafts and the DFlash/DSPARK logprob limitation.

## Impact

Documentation only. No runtime behavior, configuration, or public API changes.

## Validation

- `git diff --check`
- verified every local documentation link and referenced module/config path against the repository
- reviewed terminology against the `Store`, `Engine`, `Pool`, reconciliation, and scaling implementations
