### PR TITLE
cookbook: support public Kimi K3 MXFP4 weight updates

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -83,8 +83,7 @@ uv run --extra modal python -m cookbook.common.smoke \
 
 ## Profile an update
 
-The GLM-4.5-Air FP8 and Kimi K2.6 NVFP4 profilers support
-`--update-mode disk|cpu`:
+The model profilers support `--update-mode disk|cpu`:
 
 ```bash
 uv run --extra modal modal run -d \
@@ -96,3 +95,12 @@ They generate during staging, commit the target, validate the new version, and
 report timing and resource use. SGLang rejects logprob-returning requests when
 DFlash or DSPARK is enabled, so those profiles compare repeated deterministic
 text instead of token IDs and logprobs.
+
+The K3 profiler downloads the pinned public checkpoint and constructs a
+checksummed XOR publication covering every checkpoint tensor:
+
+```bash
+MODAL_FUNCTION_RUNTIME=runc uv run --extra modal modal run -d \
+  tools/profiling/kimi_k3_mxfp4_delta_weight_update.py \
+  --update-mode cpu
+```

--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -6,13 +6,16 @@ loading for quantized rollout models.
 
 ## Pin
 
-[`serving_image.py`](serving_image.py) is the executable source of truth:
+[`serving_image.py`](serving_image.py) is the executable source of truth for the
+default runtime:
 
 ```python
-SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.16"
-SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
-SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.16"
-SGLANG_FORK_COMMIT = "a562908a10fb67509a906c7c9ed8d7ff105c7a28"
+DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
+    image="lmsysorg/sglang:v0.5.16",
+    repository="https://github.com/modal-projects/sglang.git",
+    branch="stitch-sglang-v0.5.16",
+    commit="a562908a10fb67509a906c7c9ed8d7ff105c7a28",
+)
 ```
 
 The branch is upstream v0.5.16 plus:
@@ -31,6 +34,15 @@ The branch is upstream v0.5.16 plus:
 
 The image and branch must use the same SGLang release because Stitch overlays
 Python code onto the image’s existing CUDA and C++ extensions.
+
+Models that require another upstream SGLang line set `SGLANG_RUNTIME` in their
+configuration. The image, fork branch, and immutable commit stay together so
+the Python overlay remains ABI-compatible with the image.
+
+[`kimi_k3_mxfp4.py`](../miles_disagg/configs/kimi_k3_mxfp4.py) pins the public
+K3 image and `stitch-sglang-kimi-k3` fork. That fork ports the same weight-sync
+responsibilities onto SGLang’s public `kimi-k3` branch; other recipes continue
+to use the v0.5.16 default.
 
 ## API
 
@@ -140,16 +152,18 @@ one canonical checkpoint per host
 + one rank-local runtime image per local TP rank
 ```
 
-Measured TP4 reference costs are:
+Measured reference costs are:
 
-| Model | Canonical checkpoint | Rank image × 4 | Persistent core |
-| --- | ---: | ---: | ---: |
-| GLM-4.5-Air FP8 | 112.6 GB | 27.2 GB × 4 | 221.3 GB |
-| Kimi K2.6 NVFP4 | about 595 GB | about 151 GB × 4 | about 1.20 TB |
+| Model | TP | Canonical checkpoint | Rank image | Persistent core |
+| --- | ---: | ---: | ---: | ---: |
+| GLM-4.5-Air FP8 | 4 | 112.6 GB | 27.2 GB × 4 | 221.3 GB |
+| Kimi K2.6 NVFP4 | 4 | about 595 GB | about 151 GB × 4 | about 1.20 TB |
+| Kimi K3 MXFP4 | 8 | 1.561 TB | 207.5 GB × 8 | 3.221 TB |
 
 Allow additional memory for the engine process, delta decoding, and bounded
 loader staging. The supplied recipes request `(512 GiB, 2 TiB)` for GLM and
-`(1 TiB, 3 TiB)` for Kimi, expressed as `(request, limit)`.
+`(1 TiB, 3 TiB)` for Kimi K2.6, expressed as `(request, limit)`. The K3
+profiler uses `(1 TiB, 4 TiB)`.
 
 All runtime storages are prepared and committed. Element-wise sparsity only
 reduces the compressed delta transport and XOR work.

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -10,22 +10,35 @@ weight staging, correct quantized weight loading, and the optional CPU delta cac
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 import modal
 
-# The base tag MUST match the branch's base tag: the fork overlays python/ only, so the
-# baked kernels/CUDA must be ABI-compatible with it.
-SGLANG_IMAGE_TAG = "lmsysorg/sglang:v0.5.16"
-SGLANG_FORK_REPO = "https://github.com/modal-projects/sglang.git"
-SGLANG_FORK_BRANCH = "stitch-sglang-v0.5.16"
-SGLANG_FORK_COMMIT = "a562908a10fb67509a906c7c9ed8d7ff105c7a28"
+
+@dataclass(frozen=True)
+class SGLangRuntime:
+    """An immutable SGLang source overlay and its ABI-compatible base image."""
+
+    image: str
+    repository: str
+    branch: str
+    commit: str
+
+
+DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
+    image="lmsysorg/sglang:v0.5.16",
+    repository="https://github.com/modal-projects/sglang.git",
+    branch="stitch-sglang-v0.5.16",
+    commit="a562908a10fb67509a906c7c9ed8d7ff105c7a28",
+)
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent
 
 _SERVING_ENV = {
     "HF_XET_HIGH_PERFORMANCE": "1",
     "HF_HUB_ENABLE_HF_TRANSFER": "1",
+    "HF_MODULES_CACHE": "/tmp/huggingface/modules",
     "SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN": "1",
     "SGLANG_DISABLE_CUDNN_CHECK": "1",
     "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "1",
@@ -41,16 +54,22 @@ def build_serving_image(
     run_id: str | None = None,
     extra_packages: Sequence[str] = (),
     extra_env: Mapping[str, str] | None = None,
+    runtime: SGLangRuntime = DEFAULT_SGLANG_RUNTIME,
 ) -> modal.Image:
     """The rollout-pool image. Volume-backed recipes set ``delta_volume_name`` for their
     Store; other Store backends omit it. Backend-specific packages and environment
     belong in ``extra_packages`` / ``extra_env`` so all build steps still precede the
     local source layers."""
     return (
-        modal.Image.from_registry(SGLANG_IMAGE_TAG)
+        modal.Image.from_registry(runtime.image)
         .run_commands(
-            f"cd /sgl-workspace/sglang && git remote add modal-fork {SGLANG_FORK_REPO}"
-            f" && git fetch modal-fork {SGLANG_FORK_BRANCH} && git checkout {SGLANG_FORK_COMMIT} -- python/"
+            "rm -rf /tmp/stitch-sglang-overlay"
+            f" && git clone --filter=blob:none --single-branch --branch {runtime.branch}"
+            f" {runtime.repository} /tmp/stitch-sglang-overlay"
+            f" && git -C /tmp/stitch-sglang-overlay checkout --detach {runtime.commit}"
+            " && rm -rf /sgl-workspace/sglang/python/sglang"
+            " && cp -a /tmp/stitch-sglang-overlay/python/. /sgl-workspace/sglang/python/"
+            " && rm -rf /tmp/stitch-sglang-overlay"
         )
         .run_commands(
             f"rm -rf {hf_cache_path}"

--- a/cookbook/common/serving_image_test.py
+++ b/cookbook/common/serving_image_test.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from cookbook.common import serving_image
+
+
+class _Image:
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+
+    def run_commands(self, command: str) -> _Image:
+        self.commands.append(command)
+        return self
+
+    def pip_install(self, *_packages: str) -> _Image:
+        return self
+
+    def env(self, _values: dict[str, str]) -> _Image:
+        return self
+
+    def add_local_python_source(self, _module: str) -> _Image:
+        return self
+
+    def add_local_dir(self, *_args, **_kwargs) -> _Image:
+        return self
+
+
+def test_build_serving_image_uses_selected_runtime(monkeypatch) -> None:
+    image = _Image()
+    selected_image: list[str] = []
+    monkeypatch.setattr(
+        serving_image.modal.Image,
+        "from_registry",
+        lambda name: selected_image.append(name) or image,
+    )
+    runtime = serving_image.SGLangRuntime(
+        image="example/sglang:image",
+        repository="https://example.com/sglang.git",
+        branch="model-release",
+        commit="0123456789abcdef",
+    )
+
+    serving_image.build_serving_image(
+        hf_cache_path="/cache",
+        experiment="test",
+        runtime=runtime,
+    )
+
+    assert selected_image == [runtime.image]
+    source_overlay = image.commands[0]
+    assert runtime.repository in source_overlay
+    assert runtime.branch in source_overlay
+    assert runtime.commit in source_overlay

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -73,6 +73,7 @@ server_image = serving_image.build_serving_image(
     experiment=EXPERIMENT,
     run_id=RUN_ID,
     extra_env=getattr(exp, "SGLANG_SERVER_ENV", None),
+    runtime=getattr(exp, "SGLANG_RUNTIME", serving_image.DEFAULT_SGLANG_RUNTIME),
 )
 if MILES_LOCAL_DIR:
     server_image = server_image.add_local_dir(MILES_LOCAL_DIR, remote_path=MILES_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])

--- a/cookbook/miles_disagg/configs/kimi_k3_mxfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k3_mxfp4.py
@@ -1,0 +1,51 @@
+"""Kimi K3 rollout server using its native MXFP4 checkpoint."""
+
+from cookbook.common.config import ModalConfig
+from cookbook.common.serving_image import SGLangRuntime
+
+ROLLOUT_SOURCE_MODEL = "moonshotai/Kimi-K3"
+ROLLOUT_SOURCE_REVISION = "9f62e4e9fffbd0a83ddd60e1c209d828994b3569"
+ROLLOUT_NUM_GPUS_PER_ENGINE = 8
+SGLANG_DELTA_UPDATE_MODE = "cpu"
+
+SGLANG_RUNTIME = SGLangRuntime(
+    image=(
+        "lmsysorg/sglang@"
+        "sha256:81a9c00654b3e4c7c681a4728a64fcb4853aa698dc9fea1959bbf4eb26bfb2e5"
+    ),
+    repository="https://github.com/modal-projects/sglang.git",
+    branch="stitch-sglang-kimi-k3",
+    commit="1a87b07642368bbc9a7985edea73548fb3d07203",
+)
+
+SGLANG_SERVER_ARGS = {
+    "--trust-remote-code": "",
+    "--load-format": "fastsafetensors",
+    "--model-loader-extra-config": '{"enable_gds":false}',
+    "--enable-cpu-weight-cache": "",
+    "--cpu-weight-cache-max-compile-group-gb": "8",
+    "--weight-loader-drop-cache-after-load": "",
+    "--dist-timeout": "3600",
+    "--context-length": "1048576",
+    "--max-running-requests": "32",
+    "--cuda-graph-max-bs-decode": "32",
+    "--mem-fraction-static": "0.85",
+    "--kv-cache-dtype": "fp8_e4m3",
+    "--mamba-ssm-dtype": "bfloat16",
+    "--mamba-radix-cache-strategy": "extra_buffer_lazy",
+    "--chunked-prefill-size": "16384",
+    "--schedule-policy": "lpm",
+    "--mm-feature-transport": "cuda_ipc",
+    "--mm-processor-worker-num": "2",
+    "--mm-io-worker-num": "16",
+    "--reasoning-parser": "kimi_k3",
+    "--tool-call-parser": "kimi_k3",
+}
+
+modal = ModalConfig(
+    gpu="B300",
+    rollout_target_inputs=32,
+    rollout_ephemeral_disk_mib=2 * 1024 * 1024,
+    # CPU updates retain the canonical checkpoint plus all TP rank images.
+    rollout_memory_mib=(1024 * 1024, 4 * 1024 * 1024),
+)

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -66,7 +66,13 @@ ROLLOUT_CONCURRENCY = modal_cfg.rollout_target_inputs or slime_cfg.sglang_server
 # EXPERIMENT_CONFIG + RUN_ID are baked into both images so a container's re-import rebuilds the same
 # app name and transport paths as the deploy, not the defaults.
 image = trainer_image.build_trainer_image(hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, run_id=RUN_ID, slime_local=SLIME_LOCAL_DIR)
-server_image = serving_image.build_serving_image(hf_cache_path=str(HF_CACHE_PATH), delta_volume_name=exp.DELTA_VOLUME_NAME, experiment=EXPERIMENT, run_id=RUN_ID)
+server_image = serving_image.build_serving_image(
+    hf_cache_path=str(HF_CACHE_PATH),
+    delta_volume_name=exp.DELTA_VOLUME_NAME,
+    experiment=EXPERIMENT,
+    run_id=RUN_ID,
+    runtime=getattr(exp, "SGLANG_RUNTIME", serving_image.DEFAULT_SGLANG_RUNTIME),
+)
 if SLIME_LOCAL_DIR:
     server_image = server_image.add_local_dir(SLIME_LOCAL_DIR, remote_path=SLIME_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])
 

--- a/tools/profiling/_delta_weight_update.py
+++ b/tools/profiling/_delta_weight_update.py
@@ -44,7 +44,10 @@ def server_args_for_mode(
     if update_mode == "cpu":
         result["--enable-cpu-weight-cache"] = ""
         result["--cpu-weight-cache-max-compile-group-gb"] = "8"
-    elif update_mode != "disk":
+    elif update_mode == "disk":
+        result.pop("--enable-cpu-weight-cache", None)
+        result.pop("--cpu-weight-cache-max-compile-group-gb", None)
+    else:
         raise ValueError(f"unsupported update mode: {update_mode!r}")
     return result
 
@@ -124,7 +127,7 @@ def _generate(
         body = response.json()
         message = body["choices"][0]["message"]
         text = message.get("content") or message.get("reasoning_content") or ""
-        if len(text.split()) < 8 or sum(character.isalpha() for character in text) < 25:
+        if len(text.split()) < 5 or sum(character.isalpha() for character in text) < 20:
             raise RuntimeError(f"completion was not plausibly fluent: {text!r}")
         result = {
             "wall_s": round(time.perf_counter() - started, 6),

--- a/tools/profiling/_synthetic_delta.py
+++ b/tools/profiling/_synthetic_delta.py
@@ -1,0 +1,201 @@
+"""Construct bounded-memory XOR deltas for weight-update validation."""
+
+from __future__ import annotations
+
+import json
+import os
+import struct
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+_STREAM_BYTES = 8 * 1024 * 1024
+_ZERO_CHUNK = bytes(_STREAM_BYTES)
+
+
+def _safetensors_header(path: Path) -> tuple[int, dict[str, Any]]:
+    with path.open("rb") as handle:
+        (header_bytes,) = struct.unpack("<Q", handle.read(8))
+        return 8 + header_bytes, json.loads(handle.read(header_bytes))
+
+
+def _choose_bfloat16_tensor(
+    checkpoint_dir: Path,
+    weight_map: dict[str, str],
+) -> str:
+    headers: dict[Path, dict[str, Any]] = {}
+    candidates: list[tuple[int, int, str]] = []
+    for name, filename in weight_map.items():
+        path = checkpoint_dir / filename
+        if path not in headers:
+            _, headers[path] = _safetensors_header(path)
+        info = headers[path][name]
+        begin, end = info["data_offsets"]
+        if info["dtype"] != "BF16" or end <= begin:
+            continue
+        priority = (
+            0
+            if name.endswith(("model.norm.weight", "language_model.norm.weight"))
+            else 1
+            if "norm" in name
+            else 2
+        )
+        candidates.append((priority, end - begin, name))
+    if not candidates:
+        raise RuntimeError("checkpoint has no BF16 tensor for a controlled delta")
+    return min(candidates)[2]
+
+
+def _compress_xor(byte_count: int, *, flip_first_byte: bool) -> bytes:
+    import zstandard
+
+    compressor = zstandard.ZstdCompressor(level=1).compressobj()
+    output = []
+    remaining = byte_count
+    if flip_first_byte:
+        output.append(compressor.compress(b"\x01"))
+        remaining -= 1
+    while remaining:
+        size = min(remaining, len(_ZERO_CHUNK))
+        output.append(compressor.compress(memoryview(_ZERO_CHUNK)[:size]))
+        remaining -= size
+    output.append(compressor.flush())
+    return b"".join(output)
+
+
+def _target_checksum(
+    handle: Any,
+    *,
+    offset: int,
+    byte_count: int,
+    flip_first_byte: bool,
+) -> str:
+    import xxhash
+
+    checksum = xxhash.xxh3_128()
+    handle.seek(offset)
+    remaining = byte_count
+    first = True
+    while remaining:
+        chunk = handle.read(min(remaining, _STREAM_BYTES))
+        if not chunk:
+            raise RuntimeError("checkpoint tensor ended before its declared size")
+        if first and flip_first_byte:
+            changed = bytearray(chunk)
+            changed[0] ^= 1
+            chunk = changed
+        checksum.update(chunk)
+        remaining -= len(chunk)
+        first = False
+    return checksum.hexdigest()
+
+
+def write_full_coverage_delta(
+    checkpoint_dir: str,
+    source_dir: str,
+    *,
+    workers: int = 8,
+) -> dict[str, Any]:
+    """Write one DELTA containing every tensor and one safe changed byte."""
+
+    import numpy as np
+    import safetensors.numpy
+
+    started = time.perf_counter()
+    checkpoint = Path(checkpoint_dir)
+    index = json.loads((checkpoint / "model.safetensors.index.json").read_text())
+    weight_map = index["weight_map"]
+    primary_name = _choose_bfloat16_tensor(checkpoint, weight_map)
+    names_by_shard: dict[str, list[str]] = {}
+    for name, filename in weight_map.items():
+        names_by_shard.setdefault(filename, []).append(name)
+
+    target_dir = Path(source_dir) / "weight_v000001"
+    target_dir.mkdir(parents=True, exist_ok=False)
+
+    def write_shard(item: tuple[str, list[str]]) -> dict[str, int | str]:
+        filename, names = item
+        source_path = checkpoint / filename
+        data_start, header = _safetensors_header(source_path)
+        names.sort(key=lambda name: header[name]["data_offsets"][0])
+        compressed_tensors: dict[str, np.ndarray] = {}
+        checksums: dict[str, str] = {}
+        tensor_bytes = 0
+        changed_bytes = 0
+        with source_path.open("rb") as handle:
+            for name in names:
+                begin, end = header[name]["data_offsets"]
+                byte_count = end - begin
+                flip_first_byte = name == primary_name
+                checksums[name] = _target_checksum(
+                    handle,
+                    offset=data_start + begin,
+                    byte_count=byte_count,
+                    flip_first_byte=flip_first_byte,
+                )
+                compressed_tensors[name] = np.frombuffer(
+                    _compress_xor(
+                        byte_count,
+                        flip_first_byte=flip_first_byte,
+                    ),
+                    dtype=np.uint8,
+                )
+                tensor_bytes += byte_count
+                changed_bytes += int(flip_first_byte)
+            if hasattr(os, "posix_fadvise"):
+                try:
+                    os.posix_fadvise(
+                        handle.fileno(),
+                        0,
+                        0,
+                        os.POSIX_FADV_DONTNEED,
+                    )
+                except OSError:
+                    pass
+
+        target_path = target_dir / filename
+        safetensors.numpy.save_file(
+            compressed_tensors,
+            target_path,
+            metadata=checksums,
+        )
+        result: dict[str, int | str] = {
+            "filename": filename,
+            "tensors": len(names),
+            "tensor_bytes": tensor_bytes,
+            "changed_bytes": changed_bytes,
+            "wire_bytes": target_path.stat().st_size,
+        }
+        print(f"SYNTHETIC_DELTA_SHARD={json.dumps(result, sort_keys=True)}")
+        return result
+
+    with ThreadPoolExecutor(
+        max_workers=min(workers, len(names_by_shard)),
+    ) as executor:
+        shards = list(executor.map(write_shard, names_by_shard.items()))
+
+    (target_dir / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "version": "000001",
+                    "base_version": "000000",
+                    "delta_encoding": "xor",
+                    "compression_format": "zstd",
+                    "checksum_format": "xxh3-128",
+                },
+                "weight_map": weight_map,
+            }
+        )
+    )
+    return {
+        "scope": "all_tensors",
+        "tensors": len(weight_map),
+        "changed_tensors": 1,
+        "tensor_bytes": sum(int(shard["tensor_bytes"]) for shard in shards),
+        "changed_bytes": sum(int(shard["changed_bytes"]) for shard in shards),
+        "wire_bytes": sum(int(shard["wire_bytes"]) for shard in shards),
+        "primary_tensor": primary_name,
+        "generation_s": round(time.perf_counter() - started, 6),
+    }

--- a/tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
+++ b/tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
@@ -1,0 +1,233 @@
+"""Download Kimi K3 and validate one complete MXFP4 delta update on Modal.
+
+Run the CPU destination:
+
+    MODAL_FUNCTION_RUNTIME=runc uv run --extra modal modal run -d \
+      tools/profiling/kimi_k3_mxfp4_delta_weight_update.py \
+      --update-mode cpu
+
+Use ``--update-mode disk`` to profile the lower-RAM destination.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import modal
+
+from cookbook.common.serving_image import build_serving_image
+from cookbook.miles_disagg.configs import kimi_k3_mxfp4 as model
+from tools.profiling._delta_weight_update import (
+    WeightUpdateSpec,
+    modal_runtime_label,
+    parse_update_mode,
+    run_delta_weight_update,
+)
+from tools.profiling._synthetic_delta import write_full_coverage_delta
+
+APP_NAME = "profile-kimi-k3-mxfp4-delta-weight-update"
+EXPERIMENT = "kimi_k3_mxfp4"
+HF_CACHE_PATH = "/root/.cache/huggingface"
+HF_SNAPSHOT_DIR = (
+    f"{HF_CACHE_PATH}/models--moonshotai--Kimi-K3/snapshots/"
+    f"{model.ROLLOUT_SOURCE_REVISION}"
+)
+DELTA_MOUNT = "/synthetic-delta"
+DELTA_ID = f"kimi-k3/{model.ROLLOUT_SOURCE_REVISION}/full-coverage-v1"
+DELTA_SOURCE_DIR = f"{DELTA_MOUNT}/{DELTA_ID}"
+BASE_CHECKPOINT_DIR = "/local-checkpoint/kimi-k3-mxfp4/base"
+LOCAL_TARGET_CHECKPOINT_DIR = "/local-checkpoint/kimi-k3-mxfp4/target"
+SGLANG_CACHE_PATH = "/root/.cache/sglang"
+_REPO_ROOT = Path(__file__).resolve().parents[2] if modal.is_local() else Path("/root")
+
+app = modal.App(APP_NAME)
+hf_cache_volume = modal.Volume.from_name(
+    "huggingface-cache",
+    create_if_missing=True,
+    version=2,
+)
+delta_volume = modal.Volume.from_name(
+    "stitch-synthetic-deltas",
+    create_if_missing=True,
+    version=2,
+)
+sglang_cache_volume = modal.Volume.from_name(
+    "sglang-cache",
+    create_if_missing=True,
+    version=2,
+)
+
+download_image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install("huggingface_hub[hf_transfer]")
+    .env(
+        {
+            "HF_XET_HIGH_PERFORMANCE": "1",
+            "HF_HUB_ENABLE_HF_TRANSFER": "1",
+        }
+    )
+    .add_local_dir(
+        str(_REPO_ROOT / "cookbook"),
+        remote_path="/root/cookbook",
+        ignore=["**/__pycache__", "**/*.pyc"],
+    )
+    .add_local_dir(
+        str(_REPO_ROOT / "tools"),
+        remote_path="/root/tools",
+        ignore=["**/__pycache__", "**/*.pyc"],
+    )
+)
+serving_image = build_serving_image(
+    hf_cache_path=HF_CACHE_PATH,
+    experiment=EXPERIMENT,
+    runtime=model.SGLANG_RUNTIME,
+).add_local_dir(
+    str(Path(__file__).resolve().parents[1]),
+    remote_path="/root/tools",
+    ignore=["**/__pycache__", "**/*.pyc"],
+)
+
+
+@app.function(
+    image=download_image,
+    cpu=32,
+    memory=(16 * 1024, 256 * 1024),
+    volumes={HF_CACHE_PATH: hf_cache_volume},
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    timeout=6 * 60 * 60,
+)
+def download_model() -> str:
+    from huggingface_hub import HfApi, snapshot_download
+
+    files = HfApi().list_repo_files(
+        repo_id=model.ROLLOUT_SOURCE_MODEL,
+        revision=model.ROLLOUT_SOURCE_REVISION,
+    )
+    weights = sorted(path for path in files if path.endswith(".safetensors"))
+    metadata = sorted(set(files) - set(weights))
+    batches = [metadata]
+    batches.extend(weights[offset : offset + 4] for offset in range(0, len(weights), 4))
+    for index, batch in enumerate(batches, start=1):
+        snapshot_download(
+            repo_id=model.ROLLOUT_SOURCE_MODEL,
+            revision=model.ROLLOUT_SOURCE_REVISION,
+            cache_dir=HF_CACHE_PATH,
+            allow_patterns=batch,
+            max_workers=4,
+        )
+        hf_cache_volume.commit()
+        print(f"Committed checkpoint download batch {index}/{len(batches)}")
+
+    path = snapshot_download(
+        repo_id=model.ROLLOUT_SOURCE_MODEL,
+        revision=model.ROLLOUT_SOURCE_REVISION,
+        cache_dir=HF_CACHE_PATH,
+        local_files_only=True,
+    )
+    print(
+        f"Downloaded {model.ROLLOUT_SOURCE_MODEL}"
+        f"@{model.ROLLOUT_SOURCE_REVISION} to {path}"
+    )
+    return path
+
+
+@app.function(
+    image=serving_image,
+    cpu=64,
+    memory=(64 * 1024, 512 * 1024),
+    volumes={
+        HF_CACHE_PATH: hf_cache_volume.read_only(),
+        DELTA_MOUNT: delta_volume,
+    },
+    timeout=6 * 60 * 60,
+)
+def prepare_delta() -> dict:
+    metadata_path = Path(DELTA_SOURCE_DIR) / "controlled_delta.json"
+    index_path = (
+        Path(DELTA_SOURCE_DIR) / "weight_v000001" / "model.safetensors.index.json"
+    )
+    if metadata_path.is_file() and index_path.is_file():
+        result = json.loads(metadata_path.read_text())
+        print(f"Reusing synthetic delta at {DELTA_SOURCE_DIR}")
+        return result
+
+    shutil.rmtree(DELTA_SOURCE_DIR, ignore_errors=True)
+    Path(DELTA_SOURCE_DIR).mkdir(parents=True)
+    result = write_full_coverage_delta(
+        HF_SNAPSHOT_DIR,
+        DELTA_SOURCE_DIR,
+    )
+    metadata_path.write_text(json.dumps(result, sort_keys=True))
+    delta_volume.commit()
+    print(f"Committed synthetic delta at {DELTA_SOURCE_DIR}")
+    return result
+
+
+def _materialize_checkpoint_view() -> None:
+    """Give trusted remote code real sibling files without copying model weights."""
+
+    source = Path(HF_SNAPSHOT_DIR)
+    target = Path(BASE_CHECKPOINT_DIR)
+    shutil.rmtree(target, ignore_errors=True)
+    target.mkdir(parents=True)
+    for path in source.rglob("*"):
+        destination = target / path.relative_to(source)
+        if path.is_dir():
+            destination.mkdir(parents=True, exist_ok=True)
+        elif path.suffix == ".safetensors":
+            destination.symlink_to(path.resolve())
+        else:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, destination, follow_symlinks=True)
+
+
+@app.function(
+    image=serving_image,
+    gpu=f"{model.modal.gpu}:{model.ROLLOUT_NUM_GPUS_PER_ENGINE}",
+    cpu=64,
+    memory=model.modal.rollout_memory_mib,
+    ephemeral_disk=model.modal.rollout_ephemeral_disk_mib,
+    volumes={
+        HF_CACHE_PATH: hf_cache_volume.read_only(),
+        DELTA_MOUNT: delta_volume.read_only(),
+        SGLANG_CACHE_PATH: sglang_cache_volume,
+    },
+    timeout=6 * 60 * 60,
+)
+def benchmark(
+    update_mode: str,
+    runtime: str,
+    sample_id: str,
+) -> dict:
+    _materialize_checkpoint_view()
+    return run_delta_weight_update(
+        WeightUpdateSpec(
+            model_name="Kimi K3 MXFP4",
+            base_checkpoint_dir=BASE_CHECKPOINT_DIR,
+            local_target_checkpoint_dir=LOCAL_TARGET_CHECKPOINT_DIR,
+            server_args=model.SGLANG_SERVER_ARGS,
+            tp_size=model.ROLLOUT_NUM_GPUS_PER_ENGINE,
+        ),
+        source_dir=DELTA_SOURCE_DIR,
+        target_version=1,
+        update_mode=parse_update_mode(update_mode),
+        runtime=runtime,
+        sample_id=sample_id,
+    )
+
+
+@app.local_entrypoint()
+def main(
+    update_mode: str = "cpu",
+    sample_id: str = "1",
+) -> None:
+    parsed_mode = parse_update_mode(update_mode)
+    download_model.remote()
+    prepare_delta.remote()
+    benchmark.remote(
+        parsed_mode,
+        modal_runtime_label(),
+        sample_id,
+    )


### PR DESCRIPTION
## What changed

- let cookbook model configurations pin an immutable, ABI-compatible SGLang image/source runtime while preserving v0.5.16 as the default
- add a public `moonshotai/Kimi-K3` MXFP4 rollout-server configuration under the Miles configs, using 8×B300 and no speculative draft
- add a bounded-memory, full-checkpoint synthetic XOR publisher and a runnable K3 CPU/disk update profiler
- document the alternate public K3 SGLang pin and measured CPU-cache cost

## Why

K3 is supported on SGLang's public `kimi-k3` line rather than v0.5.16. Keeping the image, source branch, and immutable source commit in one model-level value prevents an ABI mismatch while leaving every existing Stitch recipe unchanged. The Stitch config owns rollout serving; trainer topology remains a caller choice.

The profiler exercises every one of the 497,220 indexed checkpoint tensors, verifies target checksums in canonical checkpoint space, serves throughout preparation, commits the complete rank images, and validates fluent generation and a changed model fingerprint afterward.

## Validation

Official `moonshotai/Kimi-K3` checkpoint, B300:8, CPU destination:

- initial serving startup: 811.07 s
- one-time CPU cache initialization: 973.47 s
- full-coverage target staging: 512.30 s
- CPU-to-GPU commit RPC: 3.831 s (3.800 s critical rank, ~54.6 GB/s/rank)
- generation during staging: 390 successful probes, no errors
- post-update version: 1; repeated token IDs/logprobs deterministic; base-to-target logprobs changed
- host memory after staging: 3.284 TB

Local checks:

- `uv run pytest` — 80 passed
- `uv run ruff check .`
- `uv run ruff format --check` on the changed formatted Python files
- `git diff --check`

The referenced public SGLang source pin is `modal-projects/sglang:stitch-sglang-kimi-k3@1a87b07642368bbc9a7985edea73548fb3d07203`.
