### PR TITLE
Use engine pause in user-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This matters for asynchronous and agentic RL: policy updates continue while
 long rollouts are in flight, rollout workers join and leave, and different
 consumers tolerate different amounts of staleness. Stitch turns an inference
 fleet into a coherent, versioned rollout service. It coordinates policy
-publication, replica convergence, request admission, and engine commits without
-prescribing the training algorithm, inference engine, storage system, or
-compute provider.
+publication, replica convergence, request admission, and weight activation
+without prescribing the training algorithm, inference engine, storage system,
+or compute provider.
 
 ```text
 Trainer ── publish policy versions ──> Store
@@ -26,12 +26,12 @@ Pool gateway ──────────────────────�
   policy version. Incompatible replicas return a retryable `409`, and responses
   report the versions at generation start and end.
 - **Continuous policy updates.** Replicas stage and verify the next full
-  checkpoint or delta while serving. Only the engine commit briefly gates new
-  requests.
+  checkpoint or delta while serving. Weight activation briefly pauses the
+  engine and gates new requests.
 - **Elastic rollout capacity.** New replicas load the base policy, catch up to
   the current version, and enter rotation only when ready.
 - **Failure-safe convergence.** Version bytes become durable before the shared
-  pointer advances. A replica reports a version only after its engine commits
+  pointer advances. A replica reports a version only after its engine activates
   it successfully.
 - **Replaceable infrastructure.** Trainers, stores, inference engines, and
   rollout pools meet at small, separate interfaces.

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -7,7 +7,7 @@ with SGLang rollout engines. Select a model through `EXPERIMENT_CONFIG`.
 
 Each recipe sets `SGLANG_DELTA_UPDATE_MODE`:
 
-| Mode | Prepared state | Engine commit | Use when |
+| Mode | Prepared state | During engine pause | Use when |
 | --- | --- | --- | --- |
 | `disk` | Complete checkpoint on local storage | Reload from disk | Host RAM is constrained or the trainer publishes full checkpoints |
 | `cpu` | Canonical checkpoint and rank-ready weight images in RAM | Copy the images to GPU | Updates are deltas and minimizing the pause justifies the RAM |
@@ -91,10 +91,10 @@ uv run --extra modal modal run -d \
   --update-mode cpu
 ```
 
-They generate during staging, commit the target, validate the new version, and
-report timing and resource use. SGLang rejects logprob-returning requests when
-DFlash or DSPARK is enabled, so those profiles compare repeated deterministic
-text instead of token IDs and logprobs.
+They generate during staging, pause the engine to activate the target, validate
+the new version, and report timing and resource use. SGLang rejects
+logprob-returning requests when DFlash or DSPARK is enabled, so those profiles
+compare repeated deterministic text instead of token IDs and logprobs.
 
 The K3 profiler downloads the pinned public checkpoint and constructs a
 checksummed XOR publication covering every checkpoint tensor:

--- a/cookbook/miles_disagg/MILES_FORK.md
+++ b/cookbook/miles_disagg/MILES_FORK.md
@@ -38,7 +38,7 @@ Miles owns trainer-side state:
 
 Stitch and SGLang own rollout-host state: materializing publications, verifying
 lineage and checksums, compiling disk or CPU destinations, gating admission for
-the short commit, and reporting the version that served each request.
+the short engine pause, and reporting the version that served each request.
 
 Canonical checkpoint bytes are required only for `disk-delta`. Other Miles
 weight transports retain their established engine-runtime layouts. Delta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "stitch"
 version = "0.1.0"
-description = "Trainer-agnostic disaggregated rollout weight sync helpers"
+description = "Versioned control plane for disaggregated RL rollouts"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/tools/probes/README.md
+++ b/tools/probes/README.md
@@ -5,8 +5,8 @@ and observing weight-version convergence. It is not a deployment example.
 
 - `traffic.py` sends long-decode, long-prefill, agentic, or mixed traffic and
   records version attribution.
-- `poller.py` records each replica's version, convergence lag, stage/commit
-  timing, and not-ready windows.
+- `poller.py` records each replica's version, convergence lag, staging and
+  engine pause timing, and not-ready windows.
 - `app.py` runs both probes on Modal and stores JSONL results.
 
 ## Run


### PR DESCRIPTION
## Summary

- use `engine pause` for the externally visible serving interruption
- describe the paused action as weight activation
- retain `stage` and `commit` terminology in technical API and SGLang fork documentation
- align package metadata with Stitch's versioned-control-plane mission

## Why

`Engine pause` describes the user-visible cost directly. `Commit` remains precise for the internal second phase of the stage/commit protocol, but is less clear as a performance or product term.

## Validation

- `uv lock --check`
- `uv run ruff check .`
- `git diff --check`