### PR TITLE
cookbook: advance SGLang for DFlash logprobs

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -14,7 +14,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.16",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.16",
-    commit="a562908a10fb67509a906c7c9ed8d7ff105c7a28",
+    commit="1a4a4fd6b54ab332c3b0b17a0383037390939587",
 )
 ```
 
@@ -31,6 +31,7 @@ The branch is upstream v0.5.16 plus:
 | `77eca472e6` | Fold disk XOR lineages with bounded positional I/O. |
 | `526e0ddca2` | Fail cache-flushing CPU commits before GPU mutation when the engine is busy. |
 | `a562908a10` | Normalize native ModelOpt FP4 expert tensors through their existing loader path. |
+| `1a4a4fd6b5` | Return aligned verifier logprobs for DFlash rollout tokens. |
 
 The image and branch must use the same SGLang release because Stitch overlays
 Python code onto the image’s existing CUDA and C++ extensions.

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -30,7 +30,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.16",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.16",
-    commit="a562908a10fb67509a906c7c9ed8d7ff105c7a28",
+    commit="1a4a4fd6b54ab332c3b0b17a0383037390939587",
 )
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary
- advance the default SGLang v0.5.16 runtime to 1a4a4fd6b54ab332c3b0b17a0383037390939587
- document the DFlash rollout-logprob commit in the fork manifest

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest (80 passed)
- Modal stitch-dev image probe cloned the pinned branch/commit and verified the DFlash logprob implementation (SGLANG_PIN_PASS)
- greedy and sampled H100 DFlash rollouts were verified before the pin bump