### PR TITLE
cookbook: support NVMe-backed canonical CPU caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,30 @@ monotonic version pointer, so a missed notification delays an update but cannot
 prevent convergence. This decentralized model lets the rollout fleet scale and
 recover without becoming part of the trainer's process lifecycle.
 
+## Measured delta updates
+
+These single-update measurements use the pinned cookbook stack, 64 vCPUs, and
+element-wise deltas covering every checkpoint tensor. Remote transfer, delta
+generation, and one-time CPU destination initialization are excluded.
+Preparation runs while inference remains available; only activation pauses the
+engine.
+
+| Model | TP | Canonical checkpoint | Preparation | Engine pause | Total update |
+| --- | ---: | --- | ---: | ---: | ---: |
+| GLM-4.5-Air FP8 | 4 | RAM | 41.2 s | 1.0 s | 42.2 s |
+| Kimi K2.6 NVFP4 | 4 | RAM | 55.6 s | 2.78 s | 58.4 s |
+| Kimi K2.6 NVFP4 | 4 | NVMe | 102.3 s | 2.76 s | 105.1 s |
+| GLM-5.2 NVFP4 | 4 | RAM | 59.3 s | 2.14 s | 61.5 s |
+| Kimi K3 MXFP4 | 8 | RAM | 122.3 s | 3.82 s | 126.1 s |
+| Kimi K3 MXFP4 | 8 | NVMe | 283.8 s | 3.79 s | 287.5 s |
+
+Each profiler reconstructs and checksums the complete target and validates
+generation before, during, and after activation. See
+[`Profile an update`](cookbook/README.md#profile-an-update) to reproduce these
+measurements and
+[`SGLANG_FORK.md`](cookbook/common/SGLANG_FORK.md#cpu-destination) for memory
+sizing and destination tradeoffs.
+
 ## Integrations
 
 The core package is trainer-, engine-, and provider-agnostic through the

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -10,7 +10,7 @@ Each recipe sets `SGLANG_DELTA_UPDATE_MODE`:
 | Mode | Prepared state | During engine pause | Use when |
 | --- | --- | --- | --- |
 | `disk` | Complete checkpoint on local storage | Reload from disk | Host RAM is constrained or the trainer publishes full checkpoints |
-| `cpu` | Canonical checkpoint and rank-ready weight images in RAM | Copy the images to GPU | Updates are deltas and minimizing the pause justifies the RAM |
+| `cpu` | Rank-ready images in RAM; canonical checkpoint in RAM or on local storage | Copy the images to GPU | Updates are deltas and minimizing the pause justifies rank-image RAM |
 
 Both modes reconstruct and checksum the complete target in canonical checkpoint
 space. CPU mode accepts deltas only and requires a new replica for a new

--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -14,7 +14,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.16",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.16",
-    commit="1a4a4fd6b54ab332c3b0b17a0383037390939587",
+    commit="1051a95a6ab16773037f8795a51aa03a1664a3b2",
 )
 ```
 
@@ -32,6 +32,8 @@ The branch is upstream v0.5.16 plus:
 | `526e0ddca2` | Fail cache-flushing CPU commits before GPU mutation when the engine is busy. |
 | `a562908a10` | Normalize native ModelOpt FP4 expert tensors through their existing loader path. |
 | `1a4a4fd6b5` | Return aligned verifier logprobs for DFlash rollout tokens. |
+| `607e107b44` | Store the canonical CPU-cache checkpoint on NVMe and overlap verified persistence with bounded rank-image compilation. |
+| `1051a95a6a` | Balance CPU delta transforms across persistent worker tasks. |
 
 The image and branch must use the same SGLang release because Stitch overlays
 Python code onto the image’s existing CUDA and C++ extensions.
@@ -41,9 +43,11 @@ configuration. The image, fork branch, and immutable commit stay together so
 the Python overlay remains ABI-compatible with the image.
 
 [`kimi_k3_mxfp4.py`](../miles_disagg/configs/kimi_k3_mxfp4.py) pins the public
-K3 image and `stitch-sglang-kimi-k3` fork. That fork ports the same weight-sync
-responsibilities onto SGLang’s public `kimi-k3` branch; other recipes continue
-to use the v0.5.16 default.
+K3 image and `stitch-sglang-kimi-k3` fork. That fork ports the
+same weight-sync responsibilities onto SGLang’s public `kimi-k3` branch; other
+recipes continue to use the v0.5.16 default. Its K3-native loader narrows expert
+lookup, batches safe copies, scopes post-load work to loaded modules, and reuses
+MXFP4 staging buffers.
 
 ## API
 
@@ -112,15 +116,17 @@ mode:
 
 ## CPU destination
 
-CPU mode trades host RAM for the shortest commit:
+CPU mode keeps rank-ready images in RAM for the shortest commit:
 
-1. After v0 begins serving, SGLang allocates one canonical checkpoint snapshot
-   per host and one complete rank-ready image per local TP rank.
+1. After v0 begins serving, SGLang allocates one complete rank-ready image per
+   local TP rank and either caches one canonical checkpoint per host in RAM or
+   materializes it on host-local storage.
 2. It builds v0 through the model’s ordinary weight loader and quantization
    hooks and verifies that the prepared runtime storages match the active model.
-3. For every delta lineage, it range-streams compressed fragments through a
-   bounded work budget, reconstructs and checksums the canonical target, then
-   builds every next rank image while inference continues.
+3. For every delta lineage, it reconstructs and checksums the canonical target,
+   then builds every next rank image while inference continues. The in-memory
+   path streams deltas through a bounded work budget; the storage-backed path
+   reuses the transactional disk materializer.
 4. `/update_weights_from_cpu` performs distributed preflight and copies the
    complete images into the existing CUDA storages without replacing storage
    pointers.
@@ -142,29 +148,49 @@ Enable it explicitly:
 "--cpu-weight-cache-max-compile-group-gb": "8",
 ```
 
+By default, both the canonical checkpoint and rank images remain in RAM. Keep
+only the rank images in RAM by placing the canonical checkpoint on writable
+host-local storage:
+
+```python
+"--cpu-weight-cache-canonical-checkpoint-dir": "/local-checkpoint/canonical",
+```
+
+Use local NVMe rather than a network or shared filesystem. This path pays a
+complete checkpoint copy during background initialization and adds NVMe
+read/write work during preparation; it does not change the CPU-to-GPU engine
+pause. Set `--weight-loader-drop-cache-after-load` to release clean checkpoint
+pages after every local TP rank finishes compiling; otherwise the kernel may
+retain those reclaimable pages for later reads.
+
 The group bound limits transient loader work; it does not tune correctness or
 assume a model architecture. An indivisible module larger than the requested
-bound remains intact and is reported.
+bound remains intact and is reported. The K3 recipe uses a 16 GiB bound to
+balance its module granularity against transient RAM.
 
-Persistent host RAM is approximately:
+With the default in-memory canonical checkpoint, persistent host RAM is:
 
 ```text
 one canonical checkpoint per host
 + one rank-local runtime image per local TP rank
 ```
 
-Measured reference costs are:
+With a storage-backed canonical checkpoint, persistent host RAM is the rank
+images; local storage holds one canonical checkpoint. File-cache pages used
+during preparation are reclaimable.
 
-| Model | TP | Canonical checkpoint | Rank image | Persistent core |
-| --- | ---: | ---: | ---: | ---: |
-| GLM-4.5-Air FP8 | 4 | 112.6 GB | 27.2 GB × 4 | 221.3 GB |
-| Kimi K2.6 NVFP4 | 4 | about 595 GB | about 151 GB × 4 | about 1.20 TB |
-| Kimi K3 MXFP4 | 8 | 1.561 TB | 207.5 GB × 8 | 3.221 TB |
+Measured component sizes are:
+
+| Model | TP | Canonical checkpoint per host | Rank image |
+| --- | ---: | ---: | ---: |
+| GLM-4.5-Air FP8 | 4 | 112.6 GB | 27.2 GB × 4 |
+| Kimi K2.6 NVFP4 | 4 | about 595 GB | about 151 GB × 4 |
+| Kimi K3 MXFP4 | 8 | 1.561 TB | 207.5 GB × 8 |
 
 Allow additional memory for the engine process, delta decoding, and bounded
 loader staging. The supplied recipes request `(512 GiB, 2 TiB)` for GLM and
-`(1 TiB, 3 TiB)` for Kimi K2.6, expressed as `(request, limit)`. The K3
-profiler uses `(1 TiB, 4 TiB)`.
+`(1 TiB, 3 TiB)` for Kimi K2.6 and Kimi K3, expressed as
+`(request, limit)`.
 
 All runtime storages are prepared and committed. Element-wise sparsity only
 reduces the compressed delta transport and XOR work.

--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -46,8 +46,9 @@ the Python overlay remains ABI-compatible with the image.
 K3 image and `stitch-sglang-kimi-k3` fork. That fork ports the
 same weight-sync responsibilities onto SGLang’s public `kimi-k3` branch; other
 recipes continue to use the v0.5.16 default. Its K3-native loader narrows expert
-lookup, batches safe copies, scopes post-load work to loaded modules, and reuses
-MXFP4 staging buffers.
+lookup, batches safe copies, scopes post-load work to loaded modules, and
+transforms Blackwell MXFP4 runtime layouts on GPU before caching rank-ready host
+images.
 
 ## API
 

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -30,7 +30,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.16",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.16",
-    commit="1a4a4fd6b54ab332c3b0b17a0383037390939587",
+    commit="1051a95a6ab16773037f8795a51aa03a1664a3b2",
 )
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent

--- a/cookbook/miles_disagg/configs/kimi_k3_mxfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k3_mxfp4.py
@@ -15,7 +15,7 @@ SGLANG_RUNTIME = SGLangRuntime(
     ),
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-kimi-k3",
-    commit="2fd91cac9a6bd7c7c611edcfa13a6c4bf799b4e2",
+    commit="8b508a478730f73eb4419e1a2adde8425732ea95",
 )
 
 SGLANG_SERVER_ARGS = {

--- a/cookbook/miles_disagg/configs/kimi_k3_mxfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k3_mxfp4.py
@@ -15,7 +15,7 @@ SGLANG_RUNTIME = SGLangRuntime(
     ),
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-kimi-k3",
-    commit="1a87b07642368bbc9a7985edea73548fb3d07203",
+    commit="2fd91cac9a6bd7c7c611edcfa13a6c4bf799b4e2",
 )
 
 SGLANG_SERVER_ARGS = {
@@ -23,7 +23,10 @@ SGLANG_SERVER_ARGS = {
     "--load-format": "fastsafetensors",
     "--model-loader-extra-config": '{"enable_gds":false}',
     "--enable-cpu-weight-cache": "",
-    "--cpu-weight-cache-max-compile-group-gb": "8",
+    "--cpu-weight-cache-max-compile-group-gb": "16",
+    "--cpu-weight-cache-canonical-checkpoint-dir": (
+        "/local-checkpoint/kimi-k3-mxfp4/canonical"
+    ),
     "--weight-loader-drop-cache-after-load": "",
     "--dist-timeout": "3600",
     "--context-length": "1048576",
@@ -46,6 +49,7 @@ modal = ModalConfig(
     gpu="B300",
     rollout_target_inputs=32,
     rollout_ephemeral_disk_mib=2 * 1024 * 1024,
-    # CPU updates retain the canonical checkpoint plus all TP rank images.
-    rollout_memory_mib=(1024 * 1024, 4 * 1024 * 1024),
+    # CPU updates retain TP rank images in RAM and the canonical checkpoint on
+    # ephemeral NVMe.
+    rollout_memory_mib=(1024 * 1024, 3 * 1024 * 1024),
 )

--- a/tools/profiling/_delta_weight_update.py
+++ b/tools/profiling/_delta_weight_update.py
@@ -43,10 +43,11 @@ def server_args_for_mode(
     result = dict(server_args)
     if update_mode == "cpu":
         result["--enable-cpu-weight-cache"] = ""
-        result["--cpu-weight-cache-max-compile-group-gb"] = "8"
+        result.setdefault("--cpu-weight-cache-max-compile-group-gb", "8")
     elif update_mode == "disk":
         result.pop("--enable-cpu-weight-cache", None)
         result.pop("--cpu-weight-cache-max-compile-group-gb", None)
+        result.pop("--cpu-weight-cache-canonical-checkpoint-dir", None)
     else:
         raise ValueError(f"unsupported update mode: {update_mode!r}")
     return result

--- a/tools/profiling/_synthetic_delta.py
+++ b/tools/profiling/_synthetic_delta.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import struct
 import time
@@ -11,7 +12,11 @@ from pathlib import Path
 from typing import Any
 
 _STREAM_BYTES = 8 * 1024 * 1024
+_CHANGE_STRIDE_BYTES = 1024 * 1024
 _ZERO_CHUNK = bytes(_STREAM_BYTES)
+_XOR_CHUNK = bytearray(_ZERO_CHUNK)
+_XOR_CHUNK[::_CHANGE_STRIDE_BYTES] = b"\x01" * (_STREAM_BYTES // _CHANGE_STRIDE_BYTES)
+_XOR_CHUNK = bytes(_XOR_CHUNK)
 
 
 def _safetensors_header(path: Path) -> tuple[int, dict[str, Any]]:
@@ -20,45 +25,15 @@ def _safetensors_header(path: Path) -> tuple[int, dict[str, Any]]:
         return 8 + header_bytes, json.loads(handle.read(header_bytes))
 
 
-def _choose_bfloat16_tensor(
-    checkpoint_dir: Path,
-    weight_map: dict[str, str],
-) -> str:
-    headers: dict[Path, dict[str, Any]] = {}
-    candidates: list[tuple[int, int, str]] = []
-    for name, filename in weight_map.items():
-        path = checkpoint_dir / filename
-        if path not in headers:
-            _, headers[path] = _safetensors_header(path)
-        info = headers[path][name]
-        begin, end = info["data_offsets"]
-        if info["dtype"] != "BF16" or end <= begin:
-            continue
-        priority = (
-            0
-            if name.endswith(("model.norm.weight", "language_model.norm.weight"))
-            else 1
-            if "norm" in name
-            else 2
-        )
-        candidates.append((priority, end - begin, name))
-    if not candidates:
-        raise RuntimeError("checkpoint has no BF16 tensor for a controlled delta")
-    return min(candidates)[2]
-
-
-def _compress_xor(byte_count: int, *, flip_first_byte: bool) -> bytes:
+def _compress_xor(byte_count: int) -> bytes:
     import zstandard
 
     compressor = zstandard.ZstdCompressor(level=1).compressobj()
     output = []
     remaining = byte_count
-    if flip_first_byte:
-        output.append(compressor.compress(b"\x01"))
-        remaining -= 1
     while remaining:
-        size = min(remaining, len(_ZERO_CHUNK))
-        output.append(compressor.compress(memoryview(_ZERO_CHUNK)[:size]))
+        size = min(remaining, len(_XOR_CHUNK))
+        output.append(compressor.compress(memoryview(_XOR_CHUNK)[:size]))
         remaining -= size
     output.append(compressor.flush())
     return b"".join(output)
@@ -69,25 +44,30 @@ def _target_checksum(
     *,
     offset: int,
     byte_count: int,
-    flip_first_byte: bool,
 ) -> str:
     import xxhash
 
     checksum = xxhash.xxh3_128()
     handle.seek(offset)
     remaining = byte_count
-    first = True
+    position = 0
     while remaining:
         chunk = handle.read(min(remaining, _STREAM_BYTES))
         if not chunk:
             raise RuntimeError("checkpoint tensor ended before its declared size")
-        if first and flip_first_byte:
+        first_change = (-position) % _CHANGE_STRIDE_BYTES
+        if first_change < len(chunk):
             changed = bytearray(chunk)
-            changed[0] ^= 1
+            for index in range(
+                first_change,
+                len(changed),
+                _CHANGE_STRIDE_BYTES,
+            ):
+                changed[index] ^= 1
             chunk = changed
         checksum.update(chunk)
         remaining -= len(chunk)
-        first = False
+        position += len(chunk)
     return checksum.hexdigest()
 
 
@@ -97,7 +77,7 @@ def write_full_coverage_delta(
     *,
     workers: int = 8,
 ) -> dict[str, Any]:
-    """Write one DELTA containing every tensor and one safe changed byte."""
+    """Write one DELTA with an element-level change in every tensor."""
 
     import numpy as np
     import safetensors.numpy
@@ -106,7 +86,6 @@ def write_full_coverage_delta(
     checkpoint = Path(checkpoint_dir)
     index = json.loads((checkpoint / "model.safetensors.index.json").read_text())
     weight_map = index["weight_map"]
-    primary_name = _choose_bfloat16_tensor(checkpoint, weight_map)
     names_by_shard: dict[str, list[str]] = {}
     for name, filename in weight_map.items():
         names_by_shard.setdefault(filename, []).append(name)
@@ -122,27 +101,24 @@ def write_full_coverage_delta(
         compressed_tensors: dict[str, np.ndarray] = {}
         checksums: dict[str, str] = {}
         tensor_bytes = 0
+        changed_tensors = 0
         changed_bytes = 0
         with source_path.open("rb") as handle:
             for name in names:
                 begin, end = header[name]["data_offsets"]
                 byte_count = end - begin
-                flip_first_byte = name == primary_name
                 checksums[name] = _target_checksum(
                     handle,
                     offset=data_start + begin,
                     byte_count=byte_count,
-                    flip_first_byte=flip_first_byte,
                 )
                 compressed_tensors[name] = np.frombuffer(
-                    _compress_xor(
-                        byte_count,
-                        flip_first_byte=flip_first_byte,
-                    ),
+                    _compress_xor(byte_count),
                     dtype=np.uint8,
                 )
                 tensor_bytes += byte_count
-                changed_bytes += int(flip_first_byte)
+                changed_tensors += int(byte_count > 0)
+                changed_bytes += math.ceil(byte_count / _CHANGE_STRIDE_BYTES)
             if hasattr(os, "posix_fadvise"):
                 try:
                     os.posix_fadvise(
@@ -164,6 +140,7 @@ def write_full_coverage_delta(
             "filename": filename,
             "tensors": len(names),
             "tensor_bytes": tensor_bytes,
+            "changed_tensors": changed_tensors,
             "changed_bytes": changed_bytes,
             "wire_bytes": target_path.stat().st_size,
         }
@@ -192,10 +169,10 @@ def write_full_coverage_delta(
     return {
         "scope": "all_tensors",
         "tensors": len(weight_map),
-        "changed_tensors": 1,
+        "changed_tensors": sum(int(shard["changed_tensors"]) for shard in shards),
         "tensor_bytes": sum(int(shard["tensor_bytes"]) for shard in shards),
         "changed_bytes": sum(int(shard["changed_bytes"]) for shard in shards),
+        "change_stride_bytes": _CHANGE_STRIDE_BYTES,
         "wire_bytes": sum(int(shard["wire_bytes"]) for shard in shards),
-        "primary_tensor": primary_name,
         "generation_s": round(time.perf_counter() - started, 6),
     }

--- a/tools/profiling/kimi_k2_6_nvfp4_delta_weight_update.py
+++ b/tools/profiling/kimi_k2_6_nvfp4_delta_weight_update.py
@@ -39,6 +39,7 @@ DELTA_MOUNT = "/delta-bulletin"
 SGLANG_CACHE_MOUNT = "/root/.cache/sglang"
 LOCAL_CHECKPOINT_ROOT = "/local-checkpoint/kimi-k2-6-nvfp4"
 LOCAL_TARGET_CHECKPOINT_DIR = f"{LOCAL_CHECKPOINT_ROOT}/target"
+LOCAL_CANONICAL_CHECKPOINT_DIR = f"{LOCAL_CHECKPOINT_ROOT}/canonical"
 
 DEFAULT_RUN_ID = "520c51f61535"
 DEFAULT_TARGET_VERSION = 1
@@ -48,6 +49,7 @@ SGLANG_SERVER_ARGS = {
     "--load-format": "fastsafetensors",
     "--model-loader-extra-config": '{"enable_gds":false}',
     "--weight-loader-drop-cache-after-load": "",
+    "--cpu-weight-cache-canonical-checkpoint-dir": LOCAL_CANONICAL_CHECKPOINT_DIR,
     "--trust-remote-code": "",
     "--tool-call-parser": "kimi_k2",
     "--reasoning-parser": "kimi_k2",

--- a/tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
+++ b/tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
@@ -1,12 +1,14 @@
 """Download Kimi K3 and validate one complete MXFP4 delta update on Modal.
 
-Run the CPU destination:
+Run the CPU destination with the canonical checkpoint on local storage:
 
     MODAL_FUNCTION_RUNTIME=runc uv run --extra modal modal run -d \
       tools/profiling/kimi_k3_mxfp4_delta_weight_update.py \
-      --update-mode cpu
+      --update-mode cpu --canonical-storage disk
 
-Use ``--update-mode disk`` to profile the lower-RAM destination.
+Use ``--canonical-storage memory`` only when the host can retain both the
+canonical checkpoint and TP rank images. ``--update-mode disk`` profiles the
+disk destination instead of rank-ready CPU staging.
 """
 
 from __future__ import annotations
@@ -35,7 +37,7 @@ HF_SNAPSHOT_DIR = (
     f"{model.ROLLOUT_SOURCE_REVISION}"
 )
 DELTA_MOUNT = "/synthetic-delta"
-DELTA_ID = f"kimi-k3/{model.ROLLOUT_SOURCE_REVISION}/full-coverage-v1"
+DELTA_ID = f"kimi-k3/{model.ROLLOUT_SOURCE_REVISION}/full-coverage-v3"
 DELTA_SOURCE_DIR = f"{DELTA_MOUNT}/{DELTA_ID}"
 BASE_CHECKPOINT_DIR = "/local-checkpoint/kimi-k3-mxfp4/base"
 LOCAL_TARGET_CHECKPOINT_DIR = "/local-checkpoint/kimi-k3-mxfp4/target"
@@ -82,6 +84,7 @@ download_image = (
 serving_image = build_serving_image(
     hf_cache_path=HF_CACHE_PATH,
     experiment=EXPERIMENT,
+    extra_env=getattr(model, "SGLANG_SERVER_ENV", None),
     runtime=model.SGLANG_RUNTIME,
 ).add_local_dir(
     str(Path(__file__).resolve().parents[1]),
@@ -198,16 +201,22 @@ def _materialize_checkpoint_view() -> None:
 )
 def benchmark(
     update_mode: str,
+    canonical_storage: str,
     runtime: str,
     sample_id: str,
 ) -> dict:
     _materialize_checkpoint_view()
+    server_args = dict(model.SGLANG_SERVER_ARGS)
+    if canonical_storage == "memory":
+        server_args.pop("--cpu-weight-cache-canonical-checkpoint-dir", None)
+    elif canonical_storage != "disk":
+        raise ValueError("canonical_storage must be 'memory' or 'disk'")
     return run_delta_weight_update(
         WeightUpdateSpec(
             model_name="Kimi K3 MXFP4",
             base_checkpoint_dir=BASE_CHECKPOINT_DIR,
             local_target_checkpoint_dir=LOCAL_TARGET_CHECKPOINT_DIR,
-            server_args=model.SGLANG_SERVER_ARGS,
+            server_args=server_args,
             tp_size=model.ROLLOUT_NUM_GPUS_PER_ENGINE,
         ),
         source_dir=DELTA_SOURCE_DIR,
@@ -221,6 +230,7 @@ def benchmark(
 @app.local_entrypoint()
 def main(
     update_mode: str = "cpu",
+    canonical_storage: str = "disk",
     sample_id: str = "1",
 ) -> None:
     parsed_mode = parse_update_mode(update_mode)
@@ -228,6 +238,7 @@ def main(
     prepare_delta.remote()
     benchmark.remote(
         parsed_mode,
+        canonical_storage,
         modal_runtime_label(),
         sample_id,
     )

--- a/tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
+++ b/tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
@@ -190,7 +190,7 @@ def _materialize_checkpoint_view() -> None:
     image=serving_image,
     gpu=f"{model.modal.gpu}:{model.ROLLOUT_NUM_GPUS_PER_ENGINE}",
     cpu=64,
-    memory=model.modal.rollout_memory_mib,
+    memory=(model.modal.rollout_memory_mib[0], 4 * 1024 * 1024),
     ephemeral_disk=model.modal.rollout_ephemeral_disk_mib,
     volumes={
         HF_CACHE_PATH: hf_cache_volume.read_only(),


### PR DESCRIPTION
## What changed

- Add host-local NVMe as an optional placement for the CPU cache canonical checkpoint while keeping rank-ready images in RAM.
- Pin the finalized v0.5.16 and public K3 SGLang branches that implement the same staging contract.
- Transform Blackwell MXFP4 runtime layouts on GPU before caching rank-ready host images.
- Configure Kimi K3 MXFP4 with bounded 16 GiB compile groups and an NVMe-backed canonical checkpoint.
- Exercise dense tensor coverage in the K2.6 and K3 profilers, and give the optional K3 RAM-canonical profiler enough physical headroom.

## Why

The short engine pause requires rank-ready images in RAM, but the canonical checkpoint is used only during background reconstruction, checksum verification, and native loader compilation. Host-local NVMe removes one model-sized persistent RAM copy without changing the CPU-to-GPU engine pause. Blackwell executes the MXFP4 runtime-layout transform substantially faster than the host CPU.

## Validation

- SGLang v0.5.16 weight-sync suite: 143 tests and 8 subtests passed.
- SGLang K3 weight-sync, MXFP4, and model suites: 155 tests and 21 subtests passed.
- Final MXFP4 GPU-staging commit: SGLang pre-commit passed; 9 tests and 13 subtests passed.
- Stitch: 80 tests passed; Ruff lint passes; all changed Python files pass Ruff formatting.

| Model | Canonical placement | Preparation | Engine pause | Total update |
| --- | --- | ---: | ---: | ---: |
| Kimi K2.6 NVFP4 TP4 | NVMe | 102.33 s | 2.76 s | 105.10 s |
| Kimi K3 MXFP4 TP8 | RAM | 122.32 s | 3.82 s | 126.14 s |
| Kimi K3 MXFP4 TP8 | NVMe | 283.75 s | 3.79 s | 287.55 s |

Every measured update used an element-wise delta covering all checkpoint tensors, reconstructed and checksummed the complete canonical target, changed from its v0 fingerprints, and produced exact repeated text, token IDs, and logprobs after activation. Live generation continued during preparation without errors.