### PR TITLE
cookbook: clean up cpu/disk delta update configs

### DIFF
--- a/cookbook/miles_disagg/configs/glm45_air_bf16.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16.py
@@ -46,7 +46,10 @@ modal = ModalConfig(
     rollout_min_containers=1,
     rollout_target_inputs=32,
     proxy_regions=["us-west"],
-    rollout_ephemeral_disk_mib=819_200,
+    # cpu persist ≈ 2x the 207.5 GiB canonical checkpoint; request covers staging + serving baseline.
+    rollout_memory_mib=(1024 * 1024, 3 * 1024 * 1024),
+    # cpu updates stage nothing local; disk is runtime + spill only.
+    rollout_ephemeral_disk_mib=524_288,
     torch_dist_prep_nodes=4,
     torch_dist_prep_gpus_per_node=8,
     torch_dist_convert_extra_args=(

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -62,8 +62,11 @@ modal = ModalConfig(
     trainer_memory_mib=(1024, int(3 * 1024 * 1024)),
     rollout_min_containers=8,  # warm floor; Flash scales above under load
     rollout_target_inputs=32,
+    # cpu persist ≈ 862 GiB measured (canonical + TP rank images), ~995 GB observed after staging.
+    rollout_memory_mib=(1024 * 1024, 3 * 1024 * 1024),
     proxy_regions=["us-west"],
-    rollout_ephemeral_disk_mib=819_200,  # delta bulletins + runtime spill
+    # cpu updates stage nothing local; disk is runtime + spill only.
+    rollout_ephemeral_disk_mib=524_288,
     trainer_ephemeral_disk_mib=2_097_152,
     # TODO(glm5.2): torch_dist conversion parallelism — match the trainer EP/TP below.
     torch_dist_prep_nodes=4,

--- a/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
@@ -48,6 +48,8 @@ modal = ModalConfig(
     gpu="B200",
     region="us",
     rollout_min_containers=1,
+    # cpu persist ≈ 2x the 15.3 GiB canonical checkpoint; request covers staging + serving baseline.
+    rollout_memory_mib=(128 * 1024, 512 * 1024),
     proxy_regions=["us-west"],
     # 2-layer model fits 1 GPU for the torch_dist conversion (pp=world_size <= 2).
     torch_dist_prep_nodes=1,

--- a/cookbook/miles_disagg/configs/kimi_k3_mxfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k3_mxfp4.py
@@ -22,11 +22,6 @@ SGLANG_SERVER_ARGS = {
     "--trust-remote-code": "",
     "--load-format": "fastsafetensors",
     "--model-loader-extra-config": '{"enable_gds":false}',
-    "--enable-cpu-weight-cache": "",
-    "--cpu-weight-cache-max-compile-group-gb": "16",
-    "--cpu-weight-cache-canonical-checkpoint-dir": (
-        "/local-checkpoint/kimi-k3-mxfp4/canonical"
-    ),
     "--weight-loader-drop-cache-after-load": "",
     "--dist-timeout": "3600",
     "--context-length": "1048576",
@@ -49,7 +44,7 @@ modal = ModalConfig(
     gpu="B300",
     rollout_target_inputs=32,
     rollout_ephemeral_disk_mib=2 * 1024 * 1024,
-    # CPU updates retain TP rank images in RAM and the canonical checkpoint on
-    # ephemeral NVMe.
+    # Disk updates reconstruct the ~600 GiB target checkpoint on ephemeral NVMe;
+    # RAM stays generous as read cache for the canonical base.
     rollout_memory_mib=(1024 * 1024, 3 * 1024 * 1024),
 )

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4.py
@@ -50,6 +50,8 @@ modal = ModalConfig(
     region="us",
     # warm floor of 1 so the pool is up before the trainer sends rollouts; Flash scales above under load.
     rollout_min_containers=1,
+    # cpu persist ≈ 2x the ~10 GiB canonical checkpoint; request covers staging + serving baseline.
+    rollout_memory_mib=(64 * 1024, 256 * 1024),
     proxy_regions=["us-west"],
 )
 

--- a/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
+++ b/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
@@ -123,6 +123,8 @@ modal = ModalConfig(
     # queue pressure so Flash scales OUT to the container cap instead of one engine
     # absorbing the whole wave at its concurrency ceiling.
     rollout_target_inputs=24,
+    # cpu persist ≈ 2x the 23.5 GiB canonical checkpoint; request covers staging + serving baseline.
+    rollout_memory_mib=(128 * 1024, 512 * 1024),
     proxy_regions=["us-west"],
 )
 

--- a/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
+++ b/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
@@ -53,6 +53,8 @@ modal = ModalConfig(
     region="us",
     rollout_min_containers=2,
     rollout_target_inputs=256,
+    # cpu persist ≈ 2x the ~550 GiB INT4 canonical checkpoint (same class as the miles NVFP4 config).
+    rollout_memory_mib=(1536 * 1024, 3 * 1024 * 1024),
     proxy_regions=["us-west"],
 )
 

--- a/cookbook/slime_disagg/configs/moonlight.py
+++ b/cookbook/slime_disagg/configs/moonlight.py
@@ -32,7 +32,12 @@ SGLANG_SERVER_ARGS = {
     "--enable-return-routed-experts": "",
 }
 
-modal = ModalConfig(gpu="H200", region="us")
+modal = ModalConfig(
+    gpu="H200",
+    region="us",
+    # cpu persist ≈ 2x the ~30 GiB bf16 canonical checkpoint; request covers staging + serving baseline.
+    rollout_memory_mib=(128 * 1024, 512 * 1024),
+)
 
 
 class _Slime(SlimeConfig):

--- a/cookbook/slime_disagg/configs/moonlight_int4.py
+++ b/cookbook/slime_disagg/configs/moonlight_int4.py
@@ -34,7 +34,12 @@ SGLANG_SERVER_ARGS = {
     "--enable-return-routed-experts": "",  # routing replay
 }
 
-modal = ModalConfig(gpu="H200", region="us")
+modal = ModalConfig(
+    gpu="H200",
+    region="us",
+    # cpu persist ≈ 2x the ~10 GiB INT4 canonical checkpoint; request covers staging + serving baseline.
+    rollout_memory_mib=(64 * 1024, 256 * 1024),
+)
 
 
 class _Slime(SlimeConfig):

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
@@ -29,7 +29,11 @@ SGLANG_SERVER_ARGS = {
     "--max-prefill-tokens": "4096",
 }
 
-modal = ModalConfig(gpu="H200")
+modal = ModalConfig(
+    gpu="H200",
+    # cpu persist ≈ 2x the ~7.5 GiB bf16 canonical checkpoint; request covers staging + serving baseline.
+    rollout_memory_mib=(64 * 1024, 256 * 1024),
+)
 
 
 class _Slime(SlimeConfig):

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash_hillclimb.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash_hillclimb.py
@@ -7,7 +7,7 @@ from cookbook.slime_disagg.configs import qwen3_4b_delta_flash as _base
 APP_NAME = "stitch-qwen3-4b-hillclimb"
 DELTA_VOLUME_NAME = "stitch-delta-qwen3-4b-hillclimb"
 DELTA_BULLETIN_ROOT = _base.DELTA_BULLETIN_ROOT
-LOCAL_CHECKPOINT_PATH = "/local-checkpoint"
+LOCAL_CHECKPOINT_PATH = _base.LOCAL_CHECKPOINT_PATH
 SIDECAR_COMMIT_MODE = _base.SIDECAR_COMMIT_MODE
 SIDECAR_FLUSH_CACHE_ON_COMMIT = _base.SIDECAR_FLUSH_CACHE_ON_COMMIT
 SGLANG_DELTA_UPDATE_MODE = _base.SGLANG_DELTA_UPDATE_MODE

--- a/tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
+++ b/tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
@@ -1,12 +1,18 @@
 """Download Kimi K3 and validate one complete MXFP4 delta update on Modal.
 
-Run the CPU destination with the canonical checkpoint on local storage:
+Disk destination (the Kimi K3 config's declared update mode):
+
+    MODAL_FUNCTION_RUNTIME=runc uv run --extra modal modal run -d \
+      tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
+
+CPU destination with the canonical checkpoint on local storage:
 
     MODAL_FUNCTION_RUNTIME=runc uv run --extra modal modal run -d \
       tools/profiling/kimi_k3_mxfp4_delta_weight_update.py \
       --update-mode cpu --canonical-storage disk
 
-Use ``--canonical-storage memory`` only when the host can retain both the
+``--canonical-storage`` applies only with ``--update-mode cpu``; use
+``--canonical-storage memory`` only when the host can retain both the
 canonical checkpoint and TP rank images. ``--update-mode disk`` profiles the
 disk destination instead of rank-ready CPU staging.
 """
@@ -41,6 +47,10 @@ DELTA_ID = f"kimi-k3/{model.ROLLOUT_SOURCE_REVISION}/full-coverage-v3"
 DELTA_SOURCE_DIR = f"{DELTA_MOUNT}/{DELTA_ID}"
 BASE_CHECKPOINT_DIR = "/local-checkpoint/kimi-k3-mxfp4/base"
 LOCAL_TARGET_CHECKPOINT_DIR = "/local-checkpoint/kimi-k3-mxfp4/target"
+# CPU-mode-only overlay: the config is a clean disk config, so the profiler
+# injects the cpu-weight-cache args when profiling the cpu destination.
+CPU_CACHE_GROUP_GB = "16"
+CANONICAL_CHECKPOINT_DIR = "/local-checkpoint/kimi-k3-mxfp4/canonical"
 SGLANG_CACHE_PATH = "/root/.cache/sglang"
 _REPO_ROOT = Path(__file__).resolve().parents[2] if modal.is_local() else Path("/root")
 
@@ -201,16 +211,22 @@ def _materialize_checkpoint_view() -> None:
 )
 def benchmark(
     update_mode: str,
-    canonical_storage: str,
+    canonical_storage: str | None,
     runtime: str,
     sample_id: str,
 ) -> dict:
     _materialize_checkpoint_view()
     server_args = dict(model.SGLANG_SERVER_ARGS)
-    if canonical_storage == "memory":
-        server_args.pop("--cpu-weight-cache-canonical-checkpoint-dir", None)
-    elif canonical_storage != "disk":
-        raise ValueError("canonical_storage must be 'memory' or 'disk'")
+    if update_mode == "cpu":
+        server_args["--enable-cpu-weight-cache"] = ""
+        server_args["--cpu-weight-cache-max-compile-group-gb"] = CPU_CACHE_GROUP_GB
+        storage = canonical_storage if canonical_storage is not None else "disk"
+        if storage == "disk":
+            server_args["--cpu-weight-cache-canonical-checkpoint-dir"] = CANONICAL_CHECKPOINT_DIR
+        elif storage != "memory":
+            raise ValueError("canonical_storage must be 'memory' or 'disk'")
+    elif canonical_storage is not None:
+        raise ValueError("--canonical-storage applies only with --update-mode cpu")
     return run_delta_weight_update(
         WeightUpdateSpec(
             model_name="Kimi K3 MXFP4",
@@ -230,10 +246,12 @@ def benchmark(
 @app.local_entrypoint()
 def main(
     update_mode: str = "disk",
-    canonical_storage: str = "disk",
+    canonical_storage: str | None = None,
     sample_id: str = "1",
 ) -> None:
     parsed_mode = parse_update_mode(update_mode)
+    if parsed_mode == "disk" and canonical_storage is not None:
+        raise ValueError("--canonical-storage applies only with --update-mode cpu")
     download_model.remote()
     prepare_delta.remote()
     benchmark.remote(


### PR DESCRIPTION
Addresses review feedback on #91.

## K3 is now a clean disk config

`kimi_k3_mxfp4.py` no longer carries `--enable-cpu-weight-cache`,
`--cpu-weight-cache-max-compile-group-gb`, or
`--cpu-weight-cache-canonical-checkpoint-dir`, so the config satisfies
`common/server.py`'s mode/arg invariant for any cookbook consumer. The
profiler now injects that CPU-only overlay itself when `--update-mode cpu`
is selected (preserving K3's 16 GiB compile-group size), and
`--canonical-storage` is only accepted with `--update-mode cpu` (validated
in the local entrypoint for a cheap fail-fast, before any GPU work).
Disk is the default: a bare `modal run` profiles the disk destination.

## Explicit rollout RAM sizing for cpu recipes

Every cpu-destination config now sets `rollout_memory_mib` explicitly rather
than relying on Modal's default request. Sizing derivation: persistent cpu
state ≈ 2× the canonical checkpoint (canonical + TP rank-ready images),
staged ≈ 1.15× persistent (the review's GLM-5.2 measured ratio), plus
~40 GiB serving baseline — request buckets up from that, limit ~2-4×.

| Config | Canonical source | (request, limit) |
| --- | --- | --- |
| glm45_air_bf16 | 207.5 GiB measured (volume) | (1 TiB, 3 TiB) |
| glm5_2_nvfp4 | reviewer's measured 862 GiB persist | (1 TiB, 3 TiB) |
| qwen3_30b_a3b_nvfp4_46 | 23.5 GiB measured (volume) | (128 GiB, 512 GiB) |
| moonlight_nvfp4 | 9.9 GiB measured (volume) | (64 GiB, 256 GiB) |
| kimi_k25_2layer_nvfp4 | 15.3 GiB measured (volume) | (128 GiB, 512 GiB) |
| slime moonlight | ~30 GiB (bf16 16B) | (128 GiB, 512 GiB) |
| slime moonlight_int4 | ~10 GiB (INT4 16B) | (64 GiB, 256 GiB) |
| slime qwen3_4b_delta_flash (+ hillclimb) | ~7.5 GiB (bf16 4B) | (64 GiB, 256 GiB) |
| slime kimi_k2_6_int4 | ~550 GiB (INT4 ~1T) | (1.5 TiB, 3 TiB) |

Pre-existing explicit tuples on `glm45_air_fp8` and `kimi_k2_6_nvfp4` are
unchanged — both are proven-in-production cpu configs.

## Residual cleanup

- `qwen3_4b_delta_flash_hillclimb.py`: `LOCAL_CHECKPOINT_PATH` now inherits
  the base's `None` instead of pinning a disk-only path under cpu mode.
- K3's stale cpu-cache RAM comment reworded for the disk destination.
- The two leftover 800 GiB rollout local-disk reservations
  (`glm45_air_bf16`, `glm5_2_nvfp4`) shrink to the measured cpu-mode spill
  size (512 GiB, the `glm45_air_fp8`/`kimi_k2_6_nvfp4` cpu exemplar).

The transport/destination separation is unchanged: trainer
`disk-delta`/`UpdateWeight` transport untouched; `SGLANG_DELTA_UPDATE_MODE`
only selects the engine destination.

## Verification

- `uv run pytest`: 80 passed
- Static sweep: K3 has no cpu-cache args (disk clean); all 11 cpu configs
  have cache arg + `LOCAL_CHECKPOINT_PATH = None` + explicit memory tuple;
  hillclimb inherits both; profiler overlay only active in cpu mode.