### PR TITLE
cookbook: isolate immutable artifacts from run state

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -35,6 +35,56 @@ the replica. Bundled MTP heads do not need a separate volume.
 
 ## Prepare and launch
 
+All persistent storage uses Modal Volume v2:
+
+| Volume | Mount | Contents |
+| --- | --- | --- |
+| `huggingface-cache` | `/root/.cache/huggingface` | Pinned source-model downloads |
+| `miles-checkpoints` or `slime-checkpoints` | `/checkpoints` | Immutable prepared model layouts |
+| `miles-data` or `slime-data` | `/data` | Immutable dataset revisions |
+| `stitch-<framework>-<model>` | `/stitch` | Run-scoped publications, checkpoints, and logs |
+| `sglang-cache` | `/root/.cache/sglang` | Compiled SGLang kernels |
+| Configured draft Volume | `/draft` | Optional external speculative draft |
+
+Prepared model layouts are immutable artifacts with explicit paths. For
+example, the Miles GLM-5.2 config uses:
+
+```text
+/checkpoints/
+├── glm5-2-nvfp4/
+└── glm5-2-torch-dist/
+```
+
+Each config also owns one `stitch-<framework>-<model>` Volume mounted at
+`/stitch`. Its root contains only run-scoped state:
+
+```text
+/stitch/
+└── <run-id>/
+    ├── latest
+    ├── updates/weight_vNNNNNN/
+    ├── checkpoints/
+    └── train.log
+```
+
+The training framework owns `updates/`; Stitch owns the `latest` commit
+pointer. A future checkpoint resume starts a new run and reads the previous
+run's `checkpoints/` rather than appending to its update chain.
+
+Datasets are independent of models and runs. Miles mounts the shared
+`miles-data` Volume at `/data`; Slime uses `slime-data`. Each immutable dataset
+revision has its own directory:
+
+```text
+/data/
+└── datasets/
+    └── <dataset>/
+        └── <revision>/
+            ├── manifest.json
+            ├── <trainer-input>
+            └── <dataset-specific-assets>/
+```
+
 Miles:
 
 ```bash
@@ -77,7 +127,7 @@ gateway and every live replica with:
 ```bash
 uv run --extra modal python -m cookbook.common.smoke \
   --app-name <app-name> \
-  --model-name /prep/glm45-air/fp8 \
+  --model-name /checkpoints/glm45-air-fp8 \
   --weight-version 10
 ```
 

--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -56,8 +56,8 @@ images.
 
 ```json
 {
-  "base_checkpoint_dir": "/prep/model/format",
-  "checkpoint_source_dir": "/delta-bulletin/run",
+  "base_checkpoint_dir": "/checkpoints/<artifact-id>",
+  "checkpoint_source_dir": "/stitch/<run-id>/updates",
   "local_checkpoint_dir": "/local-checkpoint",
   "target_version": 7,
   "destination": "disk"

--- a/cookbook/common/constants.py
+++ b/cookbook/common/constants.py
@@ -1,7 +1,4 @@
-"""Shared deployment constants — container mount points, ports, and timeouts, general
-across every recipe. The per-experiment names/values (APP_NAME, DELTA_VOLUME_NAME, the
-disk layout) live in the config modules.
-"""
+"""Shared deployment constants — container mount points, ports, and timeouts."""
 
 from __future__ import annotations
 
@@ -9,11 +6,9 @@ from pathlib import Path
 
 # Container mount points (Modal Volumes attach here).
 HF_CACHE_PATH = Path("/root/.cache/huggingface")
-DATA_PATH = Path("/data")
 CHECKPOINTS_PATH = Path("/checkpoints")
-PREP_PATH = Path(
-    "/prep"
-)  # <PREP>/<tag>/{bf16 masters, served base, torch_dist ref_load}
+DATA_PATH = Path("/data")
+STITCH_PATH = Path("/stitch")
 DRAFT_PATH = Path("/draft")
 SGLANG_CACHE_PATH = (
     "/root/.cache/sglang"  # sglang kernel/JIT cache; survives cold starts

--- a/cookbook/common/hooks.py
+++ b/cookbook/common/hooks.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import time
 from pathlib import Path
 from typing import Any
@@ -127,10 +126,14 @@ class _CachedPointer:
     async def get(self, args: Any, ttl: float = 2.0) -> int:
         store = self._store
         root = Path(_transport_root(args))
-        volume = getattr(
-            args, "update_weight_delta_volume_name", None
-        ) or os.environ.get("DELTA_VOLUME_NAME")
-        if store is None or store.root != root or store.volume_name != (volume or None):
+        run_id = _run_id(args)
+        volume = getattr(args, "experiment_volume_name", None)
+        if (
+            store is None
+            or store.root != root
+            or store.run_id != run_id
+            or store.volume_name != (volume or None)
+        ):
             store = self._store = _store(args)
             self._version = 0
             self._at = -1e9
@@ -157,28 +160,33 @@ _latest = _CachedPointer()
 
 # ── args → run coordinates ───────────────────────────────────────────────────────
 def _store(args: Any) -> ModalVolumeStore:
-    volume = getattr(args, "update_weight_delta_volume_name", None) or os.environ.get(
-        "DELTA_VOLUME_NAME"
+    volume = getattr(args, "experiment_volume_name", None)
+    return ModalVolumeStore(
+        _transport_root(args),
+        volume_name=volume or None,
+        run_id=_run_id(args),
     )
-    return ModalVolumeStore(_transport_root(args), volume_name=volume or None)
 
 
 def _pool(args: Any) -> ModalFlashPool:
-    app = getattr(args, "rollout_modal_flash_app_name", None) or os.environ.get(
-        "DELTA_APP_NAME"
-    )
-    cls = getattr(args, "rollout_modal_flash_server_cls_name", None) or os.environ.get(
-        "DELTA_SERVER_CLS_NAME", "Server"
-    )
+    app = getattr(args, "rollout_modal_flash_app_name", None)
+    if not app:
+        raise ValueError("rollout_modal_flash_app_name is required")
+    cls = getattr(args, "rollout_modal_flash_server_cls_name", "Server")
     return ModalFlashPool(app, cls)
 
 
 def _transport_root(args: Any) -> str:
-    # The trainer writes version dirs under <root>/<run_id>; the Store is rooted at <root>.
-    write_dir = getattr(args, "update_weight_disk_dir", None) or os.environ.get(
-        "DELTA_BULLETIN_ROOT", "/delta-bulletin"
-    )
-    return str(Path(write_dir).parent)
+    # The framework owns <run>/updates; Stitch owns <run>/latest.
+    write_dir = getattr(args, "update_weight_disk_dir", None)
+    if not write_dir:
+        raise ValueError("update_weight_disk_dir is required")
+    write_dir = Path(write_dir)
+    if write_dir.name != "updates":
+        raise ValueError(
+            f"update_weight_disk_dir must end in /updates: path={str(write_dir)!r}"
+        )
+    return str(write_dir.parent)
 
 
 def _run_id(args: Any) -> str:

--- a/cookbook/common/hooks_test.py
+++ b/cookbook/common/hooks_test.py
@@ -13,6 +13,8 @@ import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from cookbook.common import hooks
 from stitch.stores.modal_volume import ModalVolumeStore
 from stitch.types import VersionRef
@@ -30,14 +32,15 @@ class _FakePool:
 
 
 def _args(root: str, run_id: str = "run-abc", **extra):
-    # transport root = parent of update_weight_disk_dir, so the Store roots at `root`.
     return SimpleNamespace(
-        update_weight_disk_dir=f"{root}/{run_id}", run_id=run_id, **extra
+        update_weight_disk_dir=f"{root}/updates",
+        run_id=run_id,
+        **extra,
     )
 
 
 def _write_version(root: Path, ref: VersionRef) -> str:
-    d = root / ref.identity
+    d = root / "updates" / Path(ref.identity).name
     d.mkdir(parents=True)
     (d / "model.safetensors.index.json").write_text(
         json.dumps(
@@ -79,7 +82,9 @@ def test_commit_and_wake_publishes() -> None:
             hooks.publish_version = original_publish
             ModalVolumeStore.commit = original_commit
         assert events == ["commit", "barrier", "publish"]
-        assert ModalVolumeStore(root).read_pointer() == VersionRef("run-abc", 1)
+        assert ModalVolumeStore(root, run_id="run-abc").read_pointer() == VersionRef(
+            "run-abc", 1
+        )
         assert pool.woke == [VersionRef("run-abc", 1)]
 
 
@@ -89,8 +94,8 @@ def test_commit_and_wake_baseline_is_noop() -> None:
         root = Path(tmp)
         pool = _FakePool()
         hooks._pool = lambda args: pool
-        run_dir = root / "run-abc"
-        run_dir.mkdir(parents=True)
+        updates = root / "updates"
+        updates.mkdir(parents=True, exist_ok=True)
         original_barrier = hooks.process.dist_barrier
 
         def unexpected_barrier() -> None:
@@ -98,10 +103,10 @@ def test_commit_and_wake_baseline_is_noop() -> None:
 
         hooks.process.dist_barrier = unexpected_barrier
         try:
-            hooks.commit_and_wake(_args(str(root)), str(run_dir))
+            hooks.commit_and_wake(_args(str(root)), str(updates))
         finally:
             hooks.process.dist_barrier = original_barrier
-        assert ModalVolumeStore(root).read_pointer() is None
+        assert ModalVolumeStore(root, run_id="run-abc").read_pointer() is None
         assert pool.woke == []
 
 
@@ -110,14 +115,26 @@ def test_claim_pool_resets_to_base() -> None:
         pool = _FakePool()
         hooks._pool = lambda args: pool
         hooks.claim_pool(_args(tmp))
-        assert ModalVolumeStore(Path(tmp)).read_pointer() == VersionRef("run-abc", 0)
+        assert ModalVolumeStore(
+            Path(tmp), run_id="run-abc"
+        ).read_pointer() == VersionRef("run-abc", 0)
         assert pool.woke == [VersionRef("run-abc", 0)]
+
+
+def test_store_rejects_a_non_updates_directory() -> None:
+    with pytest.raises(ValueError, match="must end in /updates"):
+        hooks._store(
+            SimpleNamespace(
+                update_weight_disk_dir="/stitch/run-abc/deltas",
+                run_id="run-abc",
+            )
+        )
 
 
 def test_request_hook_min_lag() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        ModalVolumeStore(root).advance_pointer(
+        ModalVolumeStore(root, run_id="run-abc").advance_pointer(
             VersionRef("run-abc", 10)
         )  # published latest
         hooks._latest = hooks._CachedPointer()  # fresh cache reading this store
@@ -156,7 +173,9 @@ def test_sample_affinity_key_fallbacks() -> None:
 def test_request_hook_exact_and_none() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        ModalVolumeStore(root).advance_pointer(VersionRef("run-abc", 10))
+        ModalVolumeStore(root, run_id="run-abc").advance_pointer(
+            VersionRef("run-abc", 10)
+        )
         hooks._latest = hooks._CachedPointer()
         exact_req = {"payload": {}}
         asyncio.run(
@@ -195,21 +214,27 @@ def test_request_hook_cache_switches_runs() -> None:
         tempfile.TemporaryDirectory() as first,
         tempfile.TemporaryDirectory() as second,
     ):
-        ModalVolumeStore(first).advance_pointer(VersionRef("run-a", 7))
-        ModalVolumeStore(second).advance_pointer(VersionRef("run-b", 3))
+        ModalVolumeStore(first, run_id="run-a").advance_pointer(VersionRef("run-a", 7))
+        ModalVolumeStore(second, run_id="run-b").advance_pointer(VersionRef("run-b", 3))
         hooks._latest = hooks._CachedPointer()
 
-        async def read(root: str) -> dict:
+        async def read(root: str, run_id: str) -> dict:
             request = {"payload": {}}
             await hooks.gated_rollout_request_hook(
-                _args(root, rollout_request_weight_version_lag=0),
+                _args(root, run_id=run_id, rollout_request_weight_version_lag=0),
                 SimpleNamespace(session_id=None),
                 request,
             )
             return request["payload"]["weight_version"]
 
-        assert asyncio.run(read(first)) == {"min_version": 7, "exact_version": None}
-        assert asyncio.run(read(second)) == {"min_version": 3, "exact_version": None}
+        assert asyncio.run(read(first, "run-a")) == {
+            "min_version": 7,
+            "exact_version": None,
+        }
+        assert asyncio.run(read(second, "run-b")) == {
+            "min_version": 3,
+            "exact_version": None,
+        }
 
 
 if __name__ == "__main__":

--- a/cookbook/common/process.py
+++ b/cookbook/common/process.py
@@ -26,6 +26,7 @@ def start_sidecar(
     delta_update_mode: str,
     disk_load_format: str,
     volume_name: str,
+    run_id: str,
     commit_mode: str,
     flush_cache_on_commit: bool = False,
     debug_requests: bool = False,
@@ -51,6 +52,8 @@ def start_sidecar(
         disk_load_format,
         "--volume-name",
         volume_name,
+        "--run-id",
+        run_id,
         "--commit-mode",
         commit_mode,
     ]

--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -28,6 +28,7 @@ def serve_startup(
     local_checkpoint_dir: str | None,
     delta_update_mode: str,
     volume_name: str,
+    run_id: str,
     commit_mode: str,
     flush_cache_on_commit: bool = False,
     startup_timeout: int,
@@ -83,6 +84,7 @@ def serve_startup(
         delta_update_mode=delta_update_mode,
         disk_load_format=str(sglang_args.get("--load-format", "auto")),
         volume_name=volume_name,
+        run_id=run_id,
         commit_mode=commit_mode,
         flush_cache_on_commit=flush_cache_on_commit,
     )

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -49,17 +49,13 @@ _SERVING_ENV = {
 def build_serving_image(
     *,
     hf_cache_path: str,
-    delta_volume_name: str | None = None,
     experiment: str,
     run_id: str | None = None,
     extra_packages: Sequence[str] = (),
     extra_env: Mapping[str, str] | None = None,
     runtime: SGLangRuntime = DEFAULT_SGLANG_RUNTIME,
 ) -> modal.Image:
-    """The rollout-pool image. Volume-backed recipes set ``delta_volume_name`` for their
-    Store; other Store backends omit it. Backend-specific packages and environment
-    belong in ``extra_packages`` / ``extra_env`` so all build steps still precede the
-    local source layers."""
+    """Build the rollout-pool image for one experiment config."""
     return (
         modal.Image.from_registry(runtime.image)
         .run_commands(
@@ -90,11 +86,6 @@ def build_serving_image(
                 **_SERVING_ENV,
                 **(extra_env or {}),
                 "EXPERIMENT_CONFIG": experiment,
-                **(
-                    {"DELTA_VOLUME_NAME": delta_volume_name}
-                    if delta_volume_name
-                    else {}
-                ),
                 **({"RUN_ID": run_id} if run_id else {}),
             }
         )

--- a/cookbook/common/sidecar.py
+++ b/cookbook/common/sidecar.py
@@ -41,7 +41,7 @@ def main() -> None:
     p.add_argument("--volume-name", default="")
     p.add_argument("--commit-mode", choices=["in_place", "quiesce"], default="in_place")
     p.add_argument("--flush-cache-on-commit", action="store_true")
-    p.add_argument("--run-id", default=None)
+    p.add_argument("--run-id", required=True)
     p.add_argument("--debug-requests", action="store_true")
     p.add_argument(
         "--reconcile-interval", type=float, default=5.0
@@ -50,7 +50,11 @@ def main() -> None:
     if args.delta_update_mode == "disk" and not args.local_checkpoint_dir:
         p.error("--local-checkpoint-dir is required in disk mode")
 
-    store = ModalVolumeStore(args.bulletin_root, volume_name=args.volume_name or None)
+    store = ModalVolumeStore(
+        args.bulletin_root,
+        volume_name=args.volume_name or None,
+        run_id=args.run_id,
+    )
     engine = SGLangEngine(
         args.upstream,
         args.base_checkpoint_dir,

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -23,7 +23,6 @@ import importlib
 import os
 import subprocess
 import tempfile
-import uuid
 from types import SimpleNamespace
 from typing import Any
 
@@ -37,11 +36,11 @@ from cookbook.common.constants import (
     DRAFT_PATH,
     HF_CACHE_PATH,
     MINUTES,
-    PREP_PATH,
     RAY_PORT,
     SERVER_STARTUP_TIMEOUT,
     SGLANG_CACHE_PATH,
     SIDECAR_PORT,
+    STITCH_PATH,
 )
 from cookbook.miles_disagg import trainer_image
 from cookbook.miles_disagg.config import YAML_CONFIG_FIELDS, MilesConfig
@@ -59,11 +58,12 @@ exp = importlib.import_module(f"cookbook.miles_disagg.configs.{EXPERIMENT}")
 modal_cfg = exp.modal
 miles_cfg = exp.miles
 
-# Per-run id, minted fresh per launch by cookbook.miles_disagg.launch: names the pool app + delta
-# transport root, so each run — even an identical-config relaunch — is its own isolated pool.
+# Per-run id, minted fresh by cookbook.miles_disagg.launch. The same identity
+# scopes the pool, Stitch pointer, publications, checkpoints, and logs.
 RUN_ID = os.environ["RUN_ID"]
 APP_NAME = f"{exp.APP_NAME}-{RUN_ID}"
-BULLETIN_ROOT = f"{exp.DELTA_BULLETIN_ROOT}/{RUN_ID}"
+RUN_DIR = STITCH_PATH / RUN_ID
+UPDATES_DIR = RUN_DIR / "updates"
 
 # Flash autoscaler target / sglang concurrency cap: explicit target_inputs, else engine concurrency.
 ROLLOUT_CONCURRENCY = (
@@ -80,7 +80,6 @@ image = trainer_image.build_trainer_image(
 )
 server_image = serving_image.build_serving_image(
     hf_cache_path=str(HF_CACHE_PATH),
-    delta_volume_name=exp.DELTA_VOLUME_NAME,
     experiment=EXPERIMENT,
     run_id=RUN_ID,
     extra_env=getattr(exp, "SGLANG_SERVER_ENV", None),
@@ -97,18 +96,19 @@ hf_cache_volume = modal.Volume.from_name(
     "huggingface-cache", create_if_missing=True, version=2
 )
 data_volume = modal.Volume.from_name("miles-data", create_if_missing=True, version=2)
-checkpoints_volume = modal.Volume.from_name(
-    "miles-checkpoints", create_if_missing=True, version=2
+checkpoint_volume = modal.Volume.from_name(
+    "miles-checkpoints",
+    create_if_missing=True,
+    version=2,
 )
-prep_volume = modal.Volume.from_name(
-    "miles-prep-checkpoints", create_if_missing=True, version=2
+run_volume = modal.Volume.from_name(
+    exp.EXPERIMENT_VOLUME_NAME,
+    create_if_missing=True,
+    version=2,
 )
 sglang_cache_volume = modal.Volume.from_name(
     "sglang-cache", create_if_missing=True, version=2
 )  # survives cold starts
-delta_volume = modal.Volume.from_name(
-    exp.DELTA_VOLUME_NAME, create_if_missing=True, version=2
-)
 draft_volume = (
     modal.Volume.from_name(
         modal_cfg.draft_volume,
@@ -121,10 +121,9 @@ draft_volume = (
 
 train_volumes = {
     str(HF_CACHE_PATH): hf_cache_volume,
+    str(CHECKPOINTS_PATH): checkpoint_volume,
     str(DATA_PATH): data_volume,
-    str(CHECKPOINTS_PATH): checkpoints_volume,
-    str(PREP_PATH): prep_volume,
-    exp.DELTA_BULLETIN_ROOT: delta_volume,
+    str(STITCH_PATH): run_volume,
 }
 
 app = modal.App(APP_NAME)
@@ -147,9 +146,9 @@ SGLANG_SERVER_ARGS = {
     region=modal_cfg.region,
     volumes={
         str(HF_CACHE_PATH): hf_cache_volume,
-        str(PREP_PATH): prep_volume,
+        str(CHECKPOINTS_PATH): checkpoint_volume,
+        str(STITCH_PATH): run_volume,
         SGLANG_CACHE_PATH: sglang_cache_volume,
-        exp.DELTA_BULLETIN_ROOT: delta_volume,
         **({str(DRAFT_PATH): draft_volume} if draft_volume is not None else {}),
     },
     min_containers=modal_cfg.rollout_min_containers,
@@ -176,11 +175,12 @@ class Server:
             sglang_args=SGLANG_SERVER_ARGS,
             tp=miles_cfg.rollout_num_gpus_per_engine,
             concurrency=ROLLOUT_CONCURRENCY,
-            bulletin_root=BULLETIN_ROOT,
+            bulletin_root=str(RUN_DIR),
             local_checkpoint_dir=exp.LOCAL_CHECKPOINT_PATH,
             delta_update_mode=exp.SGLANG_DELTA_UPDATE_MODE,
-            volume_name=exp.DELTA_VOLUME_NAME,
+            volume_name=exp.EXPERIMENT_VOLUME_NAME,
             commit_mode=exp.SIDECAR_COMMIT_MODE,
+            run_id=RUN_ID,
             flush_cache_on_commit=exp.SIDECAR_FLUSH_CACHE_ON_COMMIT,
             startup_timeout=SERVER_STARTUP_TIMEOUT,
         )
@@ -258,19 +258,19 @@ class Trainer:
             return
 
         cfg.rollout_endpoint_url = ModalFlashPool(APP_NAME, "Server").gateway_url()
-        run_id = uuid.uuid4().hex[:12]  # per-launch fence token; forks a fresh chain
-        cfg.update_weight_disk_dir = f"{BULLETIN_ROOT}/{run_id}"
+        # Miles requires this CLI argument; the deployment owns its run-scoped value.
+        cfg.update_weight_disk_dir = str(UPDATES_DIR)
         if getattr(cfg, "save_interval", None) is None:
-            cfg.load = cfg.save = cfg.save_hf = None
+            cfg.save = cfg.save_hf = None
         else:
-            cfg.load = cfg.save = f"{CHECKPOINTS_PATH}/{run_id}/checkpoints"
+            cfg.save = str(RUN_DIR / "checkpoints")
         # miles setattr's every key onto args for the hooks.
         custom_config = {
             **(cfg.custom_config_path or {}),
-            "update_weight_delta_volume_name": exp.DELTA_VOLUME_NAME,
+            "experiment_volume_name": exp.EXPERIMENT_VOLUME_NAME,
             "rollout_modal_flash_app_name": APP_NAME,
             "rollout_modal_flash_server_cls_name": "Server",
-            "run_id": run_id,
+            "run_id": RUN_ID,
         }
         cfg.custom_config_path = custom_config
         launch.resolve_config(cfg, tempfile.mkdtemp(), YAML_CONFIG_FIELDS)
@@ -286,18 +286,21 @@ class Trainer:
         )
 
         print(
-            f"Training {EXPERIMENT}: nodes={miles_cfg.n_train_nodes}, rollout_endpoint={cfg.rollout_endpoint_url}"
+            f"Training {EXPERIMENT}: run={RUN_ID}, nodes={miles_cfg.n_train_nodes}, "
+            f"rollout_endpoint={cfg.rollout_endpoint_url}"
         )
         print(f"Command: {cmd}")
-        log_path = f"{CHECKPOINTS_PATH}/{run_id}/train.log"
+        log_path = str(RUN_DIR / "train.log")
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
         teed = f"set -o pipefail; ({cmd}) 2>&1 | tee {log_path}"  # tee to a committed log; survives the app-logs buffer
         try:
             subprocess.run(["bash", "-lc", teed], check=True)
         finally:
             try:
-                checkpoints_volume.commit()
-                print(f"Train log committed to miles-checkpoints at {run_id}/train.log")
+                run_volume.commit()
+                print(
+                    f"Train log committed to {exp.EXPERIMENT_VOLUME_NAME} at {log_path}"
+                )
             except Exception as exc:  # noqa: BLE001
                 print(f"WARNING: could not commit train log: {exc}")
 

--- a/cookbook/miles_disagg/configs/glm45_air_bf16.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-glm45-air-bf16"
-DELTA_VOLUME_NAME = "stitch-delta-glm45-air-bf16"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-glm45-air-bf16"
 LOCAL_CHECKPOINT_PATH = None
 
 SOURCE_MODEL = "zai-org/GLM-4.5-Air"
-MODEL_TAG = "glm45-air"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm45-air-bf16"
+ROLLOUT_CHECKPOINT_PATH = BF16_CHECKPOINT_PATH
+TORCH_DIST_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm45-air-torch-dist"
 SERVED_CHECKPOINT_FORMAT = "bf16"
 USE_MODAL_TORCH_DIST_WRAPPER = True
 DISABLE_HF_XET = True
@@ -68,8 +69,8 @@ modal = ModalConfig(
 class _Miles(MilesConfig):
     miles_model_script = "scripts/models/glm4.5-106B-A12B.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/bf16"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/torch_dist"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(TORCH_DIST_CHECKPOINT_PATH)
     megatron_to_hf_mode = "raw"
     model_name = "glm4moe"
 
@@ -100,7 +101,6 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/miles_disagg/configs/glm45_air_fp8.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-glm45-air-fp8"
-DELTA_VOLUME_NAME = "stitch-delta-glm45-air-fp8"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-glm45-air-fp8"
 LOCAL_CHECKPOINT_PATH = None
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
@@ -19,9 +18,11 @@ SGLANG_SERVER_ENV = {
     "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
 }
 
-MODEL_TAG = "glm45-air"
 SOURCE_MODEL = "zai-org/GLM-4.5-Air"
 ROLLOUT_SOURCE_MODEL = "zai-org/GLM-4.5-Air-FP8"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm45-air-bf16"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm45-air-fp8"
+TORCH_DIST_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm45-air-torch-dist"
 SERVED_CHECKPOINT_FORMAT = "fp8"
 USE_MODAL_TORCH_DIST_WRAPPER = True
 DISABLE_HF_XET = True
@@ -61,8 +62,8 @@ SGLANG_SERVER_ARGS = {
 class _Miles(MilesConfig):
     miles_model_script = "scripts/models/glm4.5-106B-A12B.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/fp8"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/torch_dist"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(TORCH_DIST_CHECKPOINT_PATH)
     megatron_to_hf_mode = "raw"
     model_name = "glm4moe"
 
@@ -93,9 +94,6 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = (
-        DELTA_BULLETIN_ROOT  # run-scoped at launch to <root>/<run_id>
-    )
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"
     input_key = "prompt"

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -6,21 +6,22 @@ Deploy: EXPERIMENT_CONFIG=glm5_2_nvfp4 uv run --extra modal modal deploy --strat
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-glm5-2-nvfp4"
-DELTA_VOLUME_NAME = "stitch-delta-glm5-2-nvfp4"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-glm5-2-nvfp4"
 LOCAL_CHECKPOINT_PATH = None
 
 # GLM-5.2 ships BF16 training masters and an NVIDIA NVFP4 rollout checkpoint.
 SOURCE_MODEL = "zai-org/GLM-5.2"
 ROLLOUT_SOURCE_MODEL = "nvidia/GLM-5.2-NVFP4"
 ROLLOUT_SOURCE_REVISION = "aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm5-2-bf16"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm5-2-nvfp4"
+TORCH_DIST_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm5-2-torch-dist"
 SERVED_CHECKPOINT_FORMAT = "nvfp4"
 CHECKPOINT_PREP_REQUIRES_GPU = False
-MODEL_TAG = "glm5-2"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
@@ -81,8 +82,8 @@ modal = ModalConfig(
 class _Miles(MilesConfig):
     miles_model_script = "scripts/models/glm5.2-744B-A40B.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/nvfp4"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/torch_dist"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(TORCH_DIST_CHECKPOINT_PATH)
     megatron_to_hf_mode = "raw"
     model_name = "glm_moe_dsa"
 
@@ -157,7 +158,6 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
@@ -7,16 +7,17 @@ Deploy (::prepare_checkpoints, ::prepare_torch_dist, deploy, then ::launch_train
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-kimi-k25-2layer-nvfp4"
-DELTA_VOLUME_NAME = "stitch-delta-kimi-k25-2layer-nvfp4"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-kimi-k25-2layer-nvfp4"
 LOCAL_CHECKPOINT_PATH = None
 
 SOURCE_MODEL = "CharyZeng/Kimi-K2.5-2layer"  # INT4, KimiK25 arch, 2 layers
-MODEL_TAG = "kimi-k25-2layer"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k25-2layer-bf16"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k25-2layer-nvfp4"
+TORCH_DIST_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k25-2layer-torch-dist"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
@@ -60,8 +61,8 @@ modal = ModalConfig(
 class _Miles(MilesConfig):
     miles_model_script = "scripts/models/kimi-k25_2layer.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/nvfp4"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/torch_dist"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(TORCH_DIST_CHECKPOINT_PATH)
     megatron_to_hf_mode = "raw"
     model_name = "kimi_k25"  # KimiK25 mbridge import + convert_kimi_k25_to_hf export
 
@@ -132,7 +133,6 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
@@ -6,17 +6,18 @@ Deploy: EXPERIMENT_CONFIG=kimi_k2_6_nvfp4 uv run --extra modal modal deploy --st
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-kimi-k2-6-nvfp4"
-DELTA_VOLUME_NAME = "stitch-delta-kimi-k2-6-nvfp4"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-kimi-k2-6-nvfp4"
 LOCAL_CHECKPOINT_PATH = None
 
 # SOURCE_MODEL (INT4) -> dequant -> bf16 masters -> convert -> served NVFP4 base.
 SOURCE_MODEL = "moonshotai/Kimi-K2.6"
-MODEL_TAG = "kimi-k2-6"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k2-6-bf16"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k2-6-nvfp4"
+TORCH_DIST_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k2-6-torch-dist"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
@@ -32,6 +33,7 @@ SGLANG_SERVER_ARGS = {
     # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
     "--model-loader-extra-config": '{"enable_gds":false}',
+    "--trust-remote-code": "",
     "--enable-cpu-weight-cache": "",
     "--cpu-weight-cache-max-compile-group-gb": "8",
     "--weight-loader-drop-cache-after-load": "",
@@ -73,8 +75,8 @@ class _Miles(MilesConfig):
     # Arch comes from the model script (shared with Kimi-K2-Thinking; K2.6 matches).
     miles_model_script = "scripts/models/kimi-k2-thinking.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/nvfp4"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/torch_dist"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(TORCH_DIST_CHECKPOINT_PATH)
     # "raw": K2.6's HF arch is a VLM wrapper AutoBridge can't build; export routes via model_name.
     megatron_to_hf_mode = "raw"
     model_name = (
@@ -155,7 +157,6 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4.py
@@ -6,16 +6,16 @@ Deploy: EXPERIMENT_CONFIG=moonlight_nvfp4 uv run --extra modal modal deploy --st
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-moonlight-nvfp4"
-DELTA_VOLUME_NAME = "stitch-delta-moonlight-nvfp4"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-moonlight-nvfp4"
 LOCAL_CHECKPOINT_PATH = None
 
 SOURCE_MODEL = "moonshotai/Moonlight-16B-A3B-Instruct"
-MODEL_TAG = "moonlight-16b"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "moonlight-bf16"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "moonlight-nvfp4"
 
 # in_place applies weights without draining in-flight rollouts; stale KV isolated per version.
 SIDECAR_COMMIT_MODE = "in_place"
@@ -60,8 +60,8 @@ class _Miles(MilesConfig):
     # Arch comes from the model script; do NOT inline arch attrs here.
     miles_model_script = "scripts/models/moonlight.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/nvfp4"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/bf16"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(BF16_CHECKPOINT_PATH)
     megatron_to_hf_mode = "bridge"
     model_name = "deepseekv3"  # bridge dispatch: Moonlight is DeepSeek-V3 arch
 
@@ -100,7 +100,6 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT  # modal_train run-scopes this
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
+++ b/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
@@ -40,16 +40,16 @@ Launch: EXPERIMENT_CONFIG=qwen3_30b_a3b_nvfp4_46 uv run --extra modal python -m 
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-qwen3-30b-nvfp4-46"
-DELTA_VOLUME_NAME = "stitch-delta-qwen3-30b-nvfp4-46"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-qwen3-30b-nvfp4-46"
 LOCAL_CHECKPOINT_PATH = None
 
 SOURCE_MODEL = "Qwen/Qwen3-30B-A3B"  # bf16 -> masters ARE the download
-MODEL_TAG = "qwen3-30b-a3b-nvfp4-46"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "qwen3-30b-a3b-bf16"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "qwen3-30b-a3b-nvfp4-46"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
@@ -133,8 +133,8 @@ class _Miles(MilesConfig):
     miles_model_script = "scripts/models/qwen3-30B-A3B.sh"
 
     # Bridge mode: ref_load is the bf16 HF masters directly (no torch_dist prep).
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/nvfp4"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/bf16"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(BF16_CHECKPOINT_PATH)
     megatron_to_hf_mode = "bridge"
     model_name = "qwen3moe"  # megatron_to_hf export dispatch
 
@@ -206,7 +206,6 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT  # app.py run-scopes this
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
     # Data: DAPO-Math-17k — the blog's dataset.

--- a/cookbook/miles_disagg/prep.py
+++ b/cookbook/miles_disagg/prep.py
@@ -14,7 +14,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from cookbook.common.constants import PREP_PATH
 from cookbook.miles_disagg.trainer_image import (
     MEGATRON_PATH,
     MILES_ROOT,
@@ -33,29 +32,40 @@ def _apply_prep_environment(exp) -> None:
     os.environ.update(getattr(exp, "PREP_ENV", {}))
 
 
-def prepare_checkpoints(exp, prep_volume) -> None:
+def _source_snapshot(exp) -> str:
+    _apply_prep_environment(exp)
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(
+        exp.SOURCE_MODEL,
+        revision=getattr(exp, "SOURCE_REVISION", None),
+    )
+
+
+def _bf16_masters(exp) -> str:
+    """Resolve the immutable BF16 source used by both checkpoint converters."""
+    src = _source_snapshot(exp)
+    if _is_int4(src) or getattr(exp, "MATERIALIZE_BF16_MASTERS", True):
+        return str(exp.BF16_CHECKPOINT_PATH)
+    return src
+
+
+def prepare_checkpoints(exp, checkpoint_volume) -> None:
     """Build the bf16 masters (trainer arch source) + the served base on a GPU.
 
     masters (bf16): a quantized source (Kimi INT4) is dequantized; a bf16 source IS the
     masters. served base: bf16 = masters; a published ROLLOUT_SOURCE_MODEL is copied
     directly; otherwise NVFP4 is built with Miles' TE-direct quantizer over the masters.
     """
-    _apply_prep_environment(exp)
-    from huggingface_hub import snapshot_download
-
-    prep_volume.reload()
-    tag = exp.MODEL_TAG
-    bf16_dir, fp8_dir, nvfp4_dir = (
-        f"{PREP_PATH}/{tag}/bf16",
-        f"{PREP_PATH}/{tag}/fp8",
-        f"{PREP_PATH}/{tag}/nvfp4",
-    )
+    checkpoint_volume.reload()
+    materialized_bf16_dir = str(exp.BF16_CHECKPOINT_PATH)
+    served_dir = str(exp.miles.hf_checkpoint)
     served_format = getattr(exp, "SERVED_CHECKPOINT_FORMAT", "nvfp4")
     if served_format not in {"bf16", "fp8", "nvfp4"}:
         raise SystemExit(f"unsupported SERVED_CHECKPOINT_FORMAT={served_format!r}")
     tools = f"{MILES_ROOT}/tools"
 
-    src = snapshot_download(exp.SOURCE_MODEL)
+    src = _source_snapshot(exp)
     is_int4 = _is_int4(src)  # read the source's quant scheme, not its repo name
 
     def _build_bf16(out: str) -> None:
@@ -76,19 +86,30 @@ def prepare_checkpoints(exp, prep_volume) -> None:
             _copy_tree("bf16 masters", src, out)
         _strip_stale_quant_config(os.path.join(out, "config.json"))
 
-    _staged(bf16_dir, _build_bf16)
+    if is_int4 or getattr(exp, "MATERIALIZE_BF16_MASTERS", True):
+        _staged(materialized_bf16_dir, _build_bf16)
+        bf16_dir = materialized_bf16_dir
+    else:
+        bf16_dir = src
+        print(f"using pinned HF snapshot as bf16 masters: {bf16_dir}", flush=True)
 
     if served_format == "bf16":
-        prep_volume.commit()
+        if served_dir != bf16_dir:
+            raise ValueError(
+                "BF16 served checkpoint must match BF16_CHECKPOINT_PATH: "
+                f"{served_dir} != {bf16_dir}"
+            )
+        checkpoint_volume.commit()
         print(f"Prepared masters={bf16_dir} served_base={bf16_dir}")
         return
 
     rollout_source = getattr(exp, "ROLLOUT_SOURCE_MODEL", None)
     if rollout_source:
         rollout_revision = getattr(exp, "ROLLOUT_SOURCE_REVISION", None)
-        served_dir = fp8_dir if served_format == "fp8" else nvfp4_dir
 
         def _download_rollout_checkpoint(out: str) -> None:
+            from huggingface_hub import snapshot_download
+
             snapshot_download(
                 rollout_source,
                 revision=rollout_revision,
@@ -97,7 +118,7 @@ def prepare_checkpoints(exp, prep_volume) -> None:
             shutil.rmtree(os.path.join(out, ".cache"), ignore_errors=True)
 
         _staged(served_dir, _download_rollout_checkpoint, resume=True)
-        prep_volume.commit()
+        checkpoint_volume.commit()
         print(f"Prepared masters={bf16_dir} served_base={served_dir}")
         return
 
@@ -130,20 +151,19 @@ def prepare_checkpoints(exp, prep_volume) -> None:
             check=True,
         )
 
-    _staged(nvfp4_dir, _build_nvfp4)
-    prep_volume.commit()
-    print(f"Prepared masters={bf16_dir} served_base={nvfp4_dir}")
+    _staged(served_dir, _build_nvfp4)
+    checkpoint_volume.commit()
+    print(f"Prepared masters={bf16_dir} served_base={served_dir}")
 
 
-def prepare_torch_dist(exp, prep_volume, *, rank: int, master_addr: str) -> None:
-    """Build {tag}/torch_dist (the raw-mode ref_load) from the {tag}/bf16 masters via a
-    clustered torchrun conversion (large MoE won't fit an 8-way split)."""
-    prep_volume.reload()
-    tag = exp.MODEL_TAG
-    bf16_dir, torch_dist_dir = (
-        f"{PREP_PATH}/{tag}/bf16",
-        f"{PREP_PATH}/{tag}/torch_dist",
-    )
+def prepare_torch_dist(exp, checkpoint_volume, *, rank: int, master_addr: str) -> None:
+    """Build the raw-mode torch_dist reference checkpoint from the BF16 source."""
+    torch_dist_path = getattr(exp, "TORCH_DIST_CHECKPOINT_PATH", None)
+    if torch_dist_path is None:
+        raise SystemExit("this config does not use a torch_dist trainer checkpoint")
+    checkpoint_volume.reload()
+    bf16_dir = _bf16_masters(exp)
+    torch_dist_dir = str(torch_dist_path)
     if os.path.exists(
         os.path.join(torch_dist_dir, "latest_checkpointed_iteration.txt")
     ):
@@ -177,7 +197,7 @@ def prepare_torch_dist(exp, prep_volume, *, rank: int, master_addr: str) -> None
     subprocess.run(["bash", "-c", inner], check=True, env=env)
     # Every node commits its own distcp shards (disjoint files merge on the Volume);
     # a rank-0-only commit would drop the other nodes' shards.
-    prep_volume.commit()
+    checkpoint_volume.commit()
     if rank == 0:
         print(f"Prepared torch_dist={torch_dist_dir}")
 

--- a/cookbook/miles_disagg/prep_app.py
+++ b/cookbook/miles_disagg/prep_app.py
@@ -20,7 +20,12 @@ import modal
 import modal.experimental
 
 from cookbook.common import ray_cluster
-from cookbook.common.constants import DATA_PATH, HF_CACHE_PATH, MINUTES, PREP_PATH
+from cookbook.common.constants import (
+    CHECKPOINTS_PATH,
+    DATA_PATH,
+    HF_CACHE_PATH,
+    MINUTES,
+)
 from cookbook.miles_disagg import prep, trainer_image
 
 EXPERIMENT = os.environ[
@@ -35,15 +40,19 @@ modal_cfg = exp.modal
 miles_cfg = exp.miles
 
 image = trainer_image.build_trainer_image(
-    hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, miles_local=MILES_LOCAL_DIR
+    hf_cache_path=str(HF_CACHE_PATH),
+    experiment=EXPERIMENT,
+    miles_local=MILES_LOCAL_DIR,
 )
 
 hf_cache_volume = modal.Volume.from_name(
     "huggingface-cache", create_if_missing=True, version=2
 )
 data_volume = modal.Volume.from_name("miles-data", create_if_missing=True, version=2)
-prep_volume = modal.Volume.from_name(
-    "miles-prep-checkpoints", create_if_missing=True, version=2
+checkpoint_volume = modal.Volume.from_name(
+    "miles-checkpoints",
+    create_if_missing=True,
+    version=2,
 )
 
 app = modal.App(f"{exp.APP_NAME}-prep")
@@ -55,14 +64,17 @@ checkpoint_gpu = (
 @app.function(
     image=image,
     gpu=checkpoint_gpu,
-    volumes={str(HF_CACHE_PATH): hf_cache_volume, str(PREP_PATH): prep_volume},
+    volumes={
+        str(HF_CACHE_PATH): hf_cache_volume,
+        str(CHECKPOINTS_PATH): checkpoint_volume,
+    },
     memory=modal_cfg.trainer_memory_mib,
     timeout=6 * 60 * MINUTES,
     secrets=[modal.Secret.from_name("huggingface-secret")],
     include_source=False,
 )
 def prepare_checkpoints() -> None:
-    prep.prepare_checkpoints(exp, prep_volume)
+    prep.prepare_checkpoints(exp, checkpoint_volume)
 
 
 # torch_dist conversion is clustered across nodes (a large MoE won't fit an 8-way split).
@@ -72,7 +84,10 @@ _TORCH_DIST_MULTINODE = modal_cfg.torch_dist_prep_nodes > 1
 @app.function(
     image=image,
     gpu=f"{modal_cfg.gpu}:{modal_cfg.torch_dist_prep_gpus_per_node}",
-    volumes={str(HF_CACHE_PATH): hf_cache_volume, str(PREP_PATH): prep_volume},
+    volumes={
+        str(HF_CACHE_PATH): hf_cache_volume,
+        str(CHECKPOINTS_PATH): checkpoint_volume,
+    },
     timeout=6 * 60 * MINUTES,
     ephemeral_disk=(
         modal_cfg.torch_dist_prep_ephemeral_disk_mib
@@ -93,7 +108,7 @@ def prepare_torch_dist() -> None:
     rank, master_addr, _ = ray_cluster.get_modal_cluster_context(
         modal_cfg.torch_dist_prep_nodes
     )
-    prep.prepare_torch_dist(exp, prep_volume, rank=rank, master_addr=master_addr)
+    prep.prepare_torch_dist(exp, checkpoint_volume, rank=rank, master_addr=master_addr)
 
 
 @app.function(

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -23,7 +23,6 @@ import importlib
 import os
 import subprocess
 import tempfile
-import uuid
 from types import SimpleNamespace
 from typing import Any
 
@@ -41,6 +40,7 @@ from cookbook.common.constants import (
     SERVER_STARTUP_TIMEOUT,
     SGLANG_CACHE_PATH,
     SIDECAR_PORT,
+    STITCH_PATH,
 )
 from cookbook.slime_disagg import trainer_image
 from cookbook.slime_disagg.config import YAML_CONFIG_FIELDS, SlimeConfig
@@ -58,11 +58,12 @@ exp = importlib.import_module(f"cookbook.slime_disagg.configs.{EXPERIMENT}")
 modal_cfg = exp.modal
 slime_cfg = exp.slime
 
-# Per-run id, minted fresh per launch by cookbook.slime_disagg.launch: names the pool app + delta
-# transport root, so each run — even an identical-config relaunch — is its own isolated pool.
+# Per-run id, minted fresh by cookbook.slime_disagg.launch. The same identity
+# scopes the pool, Stitch pointer, publications, checkpoints, and logs.
 RUN_ID = os.environ["RUN_ID"]
 APP_NAME = f"{exp.APP_NAME}-{RUN_ID}"
-BULLETIN_ROOT = f"{exp.DELTA_BULLETIN_ROOT}/{RUN_ID}"
+RUN_DIR = STITCH_PATH / RUN_ID
+UPDATES_DIR = RUN_DIR / "updates"
 
 # Flash autoscaler target / sglang concurrency cap: explicit target_inputs, else engine concurrency.
 ROLLOUT_CONCURRENCY = (
@@ -79,7 +80,6 @@ image = trainer_image.build_trainer_image(
 )
 server_image = serving_image.build_serving_image(
     hf_cache_path=str(HF_CACHE_PATH),
-    delta_volume_name=exp.DELTA_VOLUME_NAME,
     experiment=EXPERIMENT,
     run_id=RUN_ID,
     runtime=getattr(exp, "SGLANG_RUNTIME", serving_image.DEFAULT_SGLANG_RUNTIME),
@@ -95,14 +95,18 @@ hf_cache_volume = modal.Volume.from_name(
     "huggingface-cache", create_if_missing=True, version=2
 )
 data_volume = modal.Volume.from_name("slime-data", create_if_missing=True, version=2)
-checkpoints_volume = modal.Volume.from_name(
-    "slime-checkpoints", create_if_missing=True, version=2
+checkpoint_volume = modal.Volume.from_name(
+    "slime-checkpoints",
+    create_if_missing=True,
+    version=2,
 )
 sglang_cache_volume = modal.Volume.from_name(
     "sglang-cache", create_if_missing=True, version=2
 )
-delta_volume = modal.Volume.from_name(
-    exp.DELTA_VOLUME_NAME, create_if_missing=True, version=2
+run_volume = modal.Volume.from_name(
+    exp.EXPERIMENT_VOLUME_NAME,
+    create_if_missing=True,
+    version=2,
 )
 draft_volume = (
     modal.Volume.from_name(
@@ -116,9 +120,9 @@ draft_volume = (
 
 train_volumes = {
     str(HF_CACHE_PATH): hf_cache_volume,
+    str(CHECKPOINTS_PATH): checkpoint_volume,
     str(DATA_PATH): data_volume,
-    str(CHECKPOINTS_PATH): checkpoints_volume,
-    exp.DELTA_BULLETIN_ROOT: delta_volume,
+    str(STITCH_PATH): run_volume,
 }
 
 app = modal.App(APP_NAME)
@@ -138,12 +142,14 @@ SGLANG_SERVER_ARGS = {
 @app.cls(
     image=server_image,
     gpu=f"{modal_cfg.gpu}:{slime_cfg.rollout_num_gpus_per_engine}",
+    cpu=modal_cfg.rollout_cpu,
     cloud=modal_cfg.cloud,
     region=modal_cfg.region,
     volumes={
         str(HF_CACHE_PATH): hf_cache_volume,
+        str(CHECKPOINTS_PATH): checkpoint_volume,
+        str(STITCH_PATH): run_volume,
         SGLANG_CACHE_PATH: sglang_cache_volume,
-        exp.DELTA_BULLETIN_ROOT: delta_volume,
         **({str(DRAFT_PATH): draft_volume} if draft_volume is not None else {}),
     },
     min_containers=modal_cfg.rollout_min_containers,
@@ -170,11 +176,12 @@ class Server:
             sglang_args=SGLANG_SERVER_ARGS,
             tp=slime_cfg.rollout_num_gpus_per_engine,
             concurrency=ROLLOUT_CONCURRENCY,
-            bulletin_root=BULLETIN_ROOT,
+            bulletin_root=str(RUN_DIR),
             local_checkpoint_dir=exp.LOCAL_CHECKPOINT_PATH,
             delta_update_mode=exp.SGLANG_DELTA_UPDATE_MODE,
-            volume_name=exp.DELTA_VOLUME_NAME,
+            volume_name=exp.EXPERIMENT_VOLUME_NAME,
             commit_mode=exp.SIDECAR_COMMIT_MODE,
+            run_id=RUN_ID,
             flush_cache_on_commit=exp.SIDECAR_FLUSH_CACHE_ON_COMMIT,
             startup_timeout=SERVER_STARTUP_TIMEOUT,
         )
@@ -193,6 +200,7 @@ _MULTINODE = slime_cfg.n_train_nodes > 1
 @app.cls(
     image=image,
     gpu=f"{modal_cfg.gpu}:{slime_cfg.actor_num_gpus_per_node}",
+    cpu=modal_cfg.trainer_cpu,
     memory=modal_cfg.trainer_memory_mib,
     cloud=modal_cfg.cloud,
     region=modal_cfg.region,
@@ -241,13 +249,13 @@ class Trainer:
 
         cfg = SlimeConfig.from_payload(payload)
         cfg.rollout_endpoint_url = ModalFlashPool(APP_NAME, "Server").gateway_url()
-        run_id = uuid.uuid4().hex[:12]  # per-launch fence token; forks a fresh chain
-        cfg.update_weight_disk_dir = f"{BULLETIN_ROOT}/{run_id}"
+        # Slime requires this CLI argument; the deployment owns its run-scoped value.
+        cfg.update_weight_disk_dir = str(UPDATES_DIR)
         hook_knobs = {
-            "update_weight_delta_volume_name": exp.DELTA_VOLUME_NAME,
+            "experiment_volume_name": exp.EXPERIMENT_VOLUME_NAME,
             "rollout_modal_flash_app_name": APP_NAME,
             "rollout_modal_flash_server_cls_name": "Server",
-            "run_id": run_id,
+            "run_id": RUN_ID,
         }
         cfg.custom_config_path = (
             hook_knobs  # materialized to a YAML path below; keep the mapping for claim

--- a/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
+++ b/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
@@ -6,13 +6,14 @@ Deploy: EXPERIMENT_CONFIG=kimi_k2_6_int4 uv run --extra modal modal deploy -m co
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH
 from cookbook.slime_disagg.config import SlimeConfig
 
 APP_NAME = "stitch-kimi-k2-6-int4"
-DELTA_VOLUME_NAME = "stitch-delta-kimi-k2-6-int4"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-slime-kimi-k2-6-int4"
 LOCAL_CHECKPOINT_PATH = None
+SOURCE_MODEL = "moonshotai/Kimi-K2.6"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k2-6-int4"
 
 # QAT grouping; MUST match the served INT4 checkpoint's compressed-tensors group_size.
 INT4_GROUP_SIZE = "32"
@@ -64,7 +65,7 @@ class _Slime(SlimeConfig):
     slime_model_script = "scripts/models/kimi-k2-thinking.sh"
 
     # The native-INT4 base is the served model, the QAT init, and the disk-delta base.
-    hf_checkpoint = "moonshotai/Kimi-K2.6"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
     ref_load = hf_checkpoint
     megatron_to_hf_mode = "bridge"
 
@@ -92,9 +93,6 @@ class _Slime(SlimeConfig):
     update_weight_transport = "disk"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = (
-        DELTA_BULLETIN_ROOT  # run-scoped at launch to <root>/<run_id>
-    )
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"
     input_key = "prompt"

--- a/cookbook/slime_disagg/configs/moonlight.py
+++ b/cookbook/slime_disagg/configs/moonlight.py
@@ -6,13 +6,14 @@ Deploy: EXPERIMENT_CONFIG=moonlight m deploy --strategy recreate -m cookbook.sli
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH
 from cookbook.slime_disagg.config import SlimeConfig
 
 APP_NAME = "stitch-moonlight"
-DELTA_VOLUME_NAME = "stitch-delta-moonlight"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-slime-moonlight"
 LOCAL_CHECKPOINT_PATH = None
+SOURCE_MODEL = "moonshotai/Moonlight-16B-A3B-Instruct"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "moonlight-bf16"
 
 # in_place applies weights without draining in-flight rollouts; stale KV isolated per version.
 SIDECAR_COMMIT_MODE = "in_place"
@@ -44,7 +45,7 @@ class _Slime(SlimeConfig):
     # Arch comes from the model script; do NOT inline arch attrs here.
     slime_model_script = "scripts/models/moonlight.sh"
 
-    hf_checkpoint = "moonshotai/Moonlight-16B-A3B-Instruct"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
     ref_load = hf_checkpoint
     megatron_to_hf_mode = "bridge"
 
@@ -72,7 +73,6 @@ class _Slime(SlimeConfig):
     update_weight_transport = "disk"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
     custom_delta_pre_push_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/slime_disagg/configs/moonlight_int4.py
+++ b/cookbook/slime_disagg/configs/moonlight_int4.py
@@ -8,13 +8,14 @@ Deploy: EXPERIMENT_CONFIG=moonlight_int4 m deploy --strategy recreate -m cookboo
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH
 from cookbook.slime_disagg.config import SlimeConfig
 
 APP_NAME = "stitch-moonlight-int4"
-DELTA_VOLUME_NAME = "stitch-delta-moonlight-int4"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-slime-moonlight-int4"
 LOCAL_CHECKPOINT_PATH = None
+SOURCE_MODEL = "moonshotai/Moonlight-16B-A3B-Instruct-INT4"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "moonlight-int4"
 
 INT4_GROUP_SIZE = "128"
 
@@ -47,7 +48,7 @@ class _Slime(SlimeConfig):
     slime_model_script = "scripts/models/moonlight.sh"
 
     # The native-INT4 base is the served model, the QAT init, and the disk-delta base.
-    hf_checkpoint = "moonshotai/Moonlight-16B-A3B-Instruct-INT4"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
     ref_load = hf_checkpoint
     megatron_to_hf_mode = "bridge"
 
@@ -74,7 +75,6 @@ class _Slime(SlimeConfig):
     update_weight_transport = "disk"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
     custom_delta_pre_push_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH
 from cookbook.slime_disagg.config import SlimeConfig
 
 APP_NAME = "stitch-qwen3-4b"
-DELTA_VOLUME_NAME = "stitch-delta-qwen3-4b"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-slime-qwen3-4b"
 LOCAL_CHECKPOINT_PATH = None
+SOURCE_MODEL = "Qwen/Qwen3-4B"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "qwen3-4b-bf16"
 
 # in_place applies weights without draining; stale KV isolated per version via extra_key.
 SIDECAR_COMMIT_MODE = "in_place"
@@ -37,7 +38,7 @@ modal = ModalConfig(
 
 
 class _Slime(SlimeConfig):
-    hf_checkpoint = "Qwen/Qwen3-4B"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
     ref_load = hf_checkpoint
     megatron_to_hf_mode = "bridge"
 
@@ -64,7 +65,6 @@ class _Slime(SlimeConfig):
     update_weight_transport = "disk"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
     custom_delta_pre_push_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/gsm8k/train.parquet"

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash_hillclimb.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash_hillclimb.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from cookbook.slime_disagg.configs import qwen3_4b_delta_flash as _base
 
 APP_NAME = "stitch-qwen3-4b-hillclimb"
-DELTA_VOLUME_NAME = "stitch-delta-qwen3-4b-hillclimb"
-DELTA_BULLETIN_ROOT = _base.DELTA_BULLETIN_ROOT
+EXPERIMENT_VOLUME_NAME = _base.EXPERIMENT_VOLUME_NAME
+SOURCE_MODEL = _base.SOURCE_MODEL
+ROLLOUT_CHECKPOINT_PATH = _base.ROLLOUT_CHECKPOINT_PATH
 LOCAL_CHECKPOINT_PATH = _base.LOCAL_CHECKPOINT_PATH
 SIDECAR_COMMIT_MODE = _base.SIDECAR_COMMIT_MODE
 SIDECAR_FLUSH_CACHE_ON_COMMIT = _base.SIDECAR_FLUSH_CACHE_ON_COMMIT

--- a/cookbook/slime_disagg/prep_app.py
+++ b/cookbook/slime_disagg/prep_app.py
@@ -14,10 +14,17 @@ from __future__ import annotations
 
 import importlib
 import os
+import shutil
+from pathlib import Path
 
 import modal
 
-from cookbook.common.constants import DATA_PATH, HF_CACHE_PATH, MINUTES
+from cookbook.common.constants import (
+    CHECKPOINTS_PATH,
+    DATA_PATH,
+    HF_CACHE_PATH,
+    MINUTES,
+)
 from cookbook.slime_disagg import trainer_image
 
 EXPERIMENT = os.environ[
@@ -38,23 +45,46 @@ hf_cache_volume = modal.Volume.from_name(
     "huggingface-cache", create_if_missing=True, version=2
 )
 data_volume = modal.Volume.from_name("slime-data", create_if_missing=True, version=2)
+checkpoint_volume = modal.Volume.from_name(
+    "slime-checkpoints",
+    create_if_missing=True,
+    version=2,
+)
 
 app = modal.App(f"{exp.APP_NAME}-prep")
 
 
 @app.function(
     image=image,
-    volumes={str(HF_CACHE_PATH): hf_cache_volume},
+    volumes={
+        str(HF_CACHE_PATH): hf_cache_volume,
+        str(CHECKPOINTS_PATH): checkpoint_volume,
+    },
     timeout=2 * 60 * MINUTES,
     secrets=[modal.Secret.from_name("huggingface-secret")],
     include_source=False,
 )
 def download_model() -> None:
-    """Snapshot the served model into the HF cache (sglang serves it by repo id)."""
+    """Materialize the configured model artifact in the checkpoint Volume."""
     from huggingface_hub import snapshot_download
 
-    snapshot_download(repo_id=slime_cfg.hf_checkpoint)
-    hf_cache_volume.commit()
+    checkpoint_volume.reload()
+    target = Path(slime_cfg.hf_checkpoint)
+    if (target / "config.json").is_file():
+        print(f"reusing model checkpoint {target}")
+        return
+    if target.exists():
+        raise RuntimeError(f"incomplete model checkpoint: {target}")
+    partial = target.with_name(f"{target.name}.partial")
+    shutil.rmtree(partial, ignore_errors=True)
+    snapshot_download(
+        repo_id=exp.SOURCE_MODEL,
+        revision=getattr(exp, "SOURCE_REVISION", None),
+        local_dir=partial,
+    )
+    shutil.rmtree(partial / ".cache", ignore_errors=True)
+    partial.rename(target)
+    checkpoint_volume.commit()
 
 
 @app.function(

--- a/src/stitch/stores/modal_volume.py
+++ b/src/stitch/stores/modal_volume.py
@@ -1,10 +1,9 @@
 """``ModalVolumeStore`` — the ``Store`` instance backed by a Modal Volume.
 
-Each run's chain lives under ``<root>/<run_id>/weight_vNNNNNN/`` (run-less:
-``<root>/weight_vNNNNNN/``) as HF-safetensors + delta metadata, and a ``latest``
-text file holds the self-identifying pointer identity. Durability is an explicit
-Volume commit; cross-host visibility is a reload. With ``volume_name=None`` it is a
-plain local directory, so the class is exercisable without Modal.
+``root`` is one run's directory. The training framework owns
+``<root>/updates/`` and may recreate it while initializing; Stitch owns the
+self-identifying ``<root>/latest`` commit pointer. Durability is an explicit
+Volume commit and cross-host visibility is a reload.
 """
 
 from __future__ import annotations
@@ -21,9 +20,18 @@ _POINTER = "latest"
 
 
 class ModalVolumeStore(Store):
-    def __init__(self, root: str | Path, *, volume_name: str | None = None) -> None:
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        run_id: str,
+        volume_name: str | None = None,
+    ) -> None:
+        if not run_id:
+            raise ValueError("run_id is required")
         self.root = Path(root)
         self.volume_name = volume_name
+        self.run_id = run_id
 
     def refresh(self) -> None:
         if self.volume_name:
@@ -37,6 +45,10 @@ class ModalVolumeStore(Store):
         return VersionRef.parse(text) if text else None
 
     def advance_pointer(self, ref: VersionRef) -> None:
+        if ref.run_id != self.run_id:
+            raise ValueError(
+                f"store is scoped to run {self.run_id!r}, got {ref.run_id!r}"
+            )
         self.root.mkdir(parents=True, exist_ok=True)
         _atomic_write(self.root / _POINTER, ref.identity)
         if self.volume_name:
@@ -77,7 +89,11 @@ class ModalVolumeStore(Store):
             _volume(self.volume_name).commit()
 
     def _version_dir(self, ref: VersionRef) -> Path:
-        return self.root / ref.identity
+        if ref.run_id != self.run_id:
+            raise ValueError(
+                f"store is scoped to run {self.run_id!r}, got {ref.run_id!r}"
+            )
+        return self.root / "updates" / Path(ref.identity).name
 
 
 def _volume(name: str):

--- a/src/stitch/stores/modal_volume_test.py
+++ b/src/stitch/stores/modal_volume_test.py
@@ -18,7 +18,7 @@ from stitch.types import VersionKind, VersionRef
 def _write_version(
     root: Path, ref: VersionRef, *, base: int | None = None, diff: str | None = None
 ) -> str:
-    d = root / ref.identity
+    d = root / "updates" / Path(ref.identity).name
     d.mkdir(parents=True)
     meta: dict = {"version": ref.version}
     if diff:
@@ -40,7 +40,7 @@ def _write_version(
 def test_publish_full_roundtrip() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        store = ModalVolumeStore(root)
+        store = ModalVolumeStore(root, run_id="r1")
         assert store.read_pointer() is None
         vdir = _write_version(root, VersionRef("r1", 1))  # framework wrote it in place
         ref = publish_version(store, None, vdir, run_id="r1")
@@ -56,7 +56,7 @@ def test_publish_full_roundtrip() -> None:
 def test_claim_then_delta_chain() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        store = ModalVolumeStore(root)
+        store = ModalVolumeStore(root, run_id="r1")
         store.claim("r1")
         assert store.read_pointer() == VersionRef("r1", 0)  # base before any publish
         publish_version(
@@ -77,14 +77,48 @@ def test_copies_when_files_dir_is_external() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root, staging = Path(tmp) / "store", Path(tmp) / "staging"
         root.mkdir()
-        store = ModalVolumeStore(root)
+        store = ModalVolumeStore(root, run_id="r1")
         src = _write_version(
             staging, VersionRef("r1", 1)
         )  # a staging dir, not the store layout
         publish_version(store, None, src, run_id="r1")
         assert (
-            root / "r1" / "weight_v000001" / "model.safetensors.index.json"
+            root / "updates" / "weight_v000001" / "model.safetensors.index.json"
         ).exists()
+
+
+def test_rejects_a_version_from_another_run() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        store = ModalVolumeStore(tmp, run_id="r1")
+        try:
+            store.advance_pointer(VersionRef("r2", 1))
+        except ValueError as exc:
+            assert "scoped to run 'r1'" in str(exc)
+        else:
+            raise AssertionError("cross-run pointer must fail")
+
+
+def test_runs_sharing_a_volume_have_independent_state() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        volume_root = Path(tmp)
+        first_root = volume_root / "run-a"
+        second_root = volume_root / "run-b"
+        first = ModalVolumeStore(first_root, run_id="run-a")
+        second = ModalVolumeStore(second_root, run_id="run-b")
+
+        first.claim("run-a")
+        second.claim("run-b")
+        publish_version(
+            first,
+            None,
+            _write_version(first_root, VersionRef("run-a", 1)),
+            run_id="run-a",
+        )
+
+        assert first.read_pointer() == VersionRef("run-a", 1)
+        assert second.read_pointer() == VersionRef("run-b", 0)
+        assert Path(first.materialize(VersionRef("run-a", 1))).is_dir()
+        assert not Path(second.materialize(VersionRef("run-b", 1))).exists()
 
 
 if __name__ == "__main__":

--- a/tools/profiling/glm45_air_fp8_delta_weight_update.py
+++ b/tools/profiling/glm45_air_fp8_delta_weight_update.py
@@ -69,7 +69,6 @@ delta_volume = modal.Volume.from_name(DELTA_VOLUME_NAME, version=2)
 sglang_cache_volume = modal.Volume.from_name(SGLANG_CACHE_VOLUME_NAME, version=2)
 image = build_serving_image(
     hf_cache_path="/root/.cache/huggingface",
-    delta_volume_name=DELTA_VOLUME_NAME,
     experiment=EXPERIMENT,
 ).add_local_dir(
     str(Path(__file__).resolve().parents[1]),

--- a/tools/profiling/kimi_k2_6_nvfp4_delta_weight_update.py
+++ b/tools/profiling/kimi_k2_6_nvfp4_delta_weight_update.py
@@ -74,7 +74,6 @@ delta_volume = modal.Volume.from_name(DELTA_VOLUME_NAME, version=2)
 sglang_cache_volume = modal.Volume.from_name(SGLANG_CACHE_VOLUME_NAME, version=2)
 image = build_serving_image(
     hf_cache_path="/root/.cache/huggingface",
-    delta_volume_name=DELTA_VOLUME_NAME,
     experiment=EXPERIMENT,
 ).add_local_dir(
     str(Path(__file__).resolve().parents[1]),


### PR DESCRIPTION
## Summary

- keep immutable model artifacts under `/checkpoints/<artifact-id>`
- keep mutable state under `/stitch/<run-id>`
- derive `RUN_DIR` and framework update paths at launch instead of placing deployment paths in static experiment configs
- scope `ModalVolumeStore` and the Miles/Slime sidecars to one run
- keep Stitch's committed `latest` pointer outside framework-owned `updates/`
- migrate the current cookbook recipes and document the Volume contract

The apps derive their few child paths directly from `RUN_DIR`; there is no run-layout wrapper. Checkpoint, dataset, and compiler-cache Volumes remain shared immutable inputs, while mutable run state is namespaced by the launch ID.

## Stack

1. #94 — storage and run-state contract (this PR)
2. #96 — GLM-5.2 NVFP4 + SWE-bench Pro experiment

Repository-wide formatting landed separately in #98.

## Validation

- `uv run ruff format --check .` — 80 files already formatted
- `uv run ruff check .`
- `uv run pytest` — 83 passed
- same-Volume two-run test verifies independent pointers and update directories