### PR TITLE
cookbook: prepare pinned SWE-bench Pro tasks

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -35,6 +35,56 @@ the replica. Bundled MTP heads do not need a separate volume.
 
 ## Prepare and launch
 
+All persistent storage uses Modal Volume v2:
+
+| Volume | Mount | Contents |
+| --- | --- | --- |
+| `huggingface-cache` | `/root/.cache/huggingface` | Pinned source-model downloads |
+| `miles-checkpoints` or `slime-checkpoints` | `/checkpoints` | Immutable prepared model layouts |
+| `miles-data` or `slime-data` | `/data` | Immutable dataset revisions |
+| `stitch-<framework>-<model>` | `/stitch` | Run-scoped publications, checkpoints, and logs |
+| `sglang-cache` | `/root/.cache/sglang` | Compiled SGLang kernels |
+| Configured draft Volume | `/draft` | Optional external speculative draft |
+
+Prepared model layouts are immutable artifacts with explicit paths. For
+example, the Miles GLM-5.2 config uses:
+
+```text
+/checkpoints/
+├── glm5-2-nvfp4/
+└── glm5-2-torch-dist/
+```
+
+Each config also owns one `stitch-<framework>-<model>` Volume mounted at
+`/stitch`. Its root contains only run-scoped state:
+
+```text
+/stitch/
+└── <run-id>/
+    ├── latest
+    ├── updates/weight_vNNNNNN/
+    ├── checkpoints/
+    └── train.log
+```
+
+The training framework owns `updates/`; Stitch owns the `latest` commit
+pointer. A future checkpoint resume starts a new run and reads the previous
+run's `checkpoints/` rather than appending to its update chain.
+
+Datasets are independent of models and runs. Miles mounts the shared
+`miles-data` Volume at `/data`; Slime uses `slime-data`. Each immutable dataset
+revision has its own directory:
+
+```text
+/data/
+└── datasets/
+    └── <dataset>/
+        └── <revision>/
+            ├── manifest.json
+            ├── <trainer-input>
+            └── <dataset-specific-assets>/
+```
+
 Miles:
 
 ```bash
@@ -77,7 +127,7 @@ gateway and every live replica with:
 ```bash
 uv run --extra modal python -m cookbook.common.smoke \
   --app-name <app-name> \
-  --model-name /prep/glm45-air/fp8 \
+  --model-name /checkpoints/glm45-air-fp8 \
   --weight-version 10
 ```
 

--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -56,8 +56,8 @@ images.
 
 ```json
 {
-  "base_checkpoint_dir": "/prep/model/format",
-  "checkpoint_source_dir": "/delta-bulletin/run",
+  "base_checkpoint_dir": "/checkpoints/<artifact-id>",
+  "checkpoint_source_dir": "/stitch/<run-id>/updates",
   "local_checkpoint_dir": "/local-checkpoint",
   "target_version": 7,
   "destination": "disk"

--- a/cookbook/common/constants.py
+++ b/cookbook/common/constants.py
@@ -1,7 +1,4 @@
-"""Shared deployment constants — container mount points, ports, and timeouts, general
-across every recipe. The per-experiment names/values (APP_NAME, DELTA_VOLUME_NAME, the
-disk layout) live in the config modules.
-"""
+"""Shared deployment constants — container mount points, ports, and timeouts."""
 
 from __future__ import annotations
 
@@ -9,11 +6,13 @@ from pathlib import Path
 
 # Container mount points (Modal Volumes attach here).
 HF_CACHE_PATH = Path("/root/.cache/huggingface")
-DATA_PATH = Path("/data")
 CHECKPOINTS_PATH = Path("/checkpoints")
-PREP_PATH = Path("/prep")  # <PREP>/<tag>/{bf16 masters, served base, torch_dist ref_load}
+DATA_PATH = Path("/data")
+STITCH_PATH = Path("/stitch")
 DRAFT_PATH = Path("/draft")
-SGLANG_CACHE_PATH = "/root/.cache/sglang"  # sglang kernel/JIT cache; survives cold starts
+SGLANG_CACHE_PATH = (
+    "/root/.cache/sglang"  # sglang kernel/JIT cache; survives cold starts
+)
 
 # Ports.
 SIDECAR_PORT = 8000  # the container's public port

--- a/cookbook/common/hooks.py
+++ b/cookbook/common/hooks.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import time
 from pathlib import Path
 from typing import Any
@@ -127,10 +126,14 @@ class _CachedPointer:
     async def get(self, args: Any, ttl: float = 2.0) -> int:
         store = self._store
         root = Path(_transport_root(args))
-        volume = getattr(
-            args, "update_weight_delta_volume_name", None
-        ) or os.environ.get("DELTA_VOLUME_NAME")
-        if store is None or store.root != root or store.volume_name != (volume or None):
+        run_id = _run_id(args)
+        volume = getattr(args, "experiment_volume_name", None)
+        if (
+            store is None
+            or store.root != root
+            or store.run_id != run_id
+            or store.volume_name != (volume or None)
+        ):
             store = self._store = _store(args)
             self._version = 0
             self._at = -1e9
@@ -157,27 +160,27 @@ _latest = _CachedPointer()
 
 # ── args → run coordinates ───────────────────────────────────────────────────────
 def _store(args: Any) -> ModalVolumeStore:
-    volume = getattr(args, "update_weight_delta_volume_name", None) or os.environ.get(
-        "DELTA_VOLUME_NAME"
+    volume = getattr(args, "experiment_volume_name", None)
+    return ModalVolumeStore(
+        _transport_root(args),
+        volume_name=volume or None,
+        run_id=_run_id(args),
     )
-    return ModalVolumeStore(_transport_root(args), volume_name=volume or None)
 
 
 def _pool(args: Any) -> ModalFlashPool:
-    app = getattr(args, "rollout_modal_flash_app_name", None) or os.environ.get(
-        "DELTA_APP_NAME"
-    )
-    cls = getattr(args, "rollout_modal_flash_server_cls_name", None) or os.environ.get(
-        "DELTA_SERVER_CLS_NAME", "Server"
-    )
+    app = getattr(args, "rollout_modal_flash_app_name", None)
+    if not app:
+        raise ValueError("rollout_modal_flash_app_name is required")
+    cls = getattr(args, "rollout_modal_flash_server_cls_name", "Server")
     return ModalFlashPool(app, cls)
 
 
 def _transport_root(args: Any) -> str:
-    # The trainer writes version dirs under <root>/<run_id>; the Store is rooted at <root>.
-    write_dir = getattr(args, "update_weight_disk_dir", None) or os.environ.get(
-        "DELTA_BULLETIN_ROOT", "/delta-bulletin"
-    )
+    # The framework owns <run>/updates; Stitch owns <run>/latest.
+    write_dir = getattr(args, "update_weight_disk_dir", None)
+    if not write_dir:
+        raise ValueError("update_weight_disk_dir is required")
     return str(Path(write_dir).parent)
 
 

--- a/cookbook/common/hooks_test.py
+++ b/cookbook/common/hooks_test.py
@@ -30,14 +30,15 @@ class _FakePool:
 
 
 def _args(root: str, run_id: str = "run-abc", **extra):
-    # transport root = parent of update_weight_disk_dir, so the Store roots at `root`.
     return SimpleNamespace(
-        update_weight_disk_dir=f"{root}/{run_id}", run_id=run_id, **extra
+        update_weight_disk_dir=f"{root}/updates",
+        run_id=run_id,
+        **extra,
     )
 
 
 def _write_version(root: Path, ref: VersionRef) -> str:
-    d = root / ref.identity
+    d = root / "updates" / Path(ref.identity).name
     d.mkdir(parents=True)
     (d / "model.safetensors.index.json").write_text(
         json.dumps(
@@ -79,7 +80,9 @@ def test_commit_and_wake_publishes() -> None:
             hooks.publish_version = original_publish
             ModalVolumeStore.commit = original_commit
         assert events == ["commit", "barrier", "publish"]
-        assert ModalVolumeStore(root).read_pointer() == VersionRef("run-abc", 1)
+        assert ModalVolumeStore(root, run_id="run-abc").read_pointer() == VersionRef(
+            "run-abc", 1
+        )
         assert pool.woke == [VersionRef("run-abc", 1)]
 
 
@@ -89,8 +92,8 @@ def test_commit_and_wake_baseline_is_noop() -> None:
         root = Path(tmp)
         pool = _FakePool()
         hooks._pool = lambda args: pool
-        run_dir = root / "run-abc"
-        run_dir.mkdir(parents=True)
+        updates = root / "updates"
+        updates.mkdir(parents=True, exist_ok=True)
         original_barrier = hooks.process.dist_barrier
 
         def unexpected_barrier() -> None:
@@ -98,10 +101,10 @@ def test_commit_and_wake_baseline_is_noop() -> None:
 
         hooks.process.dist_barrier = unexpected_barrier
         try:
-            hooks.commit_and_wake(_args(str(root)), str(run_dir))
+            hooks.commit_and_wake(_args(str(root)), str(updates))
         finally:
             hooks.process.dist_barrier = original_barrier
-        assert ModalVolumeStore(root).read_pointer() is None
+        assert ModalVolumeStore(root, run_id="run-abc").read_pointer() is None
         assert pool.woke == []
 
 
@@ -110,14 +113,16 @@ def test_claim_pool_resets_to_base() -> None:
         pool = _FakePool()
         hooks._pool = lambda args: pool
         hooks.claim_pool(_args(tmp))
-        assert ModalVolumeStore(Path(tmp)).read_pointer() == VersionRef("run-abc", 0)
+        assert ModalVolumeStore(
+            Path(tmp), run_id="run-abc"
+        ).read_pointer() == VersionRef("run-abc", 0)
         assert pool.woke == [VersionRef("run-abc", 0)]
 
 
 def test_request_hook_min_lag() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        ModalVolumeStore(root).advance_pointer(
+        ModalVolumeStore(root, run_id="run-abc").advance_pointer(
             VersionRef("run-abc", 10)
         )  # published latest
         hooks._latest = hooks._CachedPointer()  # fresh cache reading this store
@@ -156,7 +161,9 @@ def test_sample_affinity_key_fallbacks() -> None:
 def test_request_hook_exact_and_none() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        ModalVolumeStore(root).advance_pointer(VersionRef("run-abc", 10))
+        ModalVolumeStore(root, run_id="run-abc").advance_pointer(
+            VersionRef("run-abc", 10)
+        )
         hooks._latest = hooks._CachedPointer()
         exact_req = {"payload": {}}
         asyncio.run(
@@ -195,21 +202,27 @@ def test_request_hook_cache_switches_runs() -> None:
         tempfile.TemporaryDirectory() as first,
         tempfile.TemporaryDirectory() as second,
     ):
-        ModalVolumeStore(first).advance_pointer(VersionRef("run-a", 7))
-        ModalVolumeStore(second).advance_pointer(VersionRef("run-b", 3))
+        ModalVolumeStore(first, run_id="run-a").advance_pointer(VersionRef("run-a", 7))
+        ModalVolumeStore(second, run_id="run-b").advance_pointer(VersionRef("run-b", 3))
         hooks._latest = hooks._CachedPointer()
 
-        async def read(root: str) -> dict:
+        async def read(root: str, run_id: str) -> dict:
             request = {"payload": {}}
             await hooks.gated_rollout_request_hook(
-                _args(root, rollout_request_weight_version_lag=0),
+                _args(root, run_id=run_id, rollout_request_weight_version_lag=0),
                 SimpleNamespace(session_id=None),
                 request,
             )
             return request["payload"]["weight_version"]
 
-        assert asyncio.run(read(first)) == {"min_version": 7, "exact_version": None}
-        assert asyncio.run(read(second)) == {"min_version": 3, "exact_version": None}
+        assert asyncio.run(read(first, "run-a")) == {
+            "min_version": 7,
+            "exact_version": None,
+        }
+        assert asyncio.run(read(second, "run-b")) == {
+            "min_version": 3,
+            "exact_version": None,
+        }
 
 
 if __name__ == "__main__":

--- a/cookbook/common/process.py
+++ b/cookbook/common/process.py
@@ -26,6 +26,7 @@ def start_sidecar(
     delta_update_mode: str,
     disk_load_format: str,
     volume_name: str,
+    run_id: str,
     commit_mode: str,
     flush_cache_on_commit: bool = False,
     debug_requests: bool = False,
@@ -51,6 +52,8 @@ def start_sidecar(
         disk_load_format,
         "--volume-name",
         volume_name,
+        "--run-id",
+        run_id,
         "--commit-mode",
         commit_mode,
     ]
@@ -69,7 +72,9 @@ def wait_http(url: str, process: subprocess.Popen | None, timeout: int) -> None:
     last_error: str | None = None
     while time.time() < deadline:
         if process is not None and process.poll() is not None:
-            raise RuntimeError(f"process exited while waiting for {url}: code={process.returncode}")
+            raise RuntimeError(
+                f"process exited while waiting for {url}: code={process.returncode}"
+            )
         try:
             with urllib.request.urlopen(url, timeout=5) as resp:
                 if 200 <= resp.status < 500:
@@ -99,18 +104,26 @@ def apply_git_patches(patch_paths: list[str], repo_dir: str, label: str) -> None
     for patch_path in patch_paths:
         if not os.path.exists(patch_path):
             raise FileNotFoundError(f"{label} not found: {patch_path}")
-        check = subprocess.run(["git", "-C", repo_dir, "apply", "--check", patch_path], capture_output=True, text=True)
+        check = subprocess.run(
+            ["git", "-C", repo_dir, "apply", "--check", patch_path],
+            capture_output=True,
+            text=True,
+        )
         if check.returncode == 0:
             subprocess.run(["git", "-C", repo_dir, "apply", patch_path], check=True)
             print(f"[{label}] applied {patch_path}", flush=True)
             continue
         reverse = subprocess.run(
-            ["git", "-C", repo_dir, "apply", "--reverse", "--check", patch_path], capture_output=True, text=True
+            ["git", "-C", repo_dir, "apply", "--reverse", "--check", patch_path],
+            capture_output=True,
+            text=True,
         )
         if reverse.returncode == 0:
             print(f"[{label}] already applied {patch_path}", flush=True)
             continue
-        raise RuntimeError(f"cannot apply {label} {patch_path}\ncheck: {check.stderr}\nreverse: {reverse.stderr}")
+        raise RuntimeError(
+            f"cannot apply {label} {patch_path}\ncheck: {check.stderr}\nreverse: {reverse.stderr}"
+        )
 
 
 def start_host_mem_monitor(interval_s: int = 20) -> None:
@@ -140,7 +153,10 @@ def start_host_mem_monitor(interval_s: int = 20) -> None:
         while True:
             total, avail = _meminfo()
             if i == 0 or avail < 500 or i % heartbeat == 0:
-                print(f"[hostmem] {host} used={total - avail:.0f}GiB avail={avail:.0f}GiB total={total:.0f}GiB", flush=True)
+                print(
+                    f"[hostmem] {host} used={total - avail:.0f}GiB avail={avail:.0f}GiB total={total:.0f}GiB",
+                    flush=True,
+                )
             i += 1
             time.sleep(interval_s)
 

--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -28,6 +28,7 @@ def serve_startup(
     local_checkpoint_dir: str | None,
     delta_update_mode: str,
     volume_name: str,
+    run_id: str,
     commit_mode: str,
     flush_cache_on_commit: bool = False,
     startup_timeout: int,
@@ -63,10 +64,17 @@ def serve_startup(
     warmup = {
         "model": model_name,
         "messages": [{"role": "user", "content": "Reply with exactly OK."}],
-        "max_tokens": 8, "temperature": 0, "chat_template_kwargs": {"enable_thinking": False},
+        "max_tokens": 8,
+        "temperature": 0,
+        "chat_template_kwargs": {"enable_thinking": False},
     }
-    warmup_chat_completions(port=SGLANG_PORT, payload=warmup, successful_requests=2,
-                            request_timeout=120.0, max_attempts_per_request=3)
+    warmup_chat_completions(
+        port=SGLANG_PORT,
+        payload=warmup,
+        successful_requests=2,
+        request_timeout=120.0,
+        max_attempts_per_request=3,
+    )
     replica.sidecar = process.start_sidecar(
         sidecar_port=SIDECAR_PORT,
         sglang_port=SGLANG_PORT,
@@ -76,6 +84,7 @@ def serve_startup(
         delta_update_mode=delta_update_mode,
         disk_load_format=str(sglang_args.get("--load-format", "auto")),
         volume_name=volume_name,
+        run_id=run_id,
         commit_mode=commit_mode,
         flush_cache_on_commit=flush_cache_on_commit,
     )
@@ -83,7 +92,9 @@ def serve_startup(
     # blocking here on /health (503 until the reconciler's first catch-up) is the only thing that keeps a
     # not-yet-synced replica out of rotation. Fresh boot (no pointer) clears at once; a mid-run joiner
     # waits until it has applied the live version, bounded by startup_timeout.
-    process.wait_http(f"http://127.0.0.1:{SIDECAR_PORT}/health", replica.sidecar, startup_timeout)
+    process.wait_http(
+        f"http://127.0.0.1:{SIDECAR_PORT}/health", replica.sidecar, startup_timeout
+    )
 
     def engine_health() -> str | None:
         # Weight staging can make the engine health endpoint briefly stale.
@@ -91,7 +102,11 @@ def serve_startup(
         error = replica.endpoint.health_check()
         if error is None:
             return None
-        return None if sync_in_progress(f"http://127.0.0.1:{SIDECAR_PORT}/server_info") else error
+        return (
+            None
+            if sync_in_progress(f"http://127.0.0.1:{SIDECAR_PORT}/server_info")
+            else error
+        )
 
     import modal.experimental
 

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -49,17 +49,13 @@ _SERVING_ENV = {
 def build_serving_image(
     *,
     hf_cache_path: str,
-    delta_volume_name: str | None = None,
     experiment: str,
     run_id: str | None = None,
     extra_packages: Sequence[str] = (),
     extra_env: Mapping[str, str] | None = None,
     runtime: SGLangRuntime = DEFAULT_SGLANG_RUNTIME,
 ) -> modal.Image:
-    """The rollout-pool image. Volume-backed recipes set ``delta_volume_name`` for their
-    Store; other Store backends omit it. Backend-specific packages and environment
-    belong in ``extra_packages`` / ``extra_env`` so all build steps still precede the
-    local source layers."""
+    """Build the rollout-pool image for one experiment config."""
     return (
         modal.Image.from_registry(runtime.image)
         .run_commands(
@@ -90,11 +86,6 @@ def build_serving_image(
                 **_SERVING_ENV,
                 **(extra_env or {}),
                 "EXPERIMENT_CONFIG": experiment,
-                **(
-                    {"DELTA_VOLUME_NAME": delta_volume_name}
-                    if delta_volume_name
-                    else {}
-                ),
                 **({"RUN_ID": run_id} if run_id else {}),
             }
         )

--- a/cookbook/common/sidecar.py
+++ b/cookbook/common/sidecar.py
@@ -41,14 +41,20 @@ def main() -> None:
     p.add_argument("--volume-name", default="")
     p.add_argument("--commit-mode", choices=["in_place", "quiesce"], default="in_place")
     p.add_argument("--flush-cache-on-commit", action="store_true")
-    p.add_argument("--run-id", default=None)
+    p.add_argument("--run-id", required=True)
     p.add_argument("--debug-requests", action="store_true")
-    p.add_argument("--reconcile-interval", type=float, default=5.0)  # 0 disables the periodic re-check
+    p.add_argument(
+        "--reconcile-interval", type=float, default=5.0
+    )  # 0 disables the periodic re-check
     args = p.parse_args()
     if args.delta_update_mode == "disk" and not args.local_checkpoint_dir:
         p.error("--local-checkpoint-dir is required in disk mode")
 
-    store = ModalVolumeStore(args.bulletin_root, volume_name=args.volume_name or None)
+    store = ModalVolumeStore(
+        args.bulletin_root,
+        volume_name=args.volume_name or None,
+        run_id=args.run_id,
+    )
     engine = SGLangEngine(
         args.upstream,
         args.base_checkpoint_dir,

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -23,7 +23,6 @@ import importlib
 import os
 import subprocess
 import tempfile
-import uuid
 from types import SimpleNamespace
 from typing import Any
 
@@ -37,53 +36,79 @@ from cookbook.common.constants import (
     DRAFT_PATH,
     HF_CACHE_PATH,
     MINUTES,
-    PREP_PATH,
     RAY_PORT,
     SERVER_STARTUP_TIMEOUT,
     SGLANG_CACHE_PATH,
     SIDECAR_PORT,
+    STITCH_PATH,
 )
 from cookbook.miles_disagg import trainer_image
 from cookbook.miles_disagg.config import YAML_CONFIG_FIELDS, MilesConfig
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
 from stitch.pools.modal_flash import ModalFlashPool
 
-EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]  # required; a default would silently serve the wrong experiment
-MILES_LOCAL_DIR = os.environ.get("MILES_LOCAL_DIR")  # optional dev overlay of a local miles checkout
+EXPERIMENT = os.environ[
+    "EXPERIMENT_CONFIG"
+]  # required; a default would silently serve the wrong experiment
+MILES_LOCAL_DIR = os.environ.get(
+    "MILES_LOCAL_DIR"
+)  # optional dev overlay of a local miles checkout
 
 exp = importlib.import_module(f"cookbook.miles_disagg.configs.{EXPERIMENT}")
 modal_cfg = exp.modal
 miles_cfg = exp.miles
 
-# Per-run id, minted fresh per launch by cookbook.miles_disagg.launch: names the pool app + delta
-# transport root, so each run — even an identical-config relaunch — is its own isolated pool.
+# Per-run id, minted fresh by cookbook.miles_disagg.launch. The same identity
+# scopes the pool, Stitch pointer, publications, checkpoints, and logs.
 RUN_ID = os.environ["RUN_ID"]
 APP_NAME = f"{exp.APP_NAME}-{RUN_ID}"
-BULLETIN_ROOT = f"{exp.DELTA_BULLETIN_ROOT}/{RUN_ID}"
+RUN_ROOT = f"{STITCH_PATH}/{RUN_ID}"
+UPDATE_ROOT = f"{RUN_ROOT}/updates"
 
 # Flash autoscaler target / sglang concurrency cap: explicit target_inputs, else engine concurrency.
-ROLLOUT_CONCURRENCY = modal_cfg.rollout_target_inputs or miles_cfg.sglang_server_concurrency
+ROLLOUT_CONCURRENCY = (
+    modal_cfg.rollout_target_inputs or miles_cfg.sglang_server_concurrency
+)
 
 # EXPERIMENT_CONFIG + RUN are baked into both images so a container's re-import rebuilds the same
 # app name and transport paths as the deploy, not the defaults.
-image = trainer_image.build_trainer_image(hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, run_id=RUN_ID, miles_local=MILES_LOCAL_DIR)
+image = trainer_image.build_trainer_image(
+    hf_cache_path=str(HF_CACHE_PATH),
+    experiment=EXPERIMENT,
+    run_id=RUN_ID,
+    miles_local=MILES_LOCAL_DIR,
+)
 server_image = serving_image.build_serving_image(
     hf_cache_path=str(HF_CACHE_PATH),
-    delta_volume_name=exp.DELTA_VOLUME_NAME,
     experiment=EXPERIMENT,
     run_id=RUN_ID,
     extra_env=getattr(exp, "SGLANG_SERVER_ENV", None),
     runtime=getattr(exp, "SGLANG_RUNTIME", serving_image.DEFAULT_SGLANG_RUNTIME),
 )
 if MILES_LOCAL_DIR:
-    server_image = server_image.add_local_dir(MILES_LOCAL_DIR, remote_path=MILES_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])
+    server_image = server_image.add_local_dir(
+        MILES_LOCAL_DIR,
+        remote_path=MILES_ROOT,
+        ignore=[".git", "**/__pycache__", "**/*.pyc"],
+    )
 
-hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=True, version=2)
+hf_cache_volume = modal.Volume.from_name(
+    "huggingface-cache", create_if_missing=True, version=2
+)
 data_volume = modal.Volume.from_name("miles-data", create_if_missing=True, version=2)
-checkpoints_volume = modal.Volume.from_name("miles-checkpoints", create_if_missing=True, version=2)
-prep_volume = modal.Volume.from_name("miles-prep-checkpoints", create_if_missing=True, version=2)
-sglang_cache_volume = modal.Volume.from_name("sglang-cache", create_if_missing=True, version=2)  # survives cold starts
-delta_volume = modal.Volume.from_name(exp.DELTA_VOLUME_NAME, create_if_missing=True, version=2)
+checkpoint_volume = modal.Volume.from_name(
+    "miles-checkpoints",
+    create_if_missing=True,
+    version=2,
+)
+run_volume = modal.Volume.from_name(
+    exp.EXPERIMENT_VOLUME_NAME,
+    create_if_missing=True,
+    version=2,
+)
+sglang_cache_volume = modal.Volume.from_name(
+    "sglang-cache", create_if_missing=True, version=2
+)  # survives cold starts
 draft_volume = (
     modal.Volume.from_name(
         modal_cfg.draft_volume,
@@ -96,10 +121,9 @@ draft_volume = (
 
 train_volumes = {
     str(HF_CACHE_PATH): hf_cache_volume,
+    str(CHECKPOINTS_PATH): checkpoint_volume,
     str(DATA_PATH): data_volume,
-    str(CHECKPOINTS_PATH): checkpoints_volume,
-    str(PREP_PATH): prep_volume,
-    exp.DELTA_BULLETIN_ROOT: delta_volume,
+    str(STITCH_PATH): run_volume,
 }
 
 app = modal.App(APP_NAME)
@@ -118,34 +142,45 @@ SGLANG_SERVER_ARGS = {
 @app.cls(
     image=server_image,
     gpu=f"{modal_cfg.gpu}:{miles_cfg.rollout_num_gpus_per_engine}",
-    cloud=modal_cfg.cloud, region=modal_cfg.region,
+    cloud=modal_cfg.cloud,
+    region=modal_cfg.region,
     volumes={
         str(HF_CACHE_PATH): hf_cache_volume,
-        str(PREP_PATH): prep_volume,
+        str(CHECKPOINTS_PATH): checkpoint_volume,
+        str(STITCH_PATH): run_volume,
         SGLANG_CACHE_PATH: sglang_cache_volume,
-        exp.DELTA_BULLETIN_ROOT: delta_volume,
         **({str(DRAFT_PATH): draft_volume} if draft_volume is not None else {}),
     },
-    min_containers=modal_cfg.rollout_min_containers, max_containers=modal_cfg.rollout_max_containers,
-    timeout=40 * MINUTES, scaledown_window=15 * MINUTES,
-    ephemeral_disk=modal_cfg.rollout_ephemeral_disk_mib, memory=modal_cfg.rollout_memory_mib,
+    min_containers=modal_cfg.rollout_min_containers,
+    max_containers=modal_cfg.rollout_max_containers,
+    timeout=40 * MINUTES,
+    scaledown_window=15 * MINUTES,
+    ephemeral_disk=modal_cfg.rollout_ephemeral_disk_mib,
+    memory=modal_cfg.rollout_memory_mib,
     include_source=False,
 )
 @modal.experimental.http_server(
-    port=SIDECAR_PORT, proxy_regions=modal_cfg.proxy_regions,
-    exit_grace_period=25, startup_timeout=SERVER_STARTUP_TIMEOUT,
+    port=SIDECAR_PORT,
+    proxy_regions=modal_cfg.proxy_regions,
+    exit_grace_period=25,
+    startup_timeout=SERVER_STARTUP_TIMEOUT,
 )
 @modal.concurrent(target_inputs=ROLLOUT_CONCURRENCY)
 class Server:
     @modal.enter()
     def startup(self) -> None:
         server.serve_startup(
-            self, model_name=miles_cfg.hf_checkpoint, sglang_args=SGLANG_SERVER_ARGS,
-            tp=miles_cfg.rollout_num_gpus_per_engine, concurrency=ROLLOUT_CONCURRENCY,
-            bulletin_root=BULLETIN_ROOT,
+            self,
+            model_name=miles_cfg.hf_checkpoint,
+            sglang_args=SGLANG_SERVER_ARGS,
+            tp=miles_cfg.rollout_num_gpus_per_engine,
+            concurrency=ROLLOUT_CONCURRENCY,
+            bulletin_root=RUN_ROOT,
             local_checkpoint_dir=exp.LOCAL_CHECKPOINT_PATH,
             delta_update_mode=exp.SGLANG_DELTA_UPDATE_MODE,
-            volume_name=exp.DELTA_VOLUME_NAME, commit_mode=exp.SIDECAR_COMMIT_MODE,
+            volume_name=exp.EXPERIMENT_VOLUME_NAME,
+            commit_mode=exp.SIDECAR_COMMIT_MODE,
+            run_id=RUN_ID,
             flush_cache_on_commit=exp.SIDECAR_FLUSH_CACHE_ON_COMMIT,
             startup_timeout=SERVER_STARTUP_TIMEOUT,
         )
@@ -165,14 +200,21 @@ _MULTINODE = miles_cfg.n_train_nodes > 1
     image=image,
     gpu=f"{modal_cfg.gpu}:{miles_cfg.actor_num_gpus_per_node}",
     memory=modal_cfg.trainer_memory_mib,
-    cloud=modal_cfg.cloud, region=modal_cfg.region,
+    cloud=modal_cfg.cloud,
+    region=modal_cfg.region,
     volumes=train_volumes,
     ephemeral_disk=modal_cfg.trainer_ephemeral_disk_mib,
-    timeout=24 * 60 * MINUTES, startup_timeout=20 * MINUTES, scaledown_window=30 * MINUTES,
+    timeout=24 * 60 * MINUTES,
+    startup_timeout=20 * MINUTES,
+    scaledown_window=30 * MINUTES,
     include_source=False,
     **({"experimental_options": {"efa_enabled": True}} if _MULTINODE else {}),
 )
-@(modal.experimental.clustered(miles_cfg.n_train_nodes, rdma=True) if _MULTINODE else lambda c: c)
+@(
+    modal.experimental.clustered(miles_cfg.n_train_nodes, rdma=True)
+    if _MULTINODE
+    else lambda c: c
+)
 class Trainer:
     """miles actor cluster. Ray comes up once per container in enter(), so back-to-back
     runs reuse it."""
@@ -181,12 +223,22 @@ class Trainer:
     def start_ray(self) -> None:
         from cookbook.common import process
 
-        rank, master_addr, my_ip = ray_cluster.get_modal_cluster_context(miles_cfg.n_train_nodes)
-        process.apply_git_patches(list(getattr(exp, "MEGATRON_RUNTIME_PATCHES", [])), MEGATRON_PATH, "Megatron patch")
+        rank, master_addr, my_ip = ray_cluster.get_modal_cluster_context(
+            miles_cfg.n_train_nodes
+        )
+        process.apply_git_patches(
+            list(getattr(exp, "MEGATRON_RUNTIME_PATCHES", [])),
+            MEGATRON_PATH,
+            "Megatron patch",
+        )
         self.rank = rank
         process.start_host_mem_monitor()  # per-node host-RAM trace
         ray_cluster.start_ray_node(
-            rank, master_addr, my_ip, n_nodes=miles_cfg.n_train_nodes, ray_port=RAY_PORT,
+            rank,
+            master_addr,
+            my_ip,
+            n_nodes=miles_cfg.n_train_nodes,
+            ray_port=RAY_PORT,
             extra_env={
                 "MILES_HOST_IP": my_ip,
                 "PYTHONPATH": f"{MEGATRON_PATH}:{os.environ.get('PYTHONPATH', '')}",  # source-only megatron.training
@@ -206,19 +258,18 @@ class Trainer:
             return
 
         cfg.rollout_endpoint_url = ModalFlashPool(APP_NAME, "Server").gateway_url()
-        run_id = uuid.uuid4().hex[:12]  # per-launch fence token; forks a fresh chain
-        cfg.update_weight_disk_dir = f"{BULLETIN_ROOT}/{run_id}"
+        cfg.update_weight_disk_dir = UPDATE_ROOT
         if getattr(cfg, "save_interval", None) is None:
-            cfg.load = cfg.save = cfg.save_hf = None
+            cfg.save = cfg.save_hf = None
         else:
-            cfg.load = cfg.save = f"{CHECKPOINTS_PATH}/{run_id}/checkpoints"
+            cfg.save = f"{RUN_ROOT}/checkpoints"
         # miles setattr's every key onto args for the hooks.
         custom_config = {
             **(cfg.custom_config_path or {}),
-            "update_weight_delta_volume_name": exp.DELTA_VOLUME_NAME,
+            "experiment_volume_name": exp.EXPERIMENT_VOLUME_NAME,
             "rollout_modal_flash_app_name": APP_NAME,
             "rollout_modal_flash_server_cls_name": "Server",
-            "run_id": run_id,
+            "run_id": RUN_ID,
         }
         cfg.custom_config_path = custom_config
         launch.resolve_config(cfg, tempfile.mkdtemp(), YAML_CONFIG_FIELDS)
@@ -227,19 +278,28 @@ class Trainer:
         # Claim the pool before miles publishes: reset every replica to base for this run.
         from cookbook.common import hooks
 
-        hooks.claim_pool(SimpleNamespace(update_weight_disk_dir=cfg.update_weight_disk_dir, **custom_config))
+        hooks.claim_pool(
+            SimpleNamespace(
+                update_weight_disk_dir=cfg.update_weight_disk_dir, **custom_config
+            )
+        )
 
-        print(f"Training {EXPERIMENT}: nodes={miles_cfg.n_train_nodes}, rollout_endpoint={cfg.rollout_endpoint_url}")
+        print(
+            f"Training {EXPERIMENT}: run={RUN_ID}, nodes={miles_cfg.n_train_nodes}, "
+            f"rollout_endpoint={cfg.rollout_endpoint_url}"
+        )
         print(f"Command: {cmd}")
-        log_path = f"{CHECKPOINTS_PATH}/{run_id}/train.log"
+        log_path = f"{RUN_ROOT}/train.log"
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
         teed = f"set -o pipefail; ({cmd}) 2>&1 | tee {log_path}"  # tee to a committed log; survives the app-logs buffer
         try:
             subprocess.run(["bash", "-lc", teed], check=True)
         finally:
             try:
-                checkpoints_volume.commit()
-                print(f"Train log committed to miles-checkpoints at {run_id}/train.log")
+                run_volume.commit()
+                print(
+                    f"Train log committed to {exp.EXPERIMENT_VOLUME_NAME} at {RUN_ROOT}/train.log"
+                )
             except Exception as exc:  # noqa: BLE001
                 print(f"WARNING: could not commit train log: {exc}")
 

--- a/cookbook/miles_disagg/configs/glm45_air_bf16.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH, STITCH_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-glm45-air-bf16"
-DELTA_VOLUME_NAME = "stitch-delta-glm45-air-bf16"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-glm45-air-bf16"
 LOCAL_CHECKPOINT_PATH = None
 
 SOURCE_MODEL = "zai-org/GLM-4.5-Air"
-MODEL_TAG = "glm45-air"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm45-air-bf16"
+ROLLOUT_CHECKPOINT_PATH = BF16_CHECKPOINT_PATH
+TORCH_DIST_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm45-air-torch-dist"
 SERVED_CHECKPOINT_FORMAT = "bf16"
 USE_MODAL_TORCH_DIST_WRAPPER = True
 DISABLE_HF_XET = True
@@ -21,7 +22,9 @@ DISABLE_HF_TRANSFER = True
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 SGLANG_DELTA_UPDATE_MODE = "cpu"
-MEGATRON_RUNTIME_PATCHES = ["/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"]
+MEGATRON_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"
+]
 
 
 SGLANG_SERVER_ARGS = {
@@ -66,8 +69,8 @@ modal = ModalConfig(
 class _Miles(MilesConfig):
     miles_model_script = "scripts/models/glm4.5-106B-A12B.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/bf16"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/torch_dist"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(TORCH_DIST_CHECKPOINT_PATH)
     megatron_to_hf_mode = "raw"
     model_name = "glm4moe"
 
@@ -80,7 +83,9 @@ class _Miles(MilesConfig):
     rollout_endpoint_url = None
     use_miles_router = True
 
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     custom_config_path = {
         "rollout_request_weight_version_mode": "min",
         "rollout_request_weight_version_lag": 1,
@@ -96,7 +101,7 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
+    update_weight_disk_dir = str(STITCH_PATH)
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/miles_disagg/configs/glm45_air_fp8.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH, STITCH_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-glm45-air-fp8"
-DELTA_VOLUME_NAME = "stitch-delta-glm45-air-fp8"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-glm45-air-fp8"
 LOCAL_CHECKPOINT_PATH = None
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
@@ -19,15 +18,19 @@ SGLANG_SERVER_ENV = {
     "SGLANG_ENABLE_OVERLAP_PLAN_STREAM": "0",
 }
 
-MODEL_TAG = "glm45-air"
 SOURCE_MODEL = "zai-org/GLM-4.5-Air"
 ROLLOUT_SOURCE_MODEL = "zai-org/GLM-4.5-Air-FP8"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm45-air-bf16"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm45-air-fp8"
+TORCH_DIST_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm45-air-torch-dist"
 SERVED_CHECKPOINT_FORMAT = "fp8"
 USE_MODAL_TORCH_DIST_WRAPPER = True
 DISABLE_HF_XET = True
 DISABLE_HF_TRANSFER = True
 
-MEGATRON_RUNTIME_PATCHES = ["/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"]
+MEGATRON_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"
+]
 
 SGLANG_SERVER_ARGS = {
     # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
@@ -59,8 +62,8 @@ SGLANG_SERVER_ARGS = {
 class _Miles(MilesConfig):
     miles_model_script = "scripts/models/glm4.5-106B-A12B.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/fp8"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/torch_dist"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(TORCH_DIST_CHECKPOINT_PATH)
     megatron_to_hf_mode = "raw"
     model_name = "glm4moe"
 
@@ -73,7 +76,9 @@ class _Miles(MilesConfig):
     rollout_endpoint_url = None          # filled at launch from the pool gateway
     use_miles_router = True
 
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
     custom_config_path = {
         "rollout_request_weight_version_mode": "min",
@@ -89,7 +94,7 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT  # run-scoped at launch to <root>/<run_id>
+    update_weight_disk_dir = str(STITCH_PATH)  # run-scoped at launch
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"
     input_key = "prompt"

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -6,21 +6,22 @@ Deploy: EXPERIMENT_CONFIG=glm5_2_nvfp4 uv run --extra modal modal deploy --strat
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH, STITCH_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-glm5-2-nvfp4"
-DELTA_VOLUME_NAME = "stitch-delta-glm5-2-nvfp4"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-glm5-2-nvfp4"
 LOCAL_CHECKPOINT_PATH = None
 
 # GLM-5.2 ships BF16 training masters and an NVIDIA NVFP4 rollout checkpoint.
 SOURCE_MODEL = "zai-org/GLM-5.2"
 ROLLOUT_SOURCE_MODEL = "nvidia/GLM-5.2-NVFP4"
 ROLLOUT_SOURCE_REVISION = "aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm5-2-bf16"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm5-2-nvfp4"
+TORCH_DIST_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm5-2-torch-dist"
 SERVED_CHECKPOINT_FORMAT = "nvfp4"
 CHECKPOINT_PREP_REQUIRES_GPU = False
-MODEL_TAG = "glm5-2"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
@@ -81,8 +82,8 @@ modal = ModalConfig(
 class _Miles(MilesConfig):
     miles_model_script = "scripts/models/glm5.2-744B-A40B.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/nvfp4"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/torch_dist"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(TORCH_DIST_CHECKPOINT_PATH)
     megatron_to_hf_mode = "raw"
     model_name = "glm_moe_dsa"
 
@@ -157,7 +158,7 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
+    update_weight_disk_dir = str(STITCH_PATH)
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
@@ -7,16 +7,17 @@ Deploy (::prepare_checkpoints, ::prepare_torch_dist, deploy, then ::launch_train
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH, STITCH_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-kimi-k25-2layer-nvfp4"
-DELTA_VOLUME_NAME = "stitch-delta-kimi-k25-2layer-nvfp4"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-kimi-k25-2layer-nvfp4"
 LOCAL_CHECKPOINT_PATH = None
 
 SOURCE_MODEL = "CharyZeng/Kimi-K2.5-2layer"  # INT4, KimiK25 arch, 2 layers
-MODEL_TAG = "kimi-k25-2layer"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k25-2layer-bf16"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k25-2layer-nvfp4"
+TORCH_DIST_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k25-2layer-torch-dist"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
@@ -60,8 +61,8 @@ modal = ModalConfig(
 class _Miles(MilesConfig):
     miles_model_script = "scripts/models/kimi-k25_2layer.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/nvfp4"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/torch_dist"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(TORCH_DIST_CHECKPOINT_PATH)
     megatron_to_hf_mode = "raw"
     model_name = "kimi_k25"  # KimiK25 mbridge import + convert_kimi_k25_to_hf export
 
@@ -74,7 +75,9 @@ class _Miles(MilesConfig):
     rollout_endpoint_url = None
     use_miles_router = True
 
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     custom_config_path = {
         "rollout_request_weight_version_mode": "min",
         "rollout_request_weight_version_lag": 1,
@@ -96,7 +99,10 @@ class _Miles(MilesConfig):
                 "transformer_engine_config_type": "TEQuantizationParams",
                 "training_recipe": {"fp4_quantization_recipe": "nvfp4"},
             },
-            "bf16": {"transformer_engine_config_type": "TEQuantizationParams", "training_recipe": {}},
+            "bf16": {
+                "transformer_engine_config_type": "TEQuantizationParams",
+                "training_recipe": {},
+            },
         },
         "matchers": {
             "routed_experts_fc1_nvfp4": {
@@ -111,7 +117,12 @@ class _Miles(MilesConfig):
                 "pattern": "*.mlp.experts.linear_fc2",
                 "config": "nvfp4",
             },
-            "default_bf16": {"type": "glob", "enabled": True, "pattern": "*", "config": "bf16"},
+            "default_bf16": {
+                "type": "glob",
+                "enabled": True,
+                "pattern": "*",
+                "config": "bf16",
+            },
         },
     }
     # 2 layers: layer 0 is dense (FIRST_K_DENSE_REPLACE=1) -> bf16; layer 1 is MoE
@@ -122,7 +133,7 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
+    update_weight_disk_dir = str(STITCH_PATH)
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
@@ -6,17 +6,18 @@ Deploy: EXPERIMENT_CONFIG=kimi_k2_6_nvfp4 uv run --extra modal modal deploy --st
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH, STITCH_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-kimi-k2-6-nvfp4"
-DELTA_VOLUME_NAME = "stitch-delta-kimi-k2-6-nvfp4"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-kimi-k2-6-nvfp4"
 LOCAL_CHECKPOINT_PATH = None
 
 # SOURCE_MODEL (INT4) -> dequant -> bf16 masters -> convert -> served NVFP4 base.
 SOURCE_MODEL = "moonshotai/Kimi-K2.6"
-MODEL_TAG = "kimi-k2-6"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k2-6-bf16"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k2-6-nvfp4"
+TORCH_DIST_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k2-6-torch-dist"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
@@ -32,6 +33,7 @@ SGLANG_SERVER_ARGS = {
     # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
     "--model-loader-extra-config": '{"enable_gds":false}',
+    "--trust-remote-code": "",
     "--enable-cpu-weight-cache": "",
     "--cpu-weight-cache-max-compile-group-gb": "8",
     "--weight-loader-drop-cache-after-load": "",
@@ -73,11 +75,13 @@ class _Miles(MilesConfig):
     # Arch comes from the model script (shared with Kimi-K2-Thinking; K2.6 matches).
     miles_model_script = "scripts/models/kimi-k2-thinking.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/nvfp4"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/torch_dist"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(TORCH_DIST_CHECKPOINT_PATH)
     # "raw": K2.6's HF arch is a VLM wrapper AutoBridge can't build; export routes via model_name.
     megatron_to_hf_mode = "raw"
-    model_name = "kimi_k25"  # megatron_to_hf export dispatch (convert_kimi_k25_to_hf + NVFP4)
+    model_name = (
+        "kimi_k25"  # megatron_to_hf export dispatch (convert_kimi_k25_to_hf + NVFP4)
+    )
 
     actor_num_nodes = 16  # 16x8 B200 = 128 GPUs; TP8*PP8*CP2=128 (DP=1) — debug the actor_train backward deadlock cheaper (same PP8 path as 32 nodes; both hang identically)
     actor_num_gpus_per_node = 8
@@ -109,7 +113,9 @@ class _Miles(MilesConfig):
     # NVFP4 QAT — miles' canonical NVFP4 RL recipe.
     fp4_format = "e2m1"
     fp4_recipe = "nvfp4"
-    fp4_param_gather = False  # True crashes Megatron DDP's param-buffer repoint (TE NVFP4Tensor)
+    fp4_param_gather = (
+        False  # True crashes Megatron DDP's param-buffer repoint (TE NVFP4Tensor)
+    )
     # NVFP4 only on the routed expert GEMMs, everything else bf16 — matches the served base.
     te_precision_config_file = {
         "configs": {
@@ -151,7 +157,7 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
+    update_weight_disk_dir = str(STITCH_PATH)
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4.py
@@ -6,16 +6,16 @@ Deploy: EXPERIMENT_CONFIG=moonlight_nvfp4 uv run --extra modal modal deploy --st
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH, STITCH_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-moonlight-nvfp4"
-DELTA_VOLUME_NAME = "stitch-delta-moonlight-nvfp4"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-moonlight-nvfp4"
 LOCAL_CHECKPOINT_PATH = None
 
 SOURCE_MODEL = "moonshotai/Moonlight-16B-A3B-Instruct"
-MODEL_TAG = "moonlight-16b"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "moonlight-bf16"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "moonlight-nvfp4"
 
 # in_place applies weights without draining in-flight rollouts; stale KV isolated per version.
 SIDECAR_COMMIT_MODE = "in_place"
@@ -60,22 +60,28 @@ class _Miles(MilesConfig):
     # Arch comes from the model script; do NOT inline arch attrs here.
     miles_model_script = "scripts/models/moonlight.sh"
 
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/nvfp4"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/bf16"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(BF16_CHECKPOINT_PATH)
     megatron_to_hf_mode = "bridge"
     model_name = "deepseekv3"  # bridge dispatch: Moonlight is DeepSeek-V3 arch
 
     actor_num_nodes = 1
-    actor_num_gpus_per_node = 4  # 1 node x 4 B200 trainer (matches the proven moonlight recipe)
+    actor_num_gpus_per_node = (
+        4  # 1 node x 4 B200 trainer (matches the proven moonlight recipe)
+    )
     num_gpus_per_node = 4
     colocate = False  # disk-delta is incompatible with --colocate
     rollout_num_gpus = 0  # publish-only forces this
-    rollout_num_gpus_per_engine = 1  # B200:1 per rollout container (Moonlight NVFP4 is tiny)
+    rollout_num_gpus_per_engine = (
+        1  # B200:1 per rollout container (Moonlight NVFP4 is tiny)
+    )
     rollout_endpoint_url = None
     use_miles_router = True
 
     # Staleness gate; the knobs ride in custom_config_path (read by the hook, not miles core).
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     custom_config_path = {
         "rollout_request_weight_version_mode": "min",
         "rollout_request_weight_version_lag": 1,
@@ -94,7 +100,7 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT  # modal_train run-scopes this
+    update_weight_disk_dir = str(STITCH_PATH)
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"
@@ -107,7 +113,9 @@ class _Miles(MilesConfig):
     eval_interval = None
 
     num_rollout = 20
-    save_interval = 1000  # megatron requires it; > num_rollout so the smoke skips megatron saves
+    save_interval = (
+        1000  # megatron requires it; > num_rollout so the smoke skips megatron saves
+    )
     rollout_batch_size = 32
     rollout_max_response_len = 4096  # fits within the 8192 context (prompt + response)
     rollout_temperature = 0.8

--- a/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
+++ b/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
@@ -40,16 +40,16 @@ Launch: EXPERIMENT_CONFIG=qwen3_30b_a3b_nvfp4_46 uv run --extra modal python -m 
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH, PREP_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH, STITCH_PATH
 from cookbook.miles_disagg.config import MilesConfig
 
 APP_NAME = "stitch-qwen3-30b-nvfp4-46"
-DELTA_VOLUME_NAME = "stitch-delta-qwen3-30b-nvfp4-46"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-qwen3-30b-nvfp4-46"
 LOCAL_CHECKPOINT_PATH = None
 
 SOURCE_MODEL = "Qwen/Qwen3-30B-A3B"  # bf16 -> masters ARE the download
-MODEL_TAG = "qwen3-30b-a3b-nvfp4-46"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "qwen3-30b-a3b-bf16"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "qwen3-30b-a3b-nvfp4-46"
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
@@ -133,8 +133,8 @@ class _Miles(MilesConfig):
     miles_model_script = "scripts/models/qwen3-30B-A3B.sh"
 
     # Bridge mode: ref_load is the bf16 HF masters directly (no torch_dist prep).
-    hf_checkpoint = f"{PREP_PATH}/{MODEL_TAG}/nvfp4"
-    ref_load = f"{PREP_PATH}/{MODEL_TAG}/bf16"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+    ref_load = str(BF16_CHECKPOINT_PATH)
     megatron_to_hf_mode = "bridge"
     model_name = "qwen3moe"  # megatron_to_hf export dispatch
 
@@ -206,7 +206,7 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT  # app.py run-scopes this
+    update_weight_disk_dir = str(STITCH_PATH)  # app.py run-scopes this
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
     # Data: DAPO-Math-17k — the blog's dataset.

--- a/cookbook/miles_disagg/prep.py
+++ b/cookbook/miles_disagg/prep.py
@@ -14,7 +14,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from cookbook.common.constants import PREP_PATH
 from cookbook.miles_disagg.trainer_image import (
     MEGATRON_PATH,
     MILES_ROOT,
@@ -33,48 +32,84 @@ def _apply_prep_environment(exp) -> None:
     os.environ.update(getattr(exp, "PREP_ENV", {}))
 
 
-def prepare_checkpoints(exp, prep_volume) -> None:
+def _source_snapshot(exp) -> str:
+    _apply_prep_environment(exp)
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(
+        exp.SOURCE_MODEL,
+        revision=getattr(exp, "SOURCE_REVISION", None),
+    )
+
+
+def _bf16_masters(exp) -> str:
+    """Resolve the immutable BF16 source used by both checkpoint converters."""
+    src = _source_snapshot(exp)
+    if _is_int4(src) or getattr(exp, "MATERIALIZE_BF16_MASTERS", True):
+        return str(exp.BF16_CHECKPOINT_PATH)
+    return src
+
+
+def prepare_checkpoints(exp, checkpoint_volume) -> None:
     """Build the bf16 masters (trainer arch source) + the served base on a GPU.
 
     masters (bf16): a quantized source (Kimi INT4) is dequantized; a bf16 source IS the
     masters. served base: bf16 = masters; a published ROLLOUT_SOURCE_MODEL is copied
     directly; otherwise NVFP4 is built with Miles' TE-direct quantizer over the masters.
     """
-    _apply_prep_environment(exp)
-    from huggingface_hub import snapshot_download
-
-    prep_volume.reload()
-    tag = exp.MODEL_TAG
-    bf16_dir, fp8_dir, nvfp4_dir = f"{PREP_PATH}/{tag}/bf16", f"{PREP_PATH}/{tag}/fp8", f"{PREP_PATH}/{tag}/nvfp4"
+    checkpoint_volume.reload()
+    materialized_bf16_dir = str(exp.BF16_CHECKPOINT_PATH)
+    served_dir = str(exp.miles.hf_checkpoint)
     served_format = getattr(exp, "SERVED_CHECKPOINT_FORMAT", "nvfp4")
     if served_format not in {"bf16", "fp8", "nvfp4"}:
         raise SystemExit(f"unsupported SERVED_CHECKPOINT_FORMAT={served_format!r}")
     tools = f"{MILES_ROOT}/tools"
 
-    src = snapshot_download(exp.SOURCE_MODEL)
+    src = _source_snapshot(exp)
     is_int4 = _is_int4(src)  # read the source's quant scheme, not its repo name
 
     def _build_bf16(out: str) -> None:
         if is_int4:
             print("dequantizing INT4 source -> bf16 masters (GPU)...", flush=True)
-            subprocess.run(["python", f"{tools}/convert_kimi_int4_to_bf16.py", "--model-dir", src, "--output-dir", out], check=True)
+            subprocess.run(
+                [
+                    "python",
+                    f"{tools}/convert_kimi_int4_to_bf16.py",
+                    "--model-dir",
+                    src,
+                    "--output-dir",
+                    out,
+                ],
+                check=True,
+            )
         else:
             _copy_tree("bf16 masters", src, out)
         _strip_stale_quant_config(os.path.join(out, "config.json"))
 
-    _staged(bf16_dir, _build_bf16)
+    if is_int4 or getattr(exp, "MATERIALIZE_BF16_MASTERS", True):
+        _staged(materialized_bf16_dir, _build_bf16)
+        bf16_dir = materialized_bf16_dir
+    else:
+        bf16_dir = src
+        print(f"using pinned HF snapshot as bf16 masters: {bf16_dir}", flush=True)
 
     if served_format == "bf16":
-        prep_volume.commit()
+        if served_dir != bf16_dir:
+            raise ValueError(
+                "BF16 served checkpoint must match BF16_CHECKPOINT_PATH: "
+                f"{served_dir} != {bf16_dir}"
+            )
+        checkpoint_volume.commit()
         print(f"Prepared masters={bf16_dir} served_base={bf16_dir}")
         return
 
     rollout_source = getattr(exp, "ROLLOUT_SOURCE_MODEL", None)
     if rollout_source:
         rollout_revision = getattr(exp, "ROLLOUT_SOURCE_REVISION", None)
-        served_dir = fp8_dir if served_format == "fp8" else nvfp4_dir
 
         def _download_rollout_checkpoint(out: str) -> None:
+            from huggingface_hub import snapshot_download
+
             snapshot_download(
                 rollout_source,
                 revision=rollout_revision,
@@ -83,7 +118,7 @@ def prepare_checkpoints(exp, prep_volume) -> None:
             shutil.rmtree(os.path.join(out, ".cache"), ignore_errors=True)
 
         _staged(served_dir, _download_rollout_checkpoint, resume=True)
-        prep_volume.commit()
+        checkpoint_volume.commit()
         print(f"Prepared masters={bf16_dir} served_base={served_dir}")
         return
 
@@ -98,28 +133,50 @@ def prepare_checkpoints(exp, prep_volume) -> None:
     if (n := getattr(exp.miles, "num_layers_at_end_in_bf16", None)) is not None:
         carveouts += ["--num-layers-at-end-in-bf16", str(n)]
     def _build_nvfp4(out: str) -> None:
-        print("building nvfp4 served base from bf16 masters (GPU conversion)...", flush=True)
-        subprocess.run(["python", f"{tools}/convert_hf_to_nvfp4.py", "--model-dir", bf16_dir, "--save-dir", out, *carveouts], check=True)
+        print(
+            "building nvfp4 served base from bf16 masters (GPU conversion)...",
+            flush=True,
+        )
+        subprocess.run(
+            [
+                "python",
+                f"{tools}/convert_hf_to_nvfp4.py",
+                "--model-dir",
+                bf16_dir,
+                "--save-dir",
+                out,
+                *carveouts,
+            ],
+            check=True,
+        )
 
-    _staged(nvfp4_dir, _build_nvfp4)
-    prep_volume.commit()
-    print(f"Prepared masters={bf16_dir} served_base={nvfp4_dir}")
+    _staged(served_dir, _build_nvfp4)
+    checkpoint_volume.commit()
+    print(f"Prepared masters={bf16_dir} served_base={served_dir}")
 
 
-def prepare_torch_dist(exp, prep_volume, *, rank: int, master_addr: str) -> None:
-    """Build {tag}/torch_dist (the raw-mode ref_load) from the {tag}/bf16 masters via a
-    clustered torchrun conversion (large MoE won't fit an 8-way split)."""
-    prep_volume.reload()
-    tag = exp.MODEL_TAG
-    bf16_dir, torch_dist_dir = f"{PREP_PATH}/{tag}/bf16", f"{PREP_PATH}/{tag}/torch_dist"
-    if os.path.exists(os.path.join(torch_dist_dir, "latest_checkpointed_iteration.txt")):
+def prepare_torch_dist(exp, checkpoint_volume, *, rank: int, master_addr: str) -> None:
+    """Build the raw-mode torch_dist reference checkpoint from the BF16 source."""
+    torch_dist_path = getattr(exp, "TORCH_DIST_CHECKPOINT_PATH", None)
+    if torch_dist_path is None:
+        raise SystemExit("this config does not use a torch_dist trainer checkpoint")
+    checkpoint_volume.reload()
+    bf16_dir = _bf16_masters(exp)
+    torch_dist_dir = str(torch_dist_path)
+    if os.path.exists(
+        os.path.join(torch_dist_dir, "latest_checkpointed_iteration.txt")
+    ):
         print(f"reusing existing torch_dist {torch_dist_dir}")
         return
     if not exp.miles.miles_model_script:
         raise SystemExit("prepare_torch_dist requires miles_model_script (MODEL_ARGS)")
     nodes = exp.modal.torch_dist_prep_nodes
     use_wrapper = nodes > 1 and getattr(exp, "USE_MODAL_TORCH_DIST_WRAPPER", False)
-    convert = TORCH_DIST_CONVERT_WRAPPER if use_wrapper else f"{MILES_ROOT}/tools/convert_hf_to_torch_dist.py"
+    convert = (
+        TORCH_DIST_CONVERT_WRAPPER
+        if use_wrapper
+        else f"{MILES_ROOT}/tools/convert_hf_to_torch_dist.py"
+    )
     inner = (
         f"source {MILES_ROOT}/{exp.miles.miles_model_script} && "
         f"PYTHONPATH={MEGATRON_PATH} torchrun"
@@ -132,11 +189,14 @@ def prepare_torch_dist(exp, prep_volume, *, rank: int, master_addr: str) -> None
     env = {**os.environ}
     if use_wrapper:
         env["SKIP_RELEASE_RENAME"] = "1"
-    print(f"converting bf16 masters -> torch_dist ref_load ({nodes}-node torchrun, rank {rank})...", flush=True)
+    print(
+        f"converting bf16 masters -> torch_dist ref_load ({nodes}-node torchrun, rank {rank})...",
+        flush=True,
+    )
     subprocess.run(["bash", "-c", inner], check=True, env=env)
     # Every node commits its own distcp shards (disjoint files merge on the Volume);
     # a rank-0-only commit would drop the other nodes' shards.
-    prep_volume.commit()
+    checkpoint_volume.commit()
     if rank == 0:
         print(f"Prepared torch_dist={torch_dist_dir}")
 
@@ -145,13 +205,17 @@ def prepare_torch_dist(exp, prep_volume, *, rank: int, master_addr: str) -> None
 # sglang base-seed's profiled knee). 16 MiB reads run at full mount speed while bounding memory.
 _COPY_WORKERS = int(os.environ.get("PREP_COPY_WORKERS", "8"))
 _COPY_CHUNK = 16 << 20
-_COPY_LOG_STEP_GB = 50  # one progress line per this many GB, so a multi-TB copy isn't a silent stall
+_COPY_LOG_STEP_GB = (
+    50  # one progress line per this many GB, so a multi-TB copy isn't a silent stall
+)
 
 
 def _copy_tree(label: str, src: str, dst: str) -> None:
     """Copy a checkpoint dir, dereferencing the HF cache's blob symlinks into real files (the old
     ``cp -aL``), but across a thread pool for the ~5x and with throttled GB/GB + rate progress."""
-    src_files = [p for p in Path(src).rglob("*") if p.is_file()]  # is_file() follows symlinks
+    src_files = [
+        p for p in Path(src).rglob("*") if p.is_file()
+    ]  # is_file() follows symlinks
     total_gb = sum(p.stat().st_size for p in src_files) / 1e9
     progress = {"done_gb": 0.0, "next_log_gb": _COPY_LOG_STEP_GB}
     lock = threading.Lock()
@@ -160,7 +224,10 @@ def _copy_tree(label: str, src: str, dst: str) -> None:
     def copy_one(p: Path) -> None:
         out = Path(dst) / p.relative_to(src)
         out.parent.mkdir(parents=True, exist_ok=True)
-        with open(p, "rb") as fsrc, open(out, "wb") as fdst:  # open() follows the symlink to the real blob
+        with (
+            open(p, "rb") as fsrc,
+            open(out, "wb") as fdst,
+        ):  # open() follows the symlink to the real blob
             while chunk := fsrc.read(_COPY_CHUNK):
                 fdst.write(chunk)
         with lock:
@@ -168,11 +235,16 @@ def _copy_tree(label: str, src: str, dst: str) -> None:
             done = progress["done_gb"]
             if done >= progress["next_log_gb"] or done >= total_gb:
                 rate = done / max(time.monotonic() - start, 1e-3)
-                print(f"copying {label}: {done:.0f}/{total_gb:.0f} GB ({100 * done / max(total_gb, 1e-9):.0f}%), {rate:.1f} GB/s", flush=True)
+                print(
+                    f"copying {label}: {done:.0f}/{total_gb:.0f} GB ({100 * done / max(total_gb, 1e-9):.0f}%), {rate:.1f} GB/s",
+                    flush=True,
+                )
                 progress["next_log_gb"] += _COPY_LOG_STEP_GB
 
     os.makedirs(dst, exist_ok=True)
-    with ThreadPoolExecutor(max_workers=min(_COPY_WORKERS, len(src_files) or 1)) as pool:
+    with ThreadPoolExecutor(
+        max_workers=min(_COPY_WORKERS, len(src_files) or 1)
+    ) as pool:
         list(pool.map(copy_one, src_files))
     print(f"copied {label}: {total_gb:.0f} GB", flush=True)
 
@@ -214,5 +286,9 @@ def _is_int4(model_dir: str) -> bool:
     with open(cfg_path) as f:
         cfg = json.load(f) or {}
     # VLMs (Kimi K2.x) nest the quant config under text_config.
-    qc = (cfg.get("text_config") or {}).get("quantization_config") or cfg.get("quantization_config") or {}
+    qc = (
+        (cfg.get("text_config") or {}).get("quantization_config")
+        or cfg.get("quantization_config")
+        or {}
+    )
     return qc.get("quant_method") == "compressed-tensors"

--- a/cookbook/miles_disagg/prep_app.py
+++ b/cookbook/miles_disagg/prep_app.py
@@ -20,38 +20,61 @@ import modal
 import modal.experimental
 
 from cookbook.common import ray_cluster
-from cookbook.common.constants import DATA_PATH, HF_CACHE_PATH, MINUTES, PREP_PATH
+from cookbook.common.constants import (
+    CHECKPOINTS_PATH,
+    DATA_PATH,
+    HF_CACHE_PATH,
+    MINUTES,
+)
 from cookbook.miles_disagg import prep, trainer_image
 
-EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]  # required; a default would silently prep the wrong experiment
-MILES_LOCAL_DIR = os.environ.get("MILES_LOCAL_DIR")  # optional dev overlay of a local miles checkout
+EXPERIMENT = os.environ[
+    "EXPERIMENT_CONFIG"
+]  # required; a default would silently prep the wrong experiment
+MILES_LOCAL_DIR = os.environ.get(
+    "MILES_LOCAL_DIR"
+)  # optional dev overlay of a local miles checkout
 
 exp = importlib.import_module(f"cookbook.miles_disagg.configs.{EXPERIMENT}")
 modal_cfg = exp.modal
 miles_cfg = exp.miles
 
-image = trainer_image.build_trainer_image(hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, miles_local=MILES_LOCAL_DIR)
+image = trainer_image.build_trainer_image(
+    hf_cache_path=str(HF_CACHE_PATH),
+    experiment=EXPERIMENT,
+    miles_local=MILES_LOCAL_DIR,
+)
 
-hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=True, version=2)
+hf_cache_volume = modal.Volume.from_name(
+    "huggingface-cache", create_if_missing=True, version=2
+)
 data_volume = modal.Volume.from_name("miles-data", create_if_missing=True, version=2)
-prep_volume = modal.Volume.from_name("miles-prep-checkpoints", create_if_missing=True, version=2)
+checkpoint_volume = modal.Volume.from_name(
+    "miles-checkpoints",
+    create_if_missing=True,
+    version=2,
+)
 
 app = modal.App(f"{exp.APP_NAME}-prep")
 checkpoint_gpu = (
-    f"{modal_cfg.gpu}:1"
-    if getattr(exp, "CHECKPOINT_PREP_REQUIRES_GPU", True)
-    else None
+    f"{modal_cfg.gpu}:1" if getattr(exp, "CHECKPOINT_PREP_REQUIRES_GPU", True) else None
 )
 
 
 @app.function(
-    image=image, gpu=checkpoint_gpu,
-    volumes={str(HF_CACHE_PATH): hf_cache_volume, str(PREP_PATH): prep_volume},
+    image=image,
+    gpu=checkpoint_gpu,
+    volumes={
+        str(HF_CACHE_PATH): hf_cache_volume,
+        str(CHECKPOINTS_PATH): checkpoint_volume,
+    },
     memory=modal_cfg.trainer_memory_mib,
-    timeout=6 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+    timeout=6 * 60 * MINUTES,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
 )
 def prepare_checkpoints() -> None:
-    prep.prepare_checkpoints(exp, prep_volume)
+    prep.prepare_checkpoints(exp, checkpoint_volume)
 
 
 # torch_dist conversion is clustered across nodes (a large MoE won't fit an 8-way split).
@@ -59,22 +82,41 @@ _TORCH_DIST_MULTINODE = modal_cfg.torch_dist_prep_nodes > 1
 
 
 @app.function(
-    image=image, gpu=f"{modal_cfg.gpu}:{modal_cfg.torch_dist_prep_gpus_per_node}",
-    volumes={str(HF_CACHE_PATH): hf_cache_volume, str(PREP_PATH): prep_volume},
+    image=image,
+    gpu=f"{modal_cfg.gpu}:{modal_cfg.torch_dist_prep_gpus_per_node}",
+    volumes={
+        str(HF_CACHE_PATH): hf_cache_volume,
+        str(CHECKPOINTS_PATH): checkpoint_volume,
+    },
     timeout=6 * 60 * MINUTES,
-    ephemeral_disk=(modal_cfg.torch_dist_prep_ephemeral_disk_mib or modal_cfg.rollout_ephemeral_disk_mib),
-    secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
-    **({"experimental_options": {"efa_enabled": True}} if _TORCH_DIST_MULTINODE else {}),
+    ephemeral_disk=(
+        modal_cfg.torch_dist_prep_ephemeral_disk_mib
+        or modal_cfg.rollout_ephemeral_disk_mib
+    ),
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
+    **(
+        {"experimental_options": {"efa_enabled": True}} if _TORCH_DIST_MULTINODE else {}
+    ),
 )
-@(modal.experimental.clustered(modal_cfg.torch_dist_prep_nodes, rdma=True) if _TORCH_DIST_MULTINODE else lambda fn: fn)
+@(
+    modal.experimental.clustered(modal_cfg.torch_dist_prep_nodes, rdma=True)
+    if _TORCH_DIST_MULTINODE
+    else lambda fn: fn
+)
 def prepare_torch_dist() -> None:
-    rank, master_addr, _ = ray_cluster.get_modal_cluster_context(modal_cfg.torch_dist_prep_nodes)
-    prep.prepare_torch_dist(exp, prep_volume, rank=rank, master_addr=master_addr)
+    rank, master_addr, _ = ray_cluster.get_modal_cluster_context(
+        modal_cfg.torch_dist_prep_nodes
+    )
+    prep.prepare_torch_dist(exp, checkpoint_volume, rank=rank, master_addr=master_addr)
 
 
 @app.function(
-    image=image, volumes={str(DATA_PATH): data_volume},
-    timeout=2 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+    image=image,
+    volumes={str(DATA_PATH): data_volume},
+    timeout=2 * 60 * MINUTES,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
 )
 def prepare_dataset() -> None:
     data_volume.reload()

--- a/cookbook/miles_disagg/swebench_pro.py
+++ b/cookbook/miles_disagg/swebench_pro.py
@@ -1,0 +1,280 @@
+"""Materialize pinned SWE-bench Pro rows as executable Harbor tasks."""
+
+from __future__ import annotations
+
+import ast
+import json
+import shlex
+import subprocess
+from pathlib import Path
+
+DATASET_REVISION = "7ab5114912baf22bb098818e604c02fe7ad2c11f"
+EVALUATOR_REVISION = "ca10a60a5fcae51e6948ffe1485d4153d421e6c5"
+
+
+def _parse_string_list(value: str, field: str, instance_id: str) -> list[str]:
+    try:
+        parsed = ast.literal_eval(value)
+    except (SyntaxError, ValueError) as error:
+        raise ValueError(
+            f"{instance_id}: {field} is not a Python list literal"
+        ) from error
+    if not isinstance(parsed, list) or not all(
+        isinstance(item, str) for item in parsed
+    ):
+        raise TypeError(f"{instance_id}: {field} must be a list of strings")
+    return parsed
+
+
+def _patched_paths(test_patch: str) -> list[str]:
+    prefix = "diff --git a/"
+    paths = []
+    for line in test_patch.splitlines():
+        if line.startswith(prefix):
+            path, _, _ = line[len(prefix) :].partition(" b/")
+            if path:
+                paths.append(path)
+    return sorted(set(paths))
+
+
+def _setup_script(before_repo_set_cmd: str) -> str:
+    return rf"""#!/bin/bash
+set -euo pipefail
+cd /app
+{before_repo_set_cmd}
+
+baseline_tree=$(git write-tree)
+baseline_commit=$(
+    printf '%s\n' 'Miles SWE-bench Pro policy baseline' |
+        GIT_AUTHOR_NAME=Miles \
+        GIT_AUTHOR_EMAIL=miles@example.invalid \
+        GIT_AUTHOR_DATE='2000-01-01T00:00:00Z' \
+        GIT_COMMITTER_NAME=Miles \
+        GIT_COMMITTER_EMAIL=miles@example.invalid \
+        GIT_COMMITTER_DATE='2000-01-01T00:00:00Z' \
+        git commit-tree "$baseline_tree" -p HEAD
+)
+git update-ref refs/miles/task-baseline "$baseline_commit"
+"""
+
+
+def _verifier_script(selected_tests: list[str]) -> str:
+    selected = shlex.quote(",".join(selected_tests))
+    return rf"""#!/bin/bash
+set -u
+
+write_zero() {{
+    mkdir -p /logs/verifier
+    printf '0\n' > /logs/verifier/reward.txt
+}}
+
+cd /app || exit 1
+baseline=$(git rev-parse refs/miles/task-baseline) || exit 1
+git add -N . >/dev/null 2>&1 || true
+git diff --name-only "$baseline" -- > /tmp/miles_changed_paths.txt || exit 1
+if grep -Fxf /tests/protected_test_paths.txt /tmp/miles_changed_paths.txt \
+        >/tmp/miles_modified_tests.txt; then
+    echo "Policy modified benchmark test files:"
+    cat /tmp/miles_modified_tests.txt
+    write_zero
+    exit 0
+fi
+
+git diff --binary "$baseline" -- . > /tmp/miles_policy.patch || exit 1
+git reset --hard "$baseline" >/dev/null || exit 1
+git clean -fd >/dev/null || exit 1
+if ! git apply --whitespace=nowarn /tmp/miles_policy.patch; then
+    echo "Policy patch could not be applied to the canonical task baseline."
+    write_zero
+    exit 0
+fi
+
+bash /tests/run_script.sh {selected} \
+    > /tmp/miles_test_stdout.log \
+    2> /tmp/miles_test_stderr.log || true
+python3 /tests/parser.py \
+    /tmp/miles_test_stdout.log \
+    /tmp/miles_test_stderr.log \
+    /tmp/miles_test_results.json || exit 1
+
+tail -c 2000 /tmp/miles_test_stdout.log || true
+tail -c 2000 /tmp/miles_test_stderr.log || true
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+required = set(json.loads(Path("/tests/required_tests.json").read_text()))
+report = json.loads(Path("/tmp/miles_test_results.json").read_text())
+passed = {{
+    test["name"]
+    for test in report.get("tests", [])
+    if test.get("status") == "PASSED"
+}}
+reward = int(bool(required) and required.issubset(passed))
+Path("/logs/verifier").mkdir(parents=True, exist_ok=True)
+Path("/logs/verifier/reward.txt").write_text(f"{{reward}}\n")
+print(
+    f"SWE-bench Pro verifier: passed_required={{len(required & passed)}}/"
+    f"{{len(required)}} reward={{reward}}"
+)
+PY
+"""
+
+
+def _checkout_evaluator(source_root: Path) -> None:
+    source_root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "-C", str(source_root), "init"], check=True)
+    has_origin = (
+        subprocess.run(
+            ["git", "-C", str(source_root), "remote", "get-url", "origin"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(source_root),
+            "remote",
+            "set-url" if has_origin else "add",
+            "origin",
+            "https://github.com/scaleapi/SWE-bench_Pro-os.git",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(source_root),
+            "fetch",
+            "--depth=1",
+            "origin",
+            EVALUATOR_REVISION,
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(source_root), "checkout", "--detach", "FETCH_HEAD"],
+        check=True,
+    )
+
+
+def prepare_swebench_pro(data_root: Path) -> Path:
+    """Write the pinned 731-task benchmark and return its prompt JSONL path."""
+    from datasets import load_dataset
+
+    tasks_root = data_root / "tasks"
+    source_root = data_root / "SWE-bench_Pro-os"
+    data_root.mkdir(parents=True, exist_ok=True)
+    _checkout_evaluator(source_root)
+
+    source_rows = load_dataset(
+        "ScaleAI/SWE-bench_Pro",
+        revision=DATASET_REVISION,
+        split="test",
+    )
+    if len(source_rows) != 731:
+        raise RuntimeError(
+            f"Expected 731 SWE-bench Pro test tasks; got {len(source_rows)}"
+        )
+
+    tasks_root.mkdir(parents=True, exist_ok=True)
+    prompt_rows = []
+    instance_ids = set()
+    for source in source_rows:
+        instance_id = source["instance_id"]
+        if instance_id in instance_ids:
+            raise RuntimeError(f"Duplicate SWE-bench Pro task: {instance_id}")
+        instance_ids.add(instance_id)
+
+        official_assets = source_root / "run_scripts" / instance_id
+        run_script = official_assets / "run_script.sh"
+        parser_script = official_assets / "parser.py"
+        if not run_script.is_file() or not parser_script.is_file():
+            raise FileNotFoundError(
+                f"{instance_id}: missing official run_script.sh or parser.py"
+            )
+
+        selected_tests = _parse_string_list(
+            source["selected_test_files_to_run"],
+            "selected_test_files_to_run",
+            instance_id,
+        )
+        required_tests = sorted(
+            set(
+                _parse_string_list(source["fail_to_pass"], "fail_to_pass", instance_id)
+                + _parse_string_list(
+                    source["pass_to_pass"], "pass_to_pass", instance_id
+                )
+            )
+        )
+        if not selected_tests or not required_tests:
+            raise RuntimeError(
+                f"{instance_id}: selected and required tests must be non-empty"
+            )
+
+        task_dir = tasks_root / instance_id
+        environment_dir = task_dir / "environment"
+        tests_dir = task_dir / "tests"
+        environment_dir.mkdir(parents=True, exist_ok=True)
+        tests_dir.mkdir(parents=True, exist_ok=True)
+        (environment_dir / "Dockerfile").write_text(
+            f"FROM jefzda/sweap-images:{source['dockerhub_tag']}\n"
+        )
+        (environment_dir / "setup.sh").write_text(
+            _setup_script(source["before_repo_set_cmd"])
+        )
+        (tests_dir / "test.sh").write_text(_verifier_script(selected_tests))
+        (tests_dir / "run_script.sh").write_text(run_script.read_text())
+        (tests_dir / "parser.py").write_text(parser_script.read_text())
+        (tests_dir / "required_tests.json").write_text(
+            json.dumps(required_tests) + "\n"
+        )
+        (tests_dir / "protected_test_paths.txt").write_text(
+            "".join(f"{path}\n" for path in _patched_paths(source["test_patch"]))
+        )
+        (task_dir / "task.toml").write_text("[verifier]\ntimeout_sec = 3600\n")
+
+        prompt_rows.append(
+            {
+                "prompt": (
+                    f"{source['problem_statement']}\n\n"
+                    f"Requirements:\n{source['requirements']}\n\n"
+                    f"New interfaces introduced:\n{source['interface']}"
+                ),
+                "metadata": {
+                    "instance_id": instance_id,
+                    "task_dir": str(task_dir),
+                    "sandbox_cwd": "/app",
+                    "agent_name": "mini-swe-agent",
+                    "source_dataset": "ScaleAI/SWE-bench_Pro",
+                    "source_revision": DATASET_REVISION,
+                    "split": "test",
+                    "repo": source["repo"],
+                    "repo_language": source["repo_language"],
+                },
+            }
+        )
+
+    prompt_path = data_root / "test.jsonl"
+    prompt_path.write_text("".join(json.dumps(row) + "\n" for row in prompt_rows))
+    (data_root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "source": "ScaleAI/SWE-bench_Pro",
+                "dataset_revision": DATASET_REVISION,
+                "evaluator": "scaleapi/SWE-bench_Pro-os",
+                "evaluator_revision": EVALUATOR_REVISION,
+                "split": "test",
+                "tasks": len(prompt_rows),
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    print(f"Prepared {len(prompt_rows)} SWE-bench Pro tasks at {prompt_path}")
+    return prompt_path

--- a/cookbook/miles_disagg/swebench_pro_test.py
+++ b/cookbook/miles_disagg/swebench_pro_test.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from cookbook.miles_disagg.swebench_pro import (
+    _parse_string_list,
+    _patched_paths,
+    _setup_script,
+    _verifier_script,
+)
+
+
+def test_parse_string_list_rejects_non_string_items() -> None:
+    assert _parse_string_list("['a', 'b']", "tests", "task") == ["a", "b"]
+    with pytest.raises(TypeError, match="list of strings"):
+        _parse_string_list("['a', 1]", "tests", "task")
+
+
+def test_patched_paths_are_unique_and_sorted() -> None:
+    patch = "\n".join(
+        [
+            "diff --git a/z.py b/z.py",
+            "diff --git a/a.py b/a.py",
+            "diff --git a/z.py b/z.py",
+        ]
+    )
+    assert _patched_paths(patch) == ["a.py", "z.py"]
+
+
+@pytest.mark.parametrize(
+    "script",
+    [_setup_script("true"), _verifier_script(["test_a.py", "test b.py"])],
+)
+def test_generated_shell_is_valid(script: str) -> None:
+    subprocess.run(["bash", "-n"], input=script, text=True, check=True)
+
+
+def test_generated_verifier_python_is_valid() -> None:
+    script = _verifier_script(["test_a.py"])
+    source = script.split("python3 - <<'PY'\n", 1)[1].rsplit("\nPY", 1)[0]
+    compile(source, "verifier.py", "exec")

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -23,7 +23,6 @@ import importlib
 import os
 import subprocess
 import tempfile
-import uuid
 from types import SimpleNamespace
 from typing import Any
 
@@ -41,46 +40,74 @@ from cookbook.common.constants import (
     SERVER_STARTUP_TIMEOUT,
     SGLANG_CACHE_PATH,
     SIDECAR_PORT,
+    STITCH_PATH,
 )
 from cookbook.slime_disagg import trainer_image
 from cookbook.slime_disagg.config import YAML_CONFIG_FIELDS, SlimeConfig
 from cookbook.slime_disagg.trainer_image import SLIME_ROOT
 from stitch.pools.modal_flash import ModalFlashPool
 
-EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]  # required; a default would silently serve the wrong experiment
-SLIME_LOCAL_DIR = os.environ.get("SLIME_LOCAL_DIR")  # optional dev overlay of a local slime checkout
+EXPERIMENT = os.environ[
+    "EXPERIMENT_CONFIG"
+]  # required; a default would silently serve the wrong experiment
+SLIME_LOCAL_DIR = os.environ.get(
+    "SLIME_LOCAL_DIR"
+)  # optional dev overlay of a local slime checkout
 
 exp = importlib.import_module(f"cookbook.slime_disagg.configs.{EXPERIMENT}")
 modal_cfg = exp.modal
 slime_cfg = exp.slime
 
-# Per-run id, minted fresh per launch by cookbook.slime_disagg.launch: names the pool app + delta
-# transport root, so each run — even an identical-config relaunch — is its own isolated pool.
+# Per-run id, minted fresh by cookbook.slime_disagg.launch. The same identity
+# scopes the pool, Stitch pointer, publications, checkpoints, and logs.
 RUN_ID = os.environ["RUN_ID"]
 APP_NAME = f"{exp.APP_NAME}-{RUN_ID}"
-BULLETIN_ROOT = f"{exp.DELTA_BULLETIN_ROOT}/{RUN_ID}"
+RUN_ROOT = f"{STITCH_PATH}/{RUN_ID}"
+UPDATE_ROOT = f"{RUN_ROOT}/updates"
 
 # Flash autoscaler target / sglang concurrency cap: explicit target_inputs, else engine concurrency.
-ROLLOUT_CONCURRENCY = modal_cfg.rollout_target_inputs or slime_cfg.sglang_server_concurrency
+ROLLOUT_CONCURRENCY = (
+    modal_cfg.rollout_target_inputs or slime_cfg.sglang_server_concurrency
+)
 
 # EXPERIMENT_CONFIG + RUN_ID are baked into both images so a container's re-import rebuilds the same
 # app name and transport paths as the deploy, not the defaults.
-image = trainer_image.build_trainer_image(hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, run_id=RUN_ID, slime_local=SLIME_LOCAL_DIR)
+image = trainer_image.build_trainer_image(
+    hf_cache_path=str(HF_CACHE_PATH),
+    experiment=EXPERIMENT,
+    run_id=RUN_ID,
+    slime_local=SLIME_LOCAL_DIR,
+)
 server_image = serving_image.build_serving_image(
     hf_cache_path=str(HF_CACHE_PATH),
-    delta_volume_name=exp.DELTA_VOLUME_NAME,
     experiment=EXPERIMENT,
     run_id=RUN_ID,
     runtime=getattr(exp, "SGLANG_RUNTIME", serving_image.DEFAULT_SGLANG_RUNTIME),
 )
 if SLIME_LOCAL_DIR:
-    server_image = server_image.add_local_dir(SLIME_LOCAL_DIR, remote_path=SLIME_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])
+    server_image = server_image.add_local_dir(
+        SLIME_LOCAL_DIR,
+        remote_path=SLIME_ROOT,
+        ignore=[".git", "**/__pycache__", "**/*.pyc"],
+    )
 
-hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=True, version=2)
+hf_cache_volume = modal.Volume.from_name(
+    "huggingface-cache", create_if_missing=True, version=2
+)
 data_volume = modal.Volume.from_name("slime-data", create_if_missing=True, version=2)
-checkpoints_volume = modal.Volume.from_name("slime-checkpoints", create_if_missing=True, version=2)
-sglang_cache_volume = modal.Volume.from_name("sglang-cache", create_if_missing=True, version=2)
-delta_volume = modal.Volume.from_name(exp.DELTA_VOLUME_NAME, create_if_missing=True, version=2)
+checkpoint_volume = modal.Volume.from_name(
+    "slime-checkpoints",
+    create_if_missing=True,
+    version=2,
+)
+sglang_cache_volume = modal.Volume.from_name(
+    "sglang-cache", create_if_missing=True, version=2
+)
+run_volume = modal.Volume.from_name(
+    exp.EXPERIMENT_VOLUME_NAME,
+    create_if_missing=True,
+    version=2,
+)
 draft_volume = (
     modal.Volume.from_name(
         modal_cfg.draft_volume,
@@ -93,9 +120,9 @@ draft_volume = (
 
 train_volumes = {
     str(HF_CACHE_PATH): hf_cache_volume,
+    str(CHECKPOINTS_PATH): checkpoint_volume,
     str(DATA_PATH): data_volume,
-    str(CHECKPOINTS_PATH): checkpoints_volume,
-    exp.DELTA_BULLETIN_ROOT: delta_volume,
+    str(STITCH_PATH): run_volume,
 }
 
 app = modal.App(APP_NAME)
@@ -115,33 +142,46 @@ SGLANG_SERVER_ARGS = {
 @app.cls(
     image=server_image,
     gpu=f"{modal_cfg.gpu}:{slime_cfg.rollout_num_gpus_per_engine}",
-    cloud=modal_cfg.cloud, region=modal_cfg.region,
+    cpu=modal_cfg.rollout_cpu,
+    cloud=modal_cfg.cloud,
+    region=modal_cfg.region,
     volumes={
         str(HF_CACHE_PATH): hf_cache_volume,
+        str(CHECKPOINTS_PATH): checkpoint_volume,
+        str(STITCH_PATH): run_volume,
         SGLANG_CACHE_PATH: sglang_cache_volume,
-        exp.DELTA_BULLETIN_ROOT: delta_volume,
         **({str(DRAFT_PATH): draft_volume} if draft_volume is not None else {}),
     },
-    min_containers=modal_cfg.rollout_min_containers, max_containers=modal_cfg.rollout_max_containers,
-    timeout=40 * MINUTES, scaledown_window=15 * MINUTES,
-    ephemeral_disk=modal_cfg.rollout_ephemeral_disk_mib, memory=modal_cfg.rollout_memory_mib,
+    min_containers=modal_cfg.rollout_min_containers,
+    max_containers=modal_cfg.rollout_max_containers,
+    timeout=40 * MINUTES,
+    scaledown_window=15 * MINUTES,
+    ephemeral_disk=modal_cfg.rollout_ephemeral_disk_mib,
+    memory=modal_cfg.rollout_memory_mib,
     include_source=False,
 )
 @modal.experimental.http_server(
-    port=SIDECAR_PORT, proxy_regions=modal_cfg.proxy_regions,
-    exit_grace_period=25, startup_timeout=SERVER_STARTUP_TIMEOUT,
+    port=SIDECAR_PORT,
+    proxy_regions=modal_cfg.proxy_regions,
+    exit_grace_period=25,
+    startup_timeout=SERVER_STARTUP_TIMEOUT,
 )
 @modal.concurrent(target_inputs=ROLLOUT_CONCURRENCY)
 class Server:
     @modal.enter()
     def startup(self) -> None:
         server.serve_startup(
-            self, model_name=slime_cfg.hf_checkpoint, sglang_args=SGLANG_SERVER_ARGS,
-            tp=slime_cfg.rollout_num_gpus_per_engine, concurrency=ROLLOUT_CONCURRENCY,
-            bulletin_root=BULLETIN_ROOT,
+            self,
+            model_name=slime_cfg.hf_checkpoint,
+            sglang_args=SGLANG_SERVER_ARGS,
+            tp=slime_cfg.rollout_num_gpus_per_engine,
+            concurrency=ROLLOUT_CONCURRENCY,
+            bulletin_root=RUN_ROOT,
             local_checkpoint_dir=exp.LOCAL_CHECKPOINT_PATH,
             delta_update_mode=exp.SGLANG_DELTA_UPDATE_MODE,
-            volume_name=exp.DELTA_VOLUME_NAME, commit_mode=exp.SIDECAR_COMMIT_MODE,
+            volume_name=exp.EXPERIMENT_VOLUME_NAME,
+            commit_mode=exp.SIDECAR_COMMIT_MODE,
+            run_id=RUN_ID,
             flush_cache_on_commit=exp.SIDECAR_FLUSH_CACHE_ON_COMMIT,
             startup_timeout=SERVER_STARTUP_TIMEOUT,
         )
@@ -160,15 +200,23 @@ _MULTINODE = slime_cfg.n_train_nodes > 1
 @app.cls(
     image=image,
     gpu=f"{modal_cfg.gpu}:{slime_cfg.actor_num_gpus_per_node}",
+    cpu=modal_cfg.trainer_cpu,
     memory=modal_cfg.trainer_memory_mib,
-    cloud=modal_cfg.cloud, region=modal_cfg.region,
+    cloud=modal_cfg.cloud,
+    region=modal_cfg.region,
     volumes=train_volumes,
     ephemeral_disk=modal_cfg.trainer_ephemeral_disk_mib,
-    timeout=24 * 60 * MINUTES, startup_timeout=20 * MINUTES, scaledown_window=30 * MINUTES,
+    timeout=24 * 60 * MINUTES,
+    startup_timeout=20 * MINUTES,
+    scaledown_window=30 * MINUTES,
     include_source=False,
     **({"experimental_options": {"efa_enabled": True}} if _MULTINODE else {}),
 )
-@(modal.experimental.clustered(slime_cfg.n_train_nodes, rdma=True) if _MULTINODE else lambda c: c)
+@(
+    modal.experimental.clustered(slime_cfg.n_train_nodes, rdma=True)
+    if _MULTINODE
+    else lambda c: c
+)
 class Trainer:
     """slime actor cluster. Ray comes up once per container in enter(), so back-to-back
     runs reuse it."""
@@ -177,11 +225,17 @@ class Trainer:
     def start_ray(self) -> None:
         from cookbook.common import process
 
-        rank, master_addr, my_ip = ray_cluster.get_modal_cluster_context(slime_cfg.n_train_nodes)
+        rank, master_addr, my_ip = ray_cluster.get_modal_cluster_context(
+            slime_cfg.n_train_nodes
+        )
         self.rank = rank
         process.start_host_mem_monitor()  # per-node host-RAM trace
         ray_cluster.start_ray_node(
-            rank, master_addr, my_ip, n_nodes=slime_cfg.n_train_nodes, ray_port=RAY_PORT,
+            rank,
+            master_addr,
+            my_ip,
+            n_nodes=slime_cfg.n_train_nodes,
+            ray_port=RAY_PORT,
             extra_env={"SLIME_HOST_IP": my_ip, **slime_cfg.environment},
         )
 
@@ -195,24 +249,31 @@ class Trainer:
 
         cfg = SlimeConfig.from_payload(payload)
         cfg.rollout_endpoint_url = ModalFlashPool(APP_NAME, "Server").gateway_url()
-        run_id = uuid.uuid4().hex[:12]  # per-launch fence token; forks a fresh chain
-        cfg.update_weight_disk_dir = f"{BULLETIN_ROOT}/{run_id}"
+        cfg.update_weight_disk_dir = UPDATE_ROOT
         hook_knobs = {
-            "update_weight_delta_volume_name": exp.DELTA_VOLUME_NAME,
+            "experiment_volume_name": exp.EXPERIMENT_VOLUME_NAME,
             "rollout_modal_flash_app_name": APP_NAME,
             "rollout_modal_flash_server_cls_name": "Server",
-            "run_id": run_id,
+            "run_id": RUN_ID,
         }
-        cfg.custom_config_path = hook_knobs  # materialized to a YAML path below; keep the mapping for claim
+        cfg.custom_config_path = (
+            hook_knobs  # materialized to a YAML path below; keep the mapping for claim
+        )
         launch.resolve_config(cfg, tempfile.mkdtemp(), YAML_CONFIG_FIELDS)
         cmd = launch.build_train_cmd(cfg, SLIME_ROOT, "slime_model_script")
 
         # Claim the pool before slime publishes: reset every replica to base for this run.
         from cookbook.common import hooks
 
-        hooks.claim_pool(SimpleNamespace(update_weight_disk_dir=cfg.update_weight_disk_dir, **hook_knobs))
+        hooks.claim_pool(
+            SimpleNamespace(
+                update_weight_disk_dir=cfg.update_weight_disk_dir, **hook_knobs
+            )
+        )
 
-        print(f"Training {EXPERIMENT}: nodes={slime_cfg.n_train_nodes}, rollout_endpoint={cfg.rollout_endpoint_url}")
+        print(
+            f"Training {EXPERIMENT}: nodes={slime_cfg.n_train_nodes}, rollout_endpoint={cfg.rollout_endpoint_url}"
+        )
         print(f"Command: {cmd}")
         subprocess.run(["bash", "-lc", cmd], check=True)
 

--- a/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
+++ b/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
@@ -6,13 +6,14 @@ Deploy: EXPERIMENT_CONFIG=kimi_k2_6_int4 uv run --extra modal modal deploy -m co
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH, STITCH_PATH
 from cookbook.slime_disagg.config import SlimeConfig
 
 APP_NAME = "stitch-kimi-k2-6-int4"
-DELTA_VOLUME_NAME = "stitch-delta-kimi-k2-6-int4"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-slime-kimi-k2-6-int4"
 LOCAL_CHECKPOINT_PATH = None
+SOURCE_MODEL = "moonshotai/Kimi-K2.6"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "kimi-k2-6-int4"
 
 # QAT grouping; MUST match the served INT4 checkpoint's compressed-tensors group_size.
 INT4_GROUP_SIZE = "32"
@@ -64,7 +65,7 @@ class _Slime(SlimeConfig):
     slime_model_script = "scripts/models/kimi-k2-thinking.sh"
 
     # The native-INT4 base is the served model, the QAT init, and the disk-delta base.
-    hf_checkpoint = "moonshotai/Kimi-K2.6"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
     ref_load = hf_checkpoint
     megatron_to_hf_mode = "bridge"
 
@@ -76,7 +77,9 @@ class _Slime(SlimeConfig):
     rollout_endpoint_url = None          # filled at launch from the pool gateway
 
     # The three plug points stitch fills (slime's publish hook key is custom_delta_pre_push_path):
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     custom_delta_pre_push_path = "cookbook.common.hooks.commit_and_wake"
     rollout_request_weight_version_mode = "min"
     rollout_request_weight_version_lag = 1
@@ -90,7 +93,7 @@ class _Slime(SlimeConfig):
     update_weight_transport = "disk"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT  # run-scoped at launch to <root>/<run_id>
+    update_weight_disk_dir = str(STITCH_PATH)  # run-scoped at launch
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"
     input_key = "prompt"
@@ -108,7 +111,9 @@ class _Slime(SlimeConfig):
     rollout_top_p = 1.0
     n_samples_per_prompt = 8
     over_sampling_batch_size = 256
-    dynamic_sampling_filter_path = "slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std"
+    dynamic_sampling_filter_path = (
+        "slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std"
+    )
     num_steps_per_rollout = 4
     balance_data = True
     sglang_server_concurrency = 256

--- a/cookbook/slime_disagg/configs/moonlight.py
+++ b/cookbook/slime_disagg/configs/moonlight.py
@@ -6,13 +6,14 @@ Deploy: EXPERIMENT_CONFIG=moonlight m deploy --strategy recreate -m cookbook.sli
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH, STITCH_PATH
 from cookbook.slime_disagg.config import SlimeConfig
 
 APP_NAME = "stitch-moonlight"
-DELTA_VOLUME_NAME = "stitch-delta-moonlight"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-slime-moonlight"
 LOCAL_CHECKPOINT_PATH = None
+SOURCE_MODEL = "moonshotai/Moonlight-16B-A3B-Instruct"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "moonlight-bf16"
 
 # in_place applies weights without draining in-flight rollouts; stale KV isolated per version.
 SIDECAR_COMMIT_MODE = "in_place"
@@ -44,7 +45,7 @@ class _Slime(SlimeConfig):
     # Arch comes from the model script; do NOT inline arch attrs here.
     slime_model_script = "scripts/models/moonlight.sh"
 
-    hf_checkpoint = "moonshotai/Moonlight-16B-A3B-Instruct"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
     ref_load = hf_checkpoint
     megatron_to_hf_mode = "bridge"
 
@@ -55,7 +56,9 @@ class _Slime(SlimeConfig):
     rollout_num_gpus_per_engine = 1  # 1xH200 per rollout container (MLA -> cheap KV)
     rollout_endpoint_url = None
     # Staleness gate: pin each request to latest_published - lag; over-stale replicas 409 -> retry.
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     rollout_request_weight_version_mode = "min"
     rollout_request_weight_version_lag = 1
     rollout_request_retry_attempts = 240
@@ -70,7 +73,7 @@ class _Slime(SlimeConfig):
     update_weight_transport = "disk"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
+    update_weight_disk_dir = str(STITCH_PATH)
     custom_delta_pre_push_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/slime_disagg/configs/moonlight_int4.py
+++ b/cookbook/slime_disagg/configs/moonlight_int4.py
@@ -8,13 +8,14 @@ Deploy: EXPERIMENT_CONFIG=moonlight_int4 m deploy --strategy recreate -m cookboo
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH, STITCH_PATH
 from cookbook.slime_disagg.config import SlimeConfig
 
 APP_NAME = "stitch-moonlight-int4"
-DELTA_VOLUME_NAME = "stitch-delta-moonlight-int4"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-slime-moonlight-int4"
 LOCAL_CHECKPOINT_PATH = None
+SOURCE_MODEL = "moonshotai/Moonlight-16B-A3B-Instruct-INT4"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "moonlight-int4"
 
 INT4_GROUP_SIZE = "128"
 
@@ -47,7 +48,7 @@ class _Slime(SlimeConfig):
     slime_model_script = "scripts/models/moonlight.sh"
 
     # The native-INT4 base is the served model, the QAT init, and the disk-delta base.
-    hf_checkpoint = "moonshotai/Moonlight-16B-A3B-Instruct-INT4"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
     ref_load = hf_checkpoint
     megatron_to_hf_mode = "bridge"
 
@@ -57,7 +58,9 @@ class _Slime(SlimeConfig):
     rollout_num_gpus = 0
     rollout_num_gpus_per_engine = 1  # 1xH200 per rollout container (16B INT4 fits)
     rollout_endpoint_url = None
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     rollout_request_weight_version_mode = "min"
     rollout_request_weight_version_lag = 1
     rollout_request_retry_attempts = 240
@@ -72,7 +75,7 @@ class _Slime(SlimeConfig):
     update_weight_transport = "disk"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
+    update_weight_disk_dir = str(STITCH_PATH)
     custom_delta_pre_push_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import DATA_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH, STITCH_PATH
 from cookbook.slime_disagg.config import SlimeConfig
 
 APP_NAME = "stitch-qwen3-4b"
-DELTA_VOLUME_NAME = "stitch-delta-qwen3-4b"
-DELTA_BULLETIN_ROOT = "/delta-bulletin"
+EXPERIMENT_VOLUME_NAME = "stitch-slime-qwen3-4b"
 LOCAL_CHECKPOINT_PATH = None
+SOURCE_MODEL = "Qwen/Qwen3-4B"
+ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "qwen3-4b-bf16"
 
 # in_place applies weights without draining; stale KV isolated per version via extra_key.
 SIDECAR_COMMIT_MODE = "in_place"
@@ -37,7 +38,7 @@ modal = ModalConfig(
 
 
 class _Slime(SlimeConfig):
-    hf_checkpoint = "Qwen/Qwen3-4B"
+    hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
     ref_load = hf_checkpoint
     megatron_to_hf_mode = "bridge"
 
@@ -46,8 +47,12 @@ class _Slime(SlimeConfig):
     colocate = False
     rollout_num_gpus = 0
     rollout_num_gpus_per_engine = 1
-    rollout_endpoint_url = None  # publish-only: slime routes /generate to the Flash gateway
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    rollout_endpoint_url = (
+        None  # publish-only: slime routes /generate to the Flash gateway
+    )
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     rollout_request_weight_version_mode = "exact"
     rollout_request_weight_version_lag = 0
     rollout_request_retry_attempts = 240
@@ -60,7 +65,7 @@ class _Slime(SlimeConfig):
     update_weight_transport = "disk"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT
+    update_weight_disk_dir = str(STITCH_PATH)
     custom_delta_pre_push_path = "cookbook.common.hooks.commit_and_wake"
 
     prompt_data = f"{DATA_PATH}/gsm8k/train.parquet"

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash_hillclimb.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash_hillclimb.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from cookbook.slime_disagg.configs import qwen3_4b_delta_flash as _base
 
 APP_NAME = "stitch-qwen3-4b-hillclimb"
-DELTA_VOLUME_NAME = "stitch-delta-qwen3-4b-hillclimb"
-DELTA_BULLETIN_ROOT = _base.DELTA_BULLETIN_ROOT
+EXPERIMENT_VOLUME_NAME = _base.EXPERIMENT_VOLUME_NAME
+SOURCE_MODEL = _base.SOURCE_MODEL
+ROLLOUT_CHECKPOINT_PATH = _base.ROLLOUT_CHECKPOINT_PATH
 LOCAL_CHECKPOINT_PATH = _base.LOCAL_CHECKPOINT_PATH
 SIDECAR_COMMIT_MODE = _base.SIDECAR_COMMIT_MODE
 SIDECAR_FLUSH_CACHE_ON_COMMIT = _base.SIDECAR_FLUSH_CACHE_ON_COMMIT

--- a/cookbook/slime_disagg/prep_app.py
+++ b/cookbook/slime_disagg/prep_app.py
@@ -14,41 +14,85 @@ from __future__ import annotations
 
 import importlib
 import os
+import shutil
+from pathlib import Path
 
 import modal
 
-from cookbook.common.constants import DATA_PATH, HF_CACHE_PATH, MINUTES
+from cookbook.common.constants import (
+    CHECKPOINTS_PATH,
+    DATA_PATH,
+    HF_CACHE_PATH,
+    MINUTES,
+)
 from cookbook.slime_disagg import trainer_image
 
-EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]  # required; a default would silently prep the wrong experiment
-SLIME_LOCAL_DIR = os.environ.get("SLIME_LOCAL_DIR")  # optional dev overlay of a local slime checkout
+EXPERIMENT = os.environ[
+    "EXPERIMENT_CONFIG"
+]  # required; a default would silently prep the wrong experiment
+SLIME_LOCAL_DIR = os.environ.get(
+    "SLIME_LOCAL_DIR"
+)  # optional dev overlay of a local slime checkout
 
 exp = importlib.import_module(f"cookbook.slime_disagg.configs.{EXPERIMENT}")
 slime_cfg = exp.slime
 
-image = trainer_image.build_trainer_image(hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, slime_local=SLIME_LOCAL_DIR)
+image = trainer_image.build_trainer_image(
+    hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, slime_local=SLIME_LOCAL_DIR
+)
 
-hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=True, version=2)
+hf_cache_volume = modal.Volume.from_name(
+    "huggingface-cache", create_if_missing=True, version=2
+)
 data_volume = modal.Volume.from_name("slime-data", create_if_missing=True, version=2)
+checkpoint_volume = modal.Volume.from_name(
+    "slime-checkpoints",
+    create_if_missing=True,
+    version=2,
+)
 
 app = modal.App(f"{exp.APP_NAME}-prep")
 
 
 @app.function(
-    image=image, volumes={str(HF_CACHE_PATH): hf_cache_volume},
-    timeout=2 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+    image=image,
+    volumes={
+        str(HF_CACHE_PATH): hf_cache_volume,
+        str(CHECKPOINTS_PATH): checkpoint_volume,
+    },
+    timeout=2 * 60 * MINUTES,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
 )
 def download_model() -> None:
-    """Snapshot the served model into the HF cache (sglang serves it by repo id)."""
+    """Materialize the configured model artifact in the checkpoint Volume."""
     from huggingface_hub import snapshot_download
 
-    snapshot_download(repo_id=slime_cfg.hf_checkpoint)
-    hf_cache_volume.commit()
+    checkpoint_volume.reload()
+    target = Path(slime_cfg.hf_checkpoint)
+    if (target / "config.json").is_file():
+        print(f"reusing model checkpoint {target}")
+        return
+    if target.exists():
+        raise RuntimeError(f"incomplete model checkpoint: {target}")
+    partial = target.with_name(f"{target.name}.partial")
+    shutil.rmtree(partial, ignore_errors=True)
+    snapshot_download(
+        repo_id=exp.SOURCE_MODEL,
+        revision=getattr(exp, "SOURCE_REVISION", None),
+        local_dir=partial,
+    )
+    shutil.rmtree(partial / ".cache", ignore_errors=True)
+    partial.rename(target)
+    checkpoint_volume.commit()
 
 
 @app.function(
-    image=image, volumes={str(DATA_PATH): data_volume},
-    timeout=2 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+    image=image,
+    volumes={str(DATA_PATH): data_volume},
+    timeout=2 * 60 * MINUTES,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
 )
 def prepare_dataset() -> None:
     data_volume.reload()

--- a/src/stitch/stores/modal_volume.py
+++ b/src/stitch/stores/modal_volume.py
@@ -1,10 +1,9 @@
 """``ModalVolumeStore`` — the ``Store`` instance backed by a Modal Volume.
 
-Each run's chain lives under ``<root>/<run_id>/weight_vNNNNNN/`` (run-less:
-``<root>/weight_vNNNNNN/``) as HF-safetensors + delta metadata, and a ``latest``
-text file holds the self-identifying pointer identity. Durability is an explicit
-Volume commit; cross-host visibility is a reload. With ``volume_name=None`` it is a
-plain local directory, so the class is exercisable without Modal.
+``root`` is one run's directory. The training framework owns
+``<root>/updates/`` and may recreate it while initializing; Stitch owns the
+self-identifying ``<root>/latest`` commit pointer. Durability is an explicit
+Volume commit and cross-host visibility is a reload.
 """
 
 from __future__ import annotations
@@ -21,9 +20,18 @@ _POINTER = "latest"
 
 
 class ModalVolumeStore(Store):
-    def __init__(self, root: str | Path, *, volume_name: str | None = None) -> None:
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        run_id: str,
+        volume_name: str | None = None,
+    ) -> None:
+        if not run_id:
+            raise ValueError("run_id is required")
         self.root = Path(root)
         self.volume_name = volume_name
+        self.run_id = run_id
 
     def refresh(self) -> None:
         if self.volume_name:
@@ -37,6 +45,10 @@ class ModalVolumeStore(Store):
         return VersionRef.parse(text) if text else None
 
     def advance_pointer(self, ref: VersionRef) -> None:
+        if ref.run_id != self.run_id:
+            raise ValueError(
+                f"store is scoped to run {self.run_id!r}, got {ref.run_id!r}"
+            )
         self.root.mkdir(parents=True, exist_ok=True)
         _atomic_write(self.root / _POINTER, ref.identity)
         if self.volume_name:
@@ -44,7 +56,9 @@ class ModalVolumeStore(Store):
 
     def claim(self, run_id: str) -> None:
         if not run_id:
-            raise ValueError("claim requires a run_id (the run's per-launch epoch token)")
+            raise ValueError(
+                "claim requires a run_id (the run's per-launch epoch token)"
+            )
         self.advance_pointer(VersionRef(run_id, 0))
 
     def read_manifest(self, ref: VersionRef) -> VersionManifest:
@@ -75,7 +89,11 @@ class ModalVolumeStore(Store):
             _volume(self.volume_name).commit()
 
     def _version_dir(self, ref: VersionRef) -> Path:
-        return self.root / ref.identity
+        if ref.run_id != self.run_id:
+            raise ValueError(
+                f"store is scoped to run {self.run_id!r}, got {ref.run_id!r}"
+            )
+        return self.root / "updates" / Path(ref.identity).name
 
 
 def _volume(name: str):

--- a/src/stitch/stores/modal_volume_test.py
+++ b/src/stitch/stores/modal_volume_test.py
@@ -15,12 +15,21 @@ from stitch.stores.modal_volume import ModalVolumeStore
 from stitch.types import VersionKind, VersionRef
 
 
-def _write_version(root: Path, ref: VersionRef, *, base: int | None = None, diff: str | None = None) -> str:
-    d = root / ref.identity
+def _write_version(
+    root: Path, ref: VersionRef, *, base: int | None = None, diff: str | None = None
+) -> str:
+    d = root / "updates" / Path(ref.identity).name
     d.mkdir(parents=True)
     meta: dict = {"version": ref.version}
     if diff:
-        meta.update({"delta_encoding": diff, "base_version": base, "compression_format": "zstd", "checksum_format": "xxh3-128"})
+        meta.update(
+            {
+                "delta_encoding": diff,
+                "base_version": base,
+                "compression_format": "zstd",
+                "checksum_format": "xxh3-128",
+            }
+        )
     (d / "model.safetensors.index.json").write_text(
         json.dumps({"metadata": meta, "weight_map": {"w": "model-00001.safetensors"}})
     )
@@ -31,12 +40,14 @@ def _write_version(root: Path, ref: VersionRef, *, base: int | None = None, diff
 def test_publish_full_roundtrip() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        store = ModalVolumeStore(root)
+        store = ModalVolumeStore(root, run_id="r1")
         assert store.read_pointer() is None
         vdir = _write_version(root, VersionRef("r1", 1))  # framework wrote it in place
         ref = publish_version(store, None, vdir, run_id="r1")
         assert ref == VersionRef("r1", 1)
-        assert store.read_pointer() == VersionRef("r1", 1)  # pointer parses back to the ref
+        assert store.read_pointer() == VersionRef(
+            "r1", 1
+        )  # pointer parses back to the ref
         man = store.read_manifest(ref)
         assert man.kind is VersionKind.FULL
         assert (Path(store.materialize(ref)) / "model.safetensors.index.json").exists()
@@ -45,11 +56,18 @@ def test_publish_full_roundtrip() -> None:
 def test_claim_then_delta_chain() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        store = ModalVolumeStore(root)
+        store = ModalVolumeStore(root, run_id="r1")
         store.claim("r1")
         assert store.read_pointer() == VersionRef("r1", 0)  # base before any publish
-        publish_version(store, None, _write_version(root, VersionRef("r1", 1)), run_id="r1")
-        publish_version(store, None, _write_version(root, VersionRef("r1", 2), base=1, diff="xor"), run_id="r1")
+        publish_version(
+            store, None, _write_version(root, VersionRef("r1", 1)), run_id="r1"
+        )
+        publish_version(
+            store,
+            None,
+            _write_version(root, VersionRef("r1", 2), base=1, diff="xor"),
+            run_id="r1",
+        )
         assert store.read_pointer() == VersionRef("r1", 2)
         man = store.read_manifest(VersionRef("r1", 2))
         assert man.kind is VersionKind.DELTA
@@ -59,10 +77,25 @@ def test_copies_when_files_dir_is_external() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root, staging = Path(tmp) / "store", Path(tmp) / "staging"
         root.mkdir()
-        store = ModalVolumeStore(root)
-        src = _write_version(staging, VersionRef("r1", 1))  # a staging dir, not the store layout
+        store = ModalVolumeStore(root, run_id="r1")
+        src = _write_version(
+            staging, VersionRef("r1", 1)
+        )  # a staging dir, not the store layout
         publish_version(store, None, src, run_id="r1")
-        assert (root / "r1" / "weight_v000001" / "model.safetensors.index.json").exists()
+        assert (
+            root / "updates" / "weight_v000001" / "model.safetensors.index.json"
+        ).exists()
+
+
+def test_rejects_a_version_from_another_run() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        store = ModalVolumeStore(tmp, run_id="r1")
+        try:
+            store.advance_pointer(VersionRef("r2", 1))
+        except ValueError as exc:
+            assert "scoped to run 'r1'" in str(exc)
+        else:
+            raise AssertionError("cross-run pointer must fail")
 
 
 if __name__ == "__main__":

--- a/tools/profiling/glm45_air_fp8_delta_weight_update.py
+++ b/tools/profiling/glm45_air_fp8_delta_weight_update.py
@@ -69,7 +69,6 @@ delta_volume = modal.Volume.from_name(DELTA_VOLUME_NAME, version=2)
 sglang_cache_volume = modal.Volume.from_name(SGLANG_CACHE_VOLUME_NAME, version=2)
 image = build_serving_image(
     hf_cache_path="/root/.cache/huggingface",
-    delta_volume_name=DELTA_VOLUME_NAME,
     experiment=EXPERIMENT,
 ).add_local_dir(
     str(Path(__file__).resolve().parents[1]),

--- a/tools/profiling/kimi_k2_6_nvfp4_delta_weight_update.py
+++ b/tools/profiling/kimi_k2_6_nvfp4_delta_weight_update.py
@@ -74,7 +74,6 @@ delta_volume = modal.Volume.from_name(DELTA_VOLUME_NAME, version=2)
 sglang_cache_volume = modal.Volume.from_name(SGLANG_CACHE_VOLUME_NAME, version=2)
 image = build_serving_image(
     hf_cache_path="/root/.cache/huggingface",
-    delta_volume_name=DELTA_VOLUME_NAME,
     experiment=EXPERIMENT,
 ).add_local_dir(
     str(Path(__file__).resolve().parents[1]),


### PR DESCRIPTION
## Summary

- pin the SWE-bench Pro dataset and open-source evaluator revisions
- materialize all 731 rows as executable Harbor tasks
- preserve the official run scripts and parsers
- reject policies that modify benchmark test files
- write a revisioned manifest and Miles prompt JSONL

## Stack

2 of 3. Review this two-file diff independently; merge after #94.

- #94 — storage and run-state contract
- #95 — pinned SWE-bench Pro preparation (this PR)
- #96 — GLM-5.2 NVFP4 experiment

## Validation

- `uv run ruff check cookbook/miles_disagg/swebench_pro.py cookbook/miles_disagg/swebench_pro_test.py`
- `uv run pytest cookbook/miles_disagg/swebench_pro_test.py` — 5 passed