### PR TITLE
style: format cookbook files with Ruff

### DIFF
--- a/cookbook/common/constants.py
+++ b/cookbook/common/constants.py
@@ -11,13 +11,17 @@ from pathlib import Path
 HF_CACHE_PATH = Path("/root/.cache/huggingface")
 DATA_PATH = Path("/data")
 CHECKPOINTS_PATH = Path("/checkpoints")
-PREP_PATH = Path("/prep")  # <PREP>/<tag>/{bf16 masters, served base, torch_dist ref_load}
+PREP_PATH = Path(
+    "/prep"
+)  # <PREP>/<tag>/{bf16 masters, served base, torch_dist ref_load}
 DRAFT_PATH = Path("/draft")
-SGLANG_CACHE_PATH = "/root/.cache/sglang"  # sglang kernel/JIT cache; survives cold starts
+SGLANG_CACHE_PATH = (
+    "/root/.cache/sglang"  # sglang kernel/JIT cache; survives cold starts
+)
 
 # Ports.
 SIDECAR_PORT = 8000  # the container's public port
-SGLANG_PORT = 8001   # the private sglang server behind the sidecar
+SGLANG_PORT = 8001  # the private sglang server behind the sidecar
 RAY_PORT = 6379
 
 # Timeouts.

--- a/cookbook/common/process.py
+++ b/cookbook/common/process.py
@@ -69,7 +69,9 @@ def wait_http(url: str, process: subprocess.Popen | None, timeout: int) -> None:
     last_error: str | None = None
     while time.time() < deadline:
         if process is not None and process.poll() is not None:
-            raise RuntimeError(f"process exited while waiting for {url}: code={process.returncode}")
+            raise RuntimeError(
+                f"process exited while waiting for {url}: code={process.returncode}"
+            )
         try:
             with urllib.request.urlopen(url, timeout=5) as resp:
                 if 200 <= resp.status < 500:
@@ -99,18 +101,26 @@ def apply_git_patches(patch_paths: list[str], repo_dir: str, label: str) -> None
     for patch_path in patch_paths:
         if not os.path.exists(patch_path):
             raise FileNotFoundError(f"{label} not found: {patch_path}")
-        check = subprocess.run(["git", "-C", repo_dir, "apply", "--check", patch_path], capture_output=True, text=True)
+        check = subprocess.run(
+            ["git", "-C", repo_dir, "apply", "--check", patch_path],
+            capture_output=True,
+            text=True,
+        )
         if check.returncode == 0:
             subprocess.run(["git", "-C", repo_dir, "apply", patch_path], check=True)
             print(f"[{label}] applied {patch_path}", flush=True)
             continue
         reverse = subprocess.run(
-            ["git", "-C", repo_dir, "apply", "--reverse", "--check", patch_path], capture_output=True, text=True
+            ["git", "-C", repo_dir, "apply", "--reverse", "--check", patch_path],
+            capture_output=True,
+            text=True,
         )
         if reverse.returncode == 0:
             print(f"[{label}] already applied {patch_path}", flush=True)
             continue
-        raise RuntimeError(f"cannot apply {label} {patch_path}\ncheck: {check.stderr}\nreverse: {reverse.stderr}")
+        raise RuntimeError(
+            f"cannot apply {label} {patch_path}\ncheck: {check.stderr}\nreverse: {reverse.stderr}"
+        )
 
 
 def start_host_mem_monitor(interval_s: int = 20) -> None:
@@ -140,7 +150,10 @@ def start_host_mem_monitor(interval_s: int = 20) -> None:
         while True:
             total, avail = _meminfo()
             if i == 0 or avail < 500 or i % heartbeat == 0:
-                print(f"[hostmem] {host} used={total - avail:.0f}GiB avail={avail:.0f}GiB total={total:.0f}GiB", flush=True)
+                print(
+                    f"[hostmem] {host} used={total - avail:.0f}GiB avail={avail:.0f}GiB total={total:.0f}GiB",
+                    flush=True,
+                )
             i += 1
             time.sleep(interval_s)
 

--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -63,10 +63,17 @@ def serve_startup(
     warmup = {
         "model": model_name,
         "messages": [{"role": "user", "content": "Reply with exactly OK."}],
-        "max_tokens": 8, "temperature": 0, "chat_template_kwargs": {"enable_thinking": False},
+        "max_tokens": 8,
+        "temperature": 0,
+        "chat_template_kwargs": {"enable_thinking": False},
     }
-    warmup_chat_completions(port=SGLANG_PORT, payload=warmup, successful_requests=2,
-                            request_timeout=120.0, max_attempts_per_request=3)
+    warmup_chat_completions(
+        port=SGLANG_PORT,
+        payload=warmup,
+        successful_requests=2,
+        request_timeout=120.0,
+        max_attempts_per_request=3,
+    )
     replica.sidecar = process.start_sidecar(
         sidecar_port=SIDECAR_PORT,
         sglang_port=SGLANG_PORT,
@@ -83,7 +90,9 @@ def serve_startup(
     # blocking here on /health (503 until the reconciler's first catch-up) is the only thing that keeps a
     # not-yet-synced replica out of rotation. Fresh boot (no pointer) clears at once; a mid-run joiner
     # waits until it has applied the live version, bounded by startup_timeout.
-    process.wait_http(f"http://127.0.0.1:{SIDECAR_PORT}/health", replica.sidecar, startup_timeout)
+    process.wait_http(
+        f"http://127.0.0.1:{SIDECAR_PORT}/health", replica.sidecar, startup_timeout
+    )
 
     def engine_health() -> str | None:
         # Weight staging can make the engine health endpoint briefly stale.
@@ -91,7 +100,11 @@ def serve_startup(
         error = replica.endpoint.health_check()
         if error is None:
             return None
-        return None if sync_in_progress(f"http://127.0.0.1:{SIDECAR_PORT}/server_info") else error
+        return (
+            None
+            if sync_in_progress(f"http://127.0.0.1:{SIDECAR_PORT}/server_info")
+            else error
+        )
 
     import modal.experimental
 

--- a/cookbook/common/sidecar.py
+++ b/cookbook/common/sidecar.py
@@ -43,7 +43,9 @@ def main() -> None:
     p.add_argument("--flush-cache-on-commit", action="store_true")
     p.add_argument("--run-id", default=None)
     p.add_argument("--debug-requests", action="store_true")
-    p.add_argument("--reconcile-interval", type=float, default=5.0)  # 0 disables the periodic re-check
+    p.add_argument(
+        "--reconcile-interval", type=float, default=5.0
+    )  # 0 disables the periodic re-check
     args = p.parse_args()
     if args.delta_update_mode == "disk" and not args.local_checkpoint_dir:
         p.error("--local-checkpoint-dir is required in disk mode")

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -48,8 +48,12 @@ from cookbook.miles_disagg.config import YAML_CONFIG_FIELDS, MilesConfig
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
 from stitch.pools.modal_flash import ModalFlashPool
 
-EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]  # required; a default would silently serve the wrong experiment
-MILES_LOCAL_DIR = os.environ.get("MILES_LOCAL_DIR")  # optional dev overlay of a local miles checkout
+EXPERIMENT = os.environ[
+    "EXPERIMENT_CONFIG"
+]  # required; a default would silently serve the wrong experiment
+MILES_LOCAL_DIR = os.environ.get(
+    "MILES_LOCAL_DIR"
+)  # optional dev overlay of a local miles checkout
 
 exp = importlib.import_module(f"cookbook.miles_disagg.configs.{EXPERIMENT}")
 modal_cfg = exp.modal
@@ -62,11 +66,18 @@ APP_NAME = f"{exp.APP_NAME}-{RUN_ID}"
 BULLETIN_ROOT = f"{exp.DELTA_BULLETIN_ROOT}/{RUN_ID}"
 
 # Flash autoscaler target / sglang concurrency cap: explicit target_inputs, else engine concurrency.
-ROLLOUT_CONCURRENCY = modal_cfg.rollout_target_inputs or miles_cfg.sglang_server_concurrency
+ROLLOUT_CONCURRENCY = (
+    modal_cfg.rollout_target_inputs or miles_cfg.sglang_server_concurrency
+)
 
 # EXPERIMENT_CONFIG + RUN are baked into both images so a container's re-import rebuilds the same
 # app name and transport paths as the deploy, not the defaults.
-image = trainer_image.build_trainer_image(hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, run_id=RUN_ID, miles_local=MILES_LOCAL_DIR)
+image = trainer_image.build_trainer_image(
+    hf_cache_path=str(HF_CACHE_PATH),
+    experiment=EXPERIMENT,
+    run_id=RUN_ID,
+    miles_local=MILES_LOCAL_DIR,
+)
 server_image = serving_image.build_serving_image(
     hf_cache_path=str(HF_CACHE_PATH),
     delta_volume_name=exp.DELTA_VOLUME_NAME,
@@ -76,14 +87,28 @@ server_image = serving_image.build_serving_image(
     runtime=getattr(exp, "SGLANG_RUNTIME", serving_image.DEFAULT_SGLANG_RUNTIME),
 )
 if MILES_LOCAL_DIR:
-    server_image = server_image.add_local_dir(MILES_LOCAL_DIR, remote_path=MILES_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])
+    server_image = server_image.add_local_dir(
+        MILES_LOCAL_DIR,
+        remote_path=MILES_ROOT,
+        ignore=[".git", "**/__pycache__", "**/*.pyc"],
+    )
 
-hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=True, version=2)
+hf_cache_volume = modal.Volume.from_name(
+    "huggingface-cache", create_if_missing=True, version=2
+)
 data_volume = modal.Volume.from_name("miles-data", create_if_missing=True, version=2)
-checkpoints_volume = modal.Volume.from_name("miles-checkpoints", create_if_missing=True, version=2)
-prep_volume = modal.Volume.from_name("miles-prep-checkpoints", create_if_missing=True, version=2)
-sglang_cache_volume = modal.Volume.from_name("sglang-cache", create_if_missing=True, version=2)  # survives cold starts
-delta_volume = modal.Volume.from_name(exp.DELTA_VOLUME_NAME, create_if_missing=True, version=2)
+checkpoints_volume = modal.Volume.from_name(
+    "miles-checkpoints", create_if_missing=True, version=2
+)
+prep_volume = modal.Volume.from_name(
+    "miles-prep-checkpoints", create_if_missing=True, version=2
+)
+sglang_cache_volume = modal.Volume.from_name(
+    "sglang-cache", create_if_missing=True, version=2
+)  # survives cold starts
+delta_volume = modal.Volume.from_name(
+    exp.DELTA_VOLUME_NAME, create_if_missing=True, version=2
+)
 draft_volume = (
     modal.Volume.from_name(
         modal_cfg.draft_volume,
@@ -118,7 +143,8 @@ SGLANG_SERVER_ARGS = {
 @app.cls(
     image=server_image,
     gpu=f"{modal_cfg.gpu}:{miles_cfg.rollout_num_gpus_per_engine}",
-    cloud=modal_cfg.cloud, region=modal_cfg.region,
+    cloud=modal_cfg.cloud,
+    region=modal_cfg.region,
     volumes={
         str(HF_CACHE_PATH): hf_cache_volume,
         str(PREP_PATH): prep_volume,
@@ -126,26 +152,35 @@ SGLANG_SERVER_ARGS = {
         exp.DELTA_BULLETIN_ROOT: delta_volume,
         **({str(DRAFT_PATH): draft_volume} if draft_volume is not None else {}),
     },
-    min_containers=modal_cfg.rollout_min_containers, max_containers=modal_cfg.rollout_max_containers,
-    timeout=40 * MINUTES, scaledown_window=15 * MINUTES,
-    ephemeral_disk=modal_cfg.rollout_ephemeral_disk_mib, memory=modal_cfg.rollout_memory_mib,
+    min_containers=modal_cfg.rollout_min_containers,
+    max_containers=modal_cfg.rollout_max_containers,
+    timeout=40 * MINUTES,
+    scaledown_window=15 * MINUTES,
+    ephemeral_disk=modal_cfg.rollout_ephemeral_disk_mib,
+    memory=modal_cfg.rollout_memory_mib,
     include_source=False,
 )
 @modal.experimental.http_server(
-    port=SIDECAR_PORT, proxy_regions=modal_cfg.proxy_regions,
-    exit_grace_period=25, startup_timeout=SERVER_STARTUP_TIMEOUT,
+    port=SIDECAR_PORT,
+    proxy_regions=modal_cfg.proxy_regions,
+    exit_grace_period=25,
+    startup_timeout=SERVER_STARTUP_TIMEOUT,
 )
 @modal.concurrent(target_inputs=ROLLOUT_CONCURRENCY)
 class Server:
     @modal.enter()
     def startup(self) -> None:
         server.serve_startup(
-            self, model_name=miles_cfg.hf_checkpoint, sglang_args=SGLANG_SERVER_ARGS,
-            tp=miles_cfg.rollout_num_gpus_per_engine, concurrency=ROLLOUT_CONCURRENCY,
+            self,
+            model_name=miles_cfg.hf_checkpoint,
+            sglang_args=SGLANG_SERVER_ARGS,
+            tp=miles_cfg.rollout_num_gpus_per_engine,
+            concurrency=ROLLOUT_CONCURRENCY,
             bulletin_root=BULLETIN_ROOT,
             local_checkpoint_dir=exp.LOCAL_CHECKPOINT_PATH,
             delta_update_mode=exp.SGLANG_DELTA_UPDATE_MODE,
-            volume_name=exp.DELTA_VOLUME_NAME, commit_mode=exp.SIDECAR_COMMIT_MODE,
+            volume_name=exp.DELTA_VOLUME_NAME,
+            commit_mode=exp.SIDECAR_COMMIT_MODE,
             flush_cache_on_commit=exp.SIDECAR_FLUSH_CACHE_ON_COMMIT,
             startup_timeout=SERVER_STARTUP_TIMEOUT,
         )
@@ -165,14 +200,21 @@ _MULTINODE = miles_cfg.n_train_nodes > 1
     image=image,
     gpu=f"{modal_cfg.gpu}:{miles_cfg.actor_num_gpus_per_node}",
     memory=modal_cfg.trainer_memory_mib,
-    cloud=modal_cfg.cloud, region=modal_cfg.region,
+    cloud=modal_cfg.cloud,
+    region=modal_cfg.region,
     volumes=train_volumes,
     ephemeral_disk=modal_cfg.trainer_ephemeral_disk_mib,
-    timeout=24 * 60 * MINUTES, startup_timeout=20 * MINUTES, scaledown_window=30 * MINUTES,
+    timeout=24 * 60 * MINUTES,
+    startup_timeout=20 * MINUTES,
+    scaledown_window=30 * MINUTES,
     include_source=False,
     **({"experimental_options": {"efa_enabled": True}} if _MULTINODE else {}),
 )
-@(modal.experimental.clustered(miles_cfg.n_train_nodes, rdma=True) if _MULTINODE else lambda c: c)
+@(
+    modal.experimental.clustered(miles_cfg.n_train_nodes, rdma=True)
+    if _MULTINODE
+    else lambda c: c
+)
 class Trainer:
     """miles actor cluster. Ray comes up once per container in enter(), so back-to-back
     runs reuse it."""
@@ -181,12 +223,22 @@ class Trainer:
     def start_ray(self) -> None:
         from cookbook.common import process
 
-        rank, master_addr, my_ip = ray_cluster.get_modal_cluster_context(miles_cfg.n_train_nodes)
-        process.apply_git_patches(list(getattr(exp, "MEGATRON_RUNTIME_PATCHES", [])), MEGATRON_PATH, "Megatron patch")
+        rank, master_addr, my_ip = ray_cluster.get_modal_cluster_context(
+            miles_cfg.n_train_nodes
+        )
+        process.apply_git_patches(
+            list(getattr(exp, "MEGATRON_RUNTIME_PATCHES", [])),
+            MEGATRON_PATH,
+            "Megatron patch",
+        )
         self.rank = rank
         process.start_host_mem_monitor()  # per-node host-RAM trace
         ray_cluster.start_ray_node(
-            rank, master_addr, my_ip, n_nodes=miles_cfg.n_train_nodes, ray_port=RAY_PORT,
+            rank,
+            master_addr,
+            my_ip,
+            n_nodes=miles_cfg.n_train_nodes,
+            ray_port=RAY_PORT,
             extra_env={
                 "MILES_HOST_IP": my_ip,
                 "PYTHONPATH": f"{MEGATRON_PATH}:{os.environ.get('PYTHONPATH', '')}",  # source-only megatron.training
@@ -227,9 +279,15 @@ class Trainer:
         # Claim the pool before miles publishes: reset every replica to base for this run.
         from cookbook.common import hooks
 
-        hooks.claim_pool(SimpleNamespace(update_weight_disk_dir=cfg.update_weight_disk_dir, **custom_config))
+        hooks.claim_pool(
+            SimpleNamespace(
+                update_weight_disk_dir=cfg.update_weight_disk_dir, **custom_config
+            )
+        )
 
-        print(f"Training {EXPERIMENT}: nodes={miles_cfg.n_train_nodes}, rollout_endpoint={cfg.rollout_endpoint_url}")
+        print(
+            f"Training {EXPERIMENT}: nodes={miles_cfg.n_train_nodes}, rollout_endpoint={cfg.rollout_endpoint_url}"
+        )
         print(f"Command: {cmd}")
         log_path = f"{CHECKPOINTS_PATH}/{run_id}/train.log"
         os.makedirs(os.path.dirname(log_path), exist_ok=True)

--- a/cookbook/miles_disagg/configs/glm45_air_bf16.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16.py
@@ -21,7 +21,9 @@ DISABLE_HF_TRANSFER = True
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 SGLANG_DELTA_UPDATE_MODE = "cpu"
-MEGATRON_RUNTIME_PATCHES = ["/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"]
+MEGATRON_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"
+]
 
 
 SGLANG_SERVER_ARGS = {
@@ -80,7 +82,9 @@ class _Miles(MilesConfig):
     rollout_endpoint_url = None
     use_miles_router = True
 
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     custom_config_path = {
         "rollout_request_weight_version_mode": "min",
         "rollout_request_weight_version_lag": 1,

--- a/cookbook/miles_disagg/configs/glm45_air_fp8.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8.py
@@ -27,7 +27,9 @@ USE_MODAL_TORCH_DIST_WRAPPER = True
 DISABLE_HF_XET = True
 DISABLE_HF_TRANSFER = True
 
-MEGATRON_RUNTIME_PATCHES = ["/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"]
+MEGATRON_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"
+]
 
 SGLANG_SERVER_ARGS = {
     # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
@@ -68,12 +70,14 @@ class _Miles(MilesConfig):
     actor_num_gpus_per_node = 8
     num_gpus_per_node = 8
     colocate = False
-    rollout_num_gpus = 0                 # external rollout: framework runs no local engines
+    rollout_num_gpus = 0  # external rollout: framework runs no local engines
     rollout_num_gpus_per_engine = 4
-    rollout_endpoint_url = None          # filled at launch from the pool gateway
+    rollout_endpoint_url = None  # filled at launch from the pool gateway
     use_miles_router = True
 
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
     custom_config_path = {
         "rollout_request_weight_version_mode": "min",
@@ -89,7 +93,9 @@ class _Miles(MilesConfig):
     update_weight_transfer_mode = "disk-delta"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT  # run-scoped at launch to <root>/<run_id>
+    update_weight_disk_dir = (
+        DELTA_BULLETIN_ROOT  # run-scoped at launch to <root>/<run_id>
+    )
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"
     input_key = "prompt"
@@ -170,7 +176,7 @@ modal = ModalConfig(
     gpu="H200",
     trainer_memory_mib=(1024, 2 * 1024 * 1024),
     rollout_min_containers=2,
-    rollout_max_containers=4,   # start at 2; scale to 4 mid-run to exercise elastic join
+    rollout_max_containers=4,  # start at 2; scale to 4 mid-run to exercise elastic join
     rollout_target_inputs=32,
     proxy_regions=["us-west"],
     rollout_ephemeral_disk_mib=524_288,

--- a/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
@@ -74,7 +74,9 @@ class _Miles(MilesConfig):
     rollout_endpoint_url = None
     use_miles_router = True
 
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     custom_config_path = {
         "rollout_request_weight_version_mode": "min",
         "rollout_request_weight_version_lag": 1,
@@ -96,7 +98,10 @@ class _Miles(MilesConfig):
                 "transformer_engine_config_type": "TEQuantizationParams",
                 "training_recipe": {"fp4_quantization_recipe": "nvfp4"},
             },
-            "bf16": {"transformer_engine_config_type": "TEQuantizationParams", "training_recipe": {}},
+            "bf16": {
+                "transformer_engine_config_type": "TEQuantizationParams",
+                "training_recipe": {},
+            },
         },
         "matchers": {
             "routed_experts_fc1_nvfp4": {
@@ -111,7 +116,12 @@ class _Miles(MilesConfig):
                 "pattern": "*.mlp.experts.linear_fc2",
                 "config": "nvfp4",
             },
-            "default_bf16": {"type": "glob", "enabled": True, "pattern": "*", "config": "bf16"},
+            "default_bf16": {
+                "type": "glob",
+                "enabled": True,
+                "pattern": "*",
+                "config": "bf16",
+            },
         },
     }
     # 2 layers: layer 0 is dense (FIRST_K_DENSE_REPLACE=1) -> bf16; layer 1 is MoE

--- a/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
@@ -77,7 +77,9 @@ class _Miles(MilesConfig):
     ref_load = f"{PREP_PATH}/{MODEL_TAG}/torch_dist"
     # "raw": K2.6's HF arch is a VLM wrapper AutoBridge can't build; export routes via model_name.
     megatron_to_hf_mode = "raw"
-    model_name = "kimi_k25"  # megatron_to_hf export dispatch (convert_kimi_k25_to_hf + NVFP4)
+    model_name = (
+        "kimi_k25"  # megatron_to_hf export dispatch (convert_kimi_k25_to_hf + NVFP4)
+    )
 
     actor_num_nodes = 16  # 16x8 B200 = 128 GPUs; TP8*PP8*CP2=128 (DP=1) — debug the actor_train backward deadlock cheaper (same PP8 path as 32 nodes; both hang identically)
     actor_num_gpus_per_node = 8
@@ -109,7 +111,9 @@ class _Miles(MilesConfig):
     # NVFP4 QAT — miles' canonical NVFP4 RL recipe.
     fp4_format = "e2m1"
     fp4_recipe = "nvfp4"
-    fp4_param_gather = False  # True crashes Megatron DDP's param-buffer repoint (TE NVFP4Tensor)
+    fp4_param_gather = (
+        False  # True crashes Megatron DDP's param-buffer repoint (TE NVFP4Tensor)
+    )
     # NVFP4 only on the routed expert GEMMs, everything else bf16 — matches the served base.
     te_precision_config_file = {
         "configs": {

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4.py
@@ -66,16 +66,22 @@ class _Miles(MilesConfig):
     model_name = "deepseekv3"  # bridge dispatch: Moonlight is DeepSeek-V3 arch
 
     actor_num_nodes = 1
-    actor_num_gpus_per_node = 4  # 1 node x 4 B200 trainer (matches the proven moonlight recipe)
+    actor_num_gpus_per_node = (
+        4  # 1 node x 4 B200 trainer (matches the proven moonlight recipe)
+    )
     num_gpus_per_node = 4
     colocate = False  # disk-delta is incompatible with --colocate
     rollout_num_gpus = 0  # publish-only forces this
-    rollout_num_gpus_per_engine = 1  # B200:1 per rollout container (Moonlight NVFP4 is tiny)
+    rollout_num_gpus_per_engine = (
+        1  # B200:1 per rollout container (Moonlight NVFP4 is tiny)
+    )
     rollout_endpoint_url = None
     use_miles_router = True
 
     # Staleness gate; the knobs ride in custom_config_path (read by the hook, not miles core).
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     custom_config_path = {
         "rollout_request_weight_version_mode": "min",
         "rollout_request_weight_version_lag": 1,
@@ -107,7 +113,9 @@ class _Miles(MilesConfig):
     eval_interval = None
 
     num_rollout = 20
-    save_interval = 1000  # megatron requires it; > num_rollout so the smoke skips megatron saves
+    save_interval = (
+        1000  # megatron requires it; > num_rollout so the smoke skips megatron saves
+    )
     rollout_batch_size = 32
     rollout_max_response_len = 4096  # fits within the 8192 context (prompt + response)
     rollout_temperature = 0.8

--- a/cookbook/miles_disagg/prep.py
+++ b/cookbook/miles_disagg/prep.py
@@ -45,7 +45,11 @@ def prepare_checkpoints(exp, prep_volume) -> None:
 
     prep_volume.reload()
     tag = exp.MODEL_TAG
-    bf16_dir, fp8_dir, nvfp4_dir = f"{PREP_PATH}/{tag}/bf16", f"{PREP_PATH}/{tag}/fp8", f"{PREP_PATH}/{tag}/nvfp4"
+    bf16_dir, fp8_dir, nvfp4_dir = (
+        f"{PREP_PATH}/{tag}/bf16",
+        f"{PREP_PATH}/{tag}/fp8",
+        f"{PREP_PATH}/{tag}/nvfp4",
+    )
     served_format = getattr(exp, "SERVED_CHECKPOINT_FORMAT", "nvfp4")
     if served_format not in {"bf16", "fp8", "nvfp4"}:
         raise SystemExit(f"unsupported SERVED_CHECKPOINT_FORMAT={served_format!r}")
@@ -57,7 +61,17 @@ def prepare_checkpoints(exp, prep_volume) -> None:
     def _build_bf16(out: str) -> None:
         if is_int4:
             print("dequantizing INT4 source -> bf16 masters (GPU)...", flush=True)
-            subprocess.run(["python", f"{tools}/convert_kimi_int4_to_bf16.py", "--model-dir", src, "--output-dir", out], check=True)
+            subprocess.run(
+                [
+                    "python",
+                    f"{tools}/convert_kimi_int4_to_bf16.py",
+                    "--model-dir",
+                    src,
+                    "--output-dir",
+                    out,
+                ],
+                check=True,
+            )
         else:
             _copy_tree("bf16 masters", src, out)
         _strip_stale_quant_config(os.path.join(out, "config.json"))
@@ -97,9 +111,24 @@ def prepare_checkpoints(exp, prep_volume) -> None:
         carveouts += ["--num-layers-at-start-in-bf16", str(n)]
     if (n := getattr(exp.miles, "num_layers_at_end_in_bf16", None)) is not None:
         carveouts += ["--num-layers-at-end-in-bf16", str(n)]
+
     def _build_nvfp4(out: str) -> None:
-        print("building nvfp4 served base from bf16 masters (GPU conversion)...", flush=True)
-        subprocess.run(["python", f"{tools}/convert_hf_to_nvfp4.py", "--model-dir", bf16_dir, "--save-dir", out, *carveouts], check=True)
+        print(
+            "building nvfp4 served base from bf16 masters (GPU conversion)...",
+            flush=True,
+        )
+        subprocess.run(
+            [
+                "python",
+                f"{tools}/convert_hf_to_nvfp4.py",
+                "--model-dir",
+                bf16_dir,
+                "--save-dir",
+                out,
+                *carveouts,
+            ],
+            check=True,
+        )
 
     _staged(nvfp4_dir, _build_nvfp4)
     prep_volume.commit()
@@ -111,15 +140,24 @@ def prepare_torch_dist(exp, prep_volume, *, rank: int, master_addr: str) -> None
     clustered torchrun conversion (large MoE won't fit an 8-way split)."""
     prep_volume.reload()
     tag = exp.MODEL_TAG
-    bf16_dir, torch_dist_dir = f"{PREP_PATH}/{tag}/bf16", f"{PREP_PATH}/{tag}/torch_dist"
-    if os.path.exists(os.path.join(torch_dist_dir, "latest_checkpointed_iteration.txt")):
+    bf16_dir, torch_dist_dir = (
+        f"{PREP_PATH}/{tag}/bf16",
+        f"{PREP_PATH}/{tag}/torch_dist",
+    )
+    if os.path.exists(
+        os.path.join(torch_dist_dir, "latest_checkpointed_iteration.txt")
+    ):
         print(f"reusing existing torch_dist {torch_dist_dir}")
         return
     if not exp.miles.miles_model_script:
         raise SystemExit("prepare_torch_dist requires miles_model_script (MODEL_ARGS)")
     nodes = exp.modal.torch_dist_prep_nodes
     use_wrapper = nodes > 1 and getattr(exp, "USE_MODAL_TORCH_DIST_WRAPPER", False)
-    convert = TORCH_DIST_CONVERT_WRAPPER if use_wrapper else f"{MILES_ROOT}/tools/convert_hf_to_torch_dist.py"
+    convert = (
+        TORCH_DIST_CONVERT_WRAPPER
+        if use_wrapper
+        else f"{MILES_ROOT}/tools/convert_hf_to_torch_dist.py"
+    )
     inner = (
         f"source {MILES_ROOT}/{exp.miles.miles_model_script} && "
         f"PYTHONPATH={MEGATRON_PATH} torchrun"
@@ -132,7 +170,10 @@ def prepare_torch_dist(exp, prep_volume, *, rank: int, master_addr: str) -> None
     env = {**os.environ}
     if use_wrapper:
         env["SKIP_RELEASE_RENAME"] = "1"
-    print(f"converting bf16 masters -> torch_dist ref_load ({nodes}-node torchrun, rank {rank})...", flush=True)
+    print(
+        f"converting bf16 masters -> torch_dist ref_load ({nodes}-node torchrun, rank {rank})...",
+        flush=True,
+    )
     subprocess.run(["bash", "-c", inner], check=True, env=env)
     # Every node commits its own distcp shards (disjoint files merge on the Volume);
     # a rank-0-only commit would drop the other nodes' shards.
@@ -145,13 +186,17 @@ def prepare_torch_dist(exp, prep_volume, *, rank: int, master_addr: str) -> None
 # sglang base-seed's profiled knee). 16 MiB reads run at full mount speed while bounding memory.
 _COPY_WORKERS = int(os.environ.get("PREP_COPY_WORKERS", "8"))
 _COPY_CHUNK = 16 << 20
-_COPY_LOG_STEP_GB = 50  # one progress line per this many GB, so a multi-TB copy isn't a silent stall
+_COPY_LOG_STEP_GB = (
+    50  # one progress line per this many GB, so a multi-TB copy isn't a silent stall
+)
 
 
 def _copy_tree(label: str, src: str, dst: str) -> None:
     """Copy a checkpoint dir, dereferencing the HF cache's blob symlinks into real files (the old
     ``cp -aL``), but across a thread pool for the ~5x and with throttled GB/GB + rate progress."""
-    src_files = [p for p in Path(src).rglob("*") if p.is_file()]  # is_file() follows symlinks
+    src_files = [
+        p for p in Path(src).rglob("*") if p.is_file()
+    ]  # is_file() follows symlinks
     total_gb = sum(p.stat().st_size for p in src_files) / 1e9
     progress = {"done_gb": 0.0, "next_log_gb": _COPY_LOG_STEP_GB}
     lock = threading.Lock()
@@ -160,7 +205,10 @@ def _copy_tree(label: str, src: str, dst: str) -> None:
     def copy_one(p: Path) -> None:
         out = Path(dst) / p.relative_to(src)
         out.parent.mkdir(parents=True, exist_ok=True)
-        with open(p, "rb") as fsrc, open(out, "wb") as fdst:  # open() follows the symlink to the real blob
+        with (
+            open(p, "rb") as fsrc,
+            open(out, "wb") as fdst,
+        ):  # open() follows the symlink to the real blob
             while chunk := fsrc.read(_COPY_CHUNK):
                 fdst.write(chunk)
         with lock:
@@ -168,11 +216,16 @@ def _copy_tree(label: str, src: str, dst: str) -> None:
             done = progress["done_gb"]
             if done >= progress["next_log_gb"] or done >= total_gb:
                 rate = done / max(time.monotonic() - start, 1e-3)
-                print(f"copying {label}: {done:.0f}/{total_gb:.0f} GB ({100 * done / max(total_gb, 1e-9):.0f}%), {rate:.1f} GB/s", flush=True)
+                print(
+                    f"copying {label}: {done:.0f}/{total_gb:.0f} GB ({100 * done / max(total_gb, 1e-9):.0f}%), {rate:.1f} GB/s",
+                    flush=True,
+                )
                 progress["next_log_gb"] += _COPY_LOG_STEP_GB
 
     os.makedirs(dst, exist_ok=True)
-    with ThreadPoolExecutor(max_workers=min(_COPY_WORKERS, len(src_files) or 1)) as pool:
+    with ThreadPoolExecutor(
+        max_workers=min(_COPY_WORKERS, len(src_files) or 1)
+    ) as pool:
         list(pool.map(copy_one, src_files))
     print(f"copied {label}: {total_gb:.0f} GB", flush=True)
 
@@ -214,5 +267,9 @@ def _is_int4(model_dir: str) -> bool:
     with open(cfg_path) as f:
         cfg = json.load(f) or {}
     # VLMs (Kimi K2.x) nest the quant config under text_config.
-    qc = (cfg.get("text_config") or {}).get("quantization_config") or cfg.get("quantization_config") or {}
+    qc = (
+        (cfg.get("text_config") or {}).get("quantization_config")
+        or cfg.get("quantization_config")
+        or {}
+    )
     return qc.get("quant_method") == "compressed-tensors"

--- a/cookbook/miles_disagg/prep_app.py
+++ b/cookbook/miles_disagg/prep_app.py
@@ -23,32 +23,43 @@ from cookbook.common import ray_cluster
 from cookbook.common.constants import DATA_PATH, HF_CACHE_PATH, MINUTES, PREP_PATH
 from cookbook.miles_disagg import prep, trainer_image
 
-EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]  # required; a default would silently prep the wrong experiment
-MILES_LOCAL_DIR = os.environ.get("MILES_LOCAL_DIR")  # optional dev overlay of a local miles checkout
+EXPERIMENT = os.environ[
+    "EXPERIMENT_CONFIG"
+]  # required; a default would silently prep the wrong experiment
+MILES_LOCAL_DIR = os.environ.get(
+    "MILES_LOCAL_DIR"
+)  # optional dev overlay of a local miles checkout
 
 exp = importlib.import_module(f"cookbook.miles_disagg.configs.{EXPERIMENT}")
 modal_cfg = exp.modal
 miles_cfg = exp.miles
 
-image = trainer_image.build_trainer_image(hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, miles_local=MILES_LOCAL_DIR)
+image = trainer_image.build_trainer_image(
+    hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, miles_local=MILES_LOCAL_DIR
+)
 
-hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=True, version=2)
+hf_cache_volume = modal.Volume.from_name(
+    "huggingface-cache", create_if_missing=True, version=2
+)
 data_volume = modal.Volume.from_name("miles-data", create_if_missing=True, version=2)
-prep_volume = modal.Volume.from_name("miles-prep-checkpoints", create_if_missing=True, version=2)
+prep_volume = modal.Volume.from_name(
+    "miles-prep-checkpoints", create_if_missing=True, version=2
+)
 
 app = modal.App(f"{exp.APP_NAME}-prep")
 checkpoint_gpu = (
-    f"{modal_cfg.gpu}:1"
-    if getattr(exp, "CHECKPOINT_PREP_REQUIRES_GPU", True)
-    else None
+    f"{modal_cfg.gpu}:1" if getattr(exp, "CHECKPOINT_PREP_REQUIRES_GPU", True) else None
 )
 
 
 @app.function(
-    image=image, gpu=checkpoint_gpu,
+    image=image,
+    gpu=checkpoint_gpu,
     volumes={str(HF_CACHE_PATH): hf_cache_volume, str(PREP_PATH): prep_volume},
     memory=modal_cfg.trainer_memory_mib,
-    timeout=6 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+    timeout=6 * 60 * MINUTES,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
 )
 def prepare_checkpoints() -> None:
     prep.prepare_checkpoints(exp, prep_volume)
@@ -59,22 +70,38 @@ _TORCH_DIST_MULTINODE = modal_cfg.torch_dist_prep_nodes > 1
 
 
 @app.function(
-    image=image, gpu=f"{modal_cfg.gpu}:{modal_cfg.torch_dist_prep_gpus_per_node}",
+    image=image,
+    gpu=f"{modal_cfg.gpu}:{modal_cfg.torch_dist_prep_gpus_per_node}",
     volumes={str(HF_CACHE_PATH): hf_cache_volume, str(PREP_PATH): prep_volume},
     timeout=6 * 60 * MINUTES,
-    ephemeral_disk=(modal_cfg.torch_dist_prep_ephemeral_disk_mib or modal_cfg.rollout_ephemeral_disk_mib),
-    secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
-    **({"experimental_options": {"efa_enabled": True}} if _TORCH_DIST_MULTINODE else {}),
+    ephemeral_disk=(
+        modal_cfg.torch_dist_prep_ephemeral_disk_mib
+        or modal_cfg.rollout_ephemeral_disk_mib
+    ),
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
+    **(
+        {"experimental_options": {"efa_enabled": True}} if _TORCH_DIST_MULTINODE else {}
+    ),
 )
-@(modal.experimental.clustered(modal_cfg.torch_dist_prep_nodes, rdma=True) if _TORCH_DIST_MULTINODE else lambda fn: fn)
+@(
+    modal.experimental.clustered(modal_cfg.torch_dist_prep_nodes, rdma=True)
+    if _TORCH_DIST_MULTINODE
+    else lambda fn: fn
+)
 def prepare_torch_dist() -> None:
-    rank, master_addr, _ = ray_cluster.get_modal_cluster_context(modal_cfg.torch_dist_prep_nodes)
+    rank, master_addr, _ = ray_cluster.get_modal_cluster_context(
+        modal_cfg.torch_dist_prep_nodes
+    )
     prep.prepare_torch_dist(exp, prep_volume, rank=rank, master_addr=master_addr)
 
 
 @app.function(
-    image=image, volumes={str(DATA_PATH): data_volume},
-    timeout=2 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+    image=image,
+    volumes={str(DATA_PATH): data_volume},
+    timeout=2 * 60 * MINUTES,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
 )
 def prepare_dataset() -> None:
     data_volume.reload()

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -47,8 +47,12 @@ from cookbook.slime_disagg.config import YAML_CONFIG_FIELDS, SlimeConfig
 from cookbook.slime_disagg.trainer_image import SLIME_ROOT
 from stitch.pools.modal_flash import ModalFlashPool
 
-EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]  # required; a default would silently serve the wrong experiment
-SLIME_LOCAL_DIR = os.environ.get("SLIME_LOCAL_DIR")  # optional dev overlay of a local slime checkout
+EXPERIMENT = os.environ[
+    "EXPERIMENT_CONFIG"
+]  # required; a default would silently serve the wrong experiment
+SLIME_LOCAL_DIR = os.environ.get(
+    "SLIME_LOCAL_DIR"
+)  # optional dev overlay of a local slime checkout
 
 exp = importlib.import_module(f"cookbook.slime_disagg.configs.{EXPERIMENT}")
 modal_cfg = exp.modal
@@ -61,11 +65,18 @@ APP_NAME = f"{exp.APP_NAME}-{RUN_ID}"
 BULLETIN_ROOT = f"{exp.DELTA_BULLETIN_ROOT}/{RUN_ID}"
 
 # Flash autoscaler target / sglang concurrency cap: explicit target_inputs, else engine concurrency.
-ROLLOUT_CONCURRENCY = modal_cfg.rollout_target_inputs or slime_cfg.sglang_server_concurrency
+ROLLOUT_CONCURRENCY = (
+    modal_cfg.rollout_target_inputs or slime_cfg.sglang_server_concurrency
+)
 
 # EXPERIMENT_CONFIG + RUN_ID are baked into both images so a container's re-import rebuilds the same
 # app name and transport paths as the deploy, not the defaults.
-image = trainer_image.build_trainer_image(hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, run_id=RUN_ID, slime_local=SLIME_LOCAL_DIR)
+image = trainer_image.build_trainer_image(
+    hf_cache_path=str(HF_CACHE_PATH),
+    experiment=EXPERIMENT,
+    run_id=RUN_ID,
+    slime_local=SLIME_LOCAL_DIR,
+)
 server_image = serving_image.build_serving_image(
     hf_cache_path=str(HF_CACHE_PATH),
     delta_volume_name=exp.DELTA_VOLUME_NAME,
@@ -74,13 +85,25 @@ server_image = serving_image.build_serving_image(
     runtime=getattr(exp, "SGLANG_RUNTIME", serving_image.DEFAULT_SGLANG_RUNTIME),
 )
 if SLIME_LOCAL_DIR:
-    server_image = server_image.add_local_dir(SLIME_LOCAL_DIR, remote_path=SLIME_ROOT, ignore=[".git", "**/__pycache__", "**/*.pyc"])
+    server_image = server_image.add_local_dir(
+        SLIME_LOCAL_DIR,
+        remote_path=SLIME_ROOT,
+        ignore=[".git", "**/__pycache__", "**/*.pyc"],
+    )
 
-hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=True, version=2)
+hf_cache_volume = modal.Volume.from_name(
+    "huggingface-cache", create_if_missing=True, version=2
+)
 data_volume = modal.Volume.from_name("slime-data", create_if_missing=True, version=2)
-checkpoints_volume = modal.Volume.from_name("slime-checkpoints", create_if_missing=True, version=2)
-sglang_cache_volume = modal.Volume.from_name("sglang-cache", create_if_missing=True, version=2)
-delta_volume = modal.Volume.from_name(exp.DELTA_VOLUME_NAME, create_if_missing=True, version=2)
+checkpoints_volume = modal.Volume.from_name(
+    "slime-checkpoints", create_if_missing=True, version=2
+)
+sglang_cache_volume = modal.Volume.from_name(
+    "sglang-cache", create_if_missing=True, version=2
+)
+delta_volume = modal.Volume.from_name(
+    exp.DELTA_VOLUME_NAME, create_if_missing=True, version=2
+)
 draft_volume = (
     modal.Volume.from_name(
         modal_cfg.draft_volume,
@@ -115,33 +138,43 @@ SGLANG_SERVER_ARGS = {
 @app.cls(
     image=server_image,
     gpu=f"{modal_cfg.gpu}:{slime_cfg.rollout_num_gpus_per_engine}",
-    cloud=modal_cfg.cloud, region=modal_cfg.region,
+    cloud=modal_cfg.cloud,
+    region=modal_cfg.region,
     volumes={
         str(HF_CACHE_PATH): hf_cache_volume,
         SGLANG_CACHE_PATH: sglang_cache_volume,
         exp.DELTA_BULLETIN_ROOT: delta_volume,
         **({str(DRAFT_PATH): draft_volume} if draft_volume is not None else {}),
     },
-    min_containers=modal_cfg.rollout_min_containers, max_containers=modal_cfg.rollout_max_containers,
-    timeout=40 * MINUTES, scaledown_window=15 * MINUTES,
-    ephemeral_disk=modal_cfg.rollout_ephemeral_disk_mib, memory=modal_cfg.rollout_memory_mib,
+    min_containers=modal_cfg.rollout_min_containers,
+    max_containers=modal_cfg.rollout_max_containers,
+    timeout=40 * MINUTES,
+    scaledown_window=15 * MINUTES,
+    ephemeral_disk=modal_cfg.rollout_ephemeral_disk_mib,
+    memory=modal_cfg.rollout_memory_mib,
     include_source=False,
 )
 @modal.experimental.http_server(
-    port=SIDECAR_PORT, proxy_regions=modal_cfg.proxy_regions,
-    exit_grace_period=25, startup_timeout=SERVER_STARTUP_TIMEOUT,
+    port=SIDECAR_PORT,
+    proxy_regions=modal_cfg.proxy_regions,
+    exit_grace_period=25,
+    startup_timeout=SERVER_STARTUP_TIMEOUT,
 )
 @modal.concurrent(target_inputs=ROLLOUT_CONCURRENCY)
 class Server:
     @modal.enter()
     def startup(self) -> None:
         server.serve_startup(
-            self, model_name=slime_cfg.hf_checkpoint, sglang_args=SGLANG_SERVER_ARGS,
-            tp=slime_cfg.rollout_num_gpus_per_engine, concurrency=ROLLOUT_CONCURRENCY,
+            self,
+            model_name=slime_cfg.hf_checkpoint,
+            sglang_args=SGLANG_SERVER_ARGS,
+            tp=slime_cfg.rollout_num_gpus_per_engine,
+            concurrency=ROLLOUT_CONCURRENCY,
             bulletin_root=BULLETIN_ROOT,
             local_checkpoint_dir=exp.LOCAL_CHECKPOINT_PATH,
             delta_update_mode=exp.SGLANG_DELTA_UPDATE_MODE,
-            volume_name=exp.DELTA_VOLUME_NAME, commit_mode=exp.SIDECAR_COMMIT_MODE,
+            volume_name=exp.DELTA_VOLUME_NAME,
+            commit_mode=exp.SIDECAR_COMMIT_MODE,
             flush_cache_on_commit=exp.SIDECAR_FLUSH_CACHE_ON_COMMIT,
             startup_timeout=SERVER_STARTUP_TIMEOUT,
         )
@@ -161,14 +194,21 @@ _MULTINODE = slime_cfg.n_train_nodes > 1
     image=image,
     gpu=f"{modal_cfg.gpu}:{slime_cfg.actor_num_gpus_per_node}",
     memory=modal_cfg.trainer_memory_mib,
-    cloud=modal_cfg.cloud, region=modal_cfg.region,
+    cloud=modal_cfg.cloud,
+    region=modal_cfg.region,
     volumes=train_volumes,
     ephemeral_disk=modal_cfg.trainer_ephemeral_disk_mib,
-    timeout=24 * 60 * MINUTES, startup_timeout=20 * MINUTES, scaledown_window=30 * MINUTES,
+    timeout=24 * 60 * MINUTES,
+    startup_timeout=20 * MINUTES,
+    scaledown_window=30 * MINUTES,
     include_source=False,
     **({"experimental_options": {"efa_enabled": True}} if _MULTINODE else {}),
 )
-@(modal.experimental.clustered(slime_cfg.n_train_nodes, rdma=True) if _MULTINODE else lambda c: c)
+@(
+    modal.experimental.clustered(slime_cfg.n_train_nodes, rdma=True)
+    if _MULTINODE
+    else lambda c: c
+)
 class Trainer:
     """slime actor cluster. Ray comes up once per container in enter(), so back-to-back
     runs reuse it."""
@@ -177,11 +217,17 @@ class Trainer:
     def start_ray(self) -> None:
         from cookbook.common import process
 
-        rank, master_addr, my_ip = ray_cluster.get_modal_cluster_context(slime_cfg.n_train_nodes)
+        rank, master_addr, my_ip = ray_cluster.get_modal_cluster_context(
+            slime_cfg.n_train_nodes
+        )
         self.rank = rank
         process.start_host_mem_monitor()  # per-node host-RAM trace
         ray_cluster.start_ray_node(
-            rank, master_addr, my_ip, n_nodes=slime_cfg.n_train_nodes, ray_port=RAY_PORT,
+            rank,
+            master_addr,
+            my_ip,
+            n_nodes=slime_cfg.n_train_nodes,
+            ray_port=RAY_PORT,
             extra_env={"SLIME_HOST_IP": my_ip, **slime_cfg.environment},
         )
 
@@ -203,16 +249,24 @@ class Trainer:
             "rollout_modal_flash_server_cls_name": "Server",
             "run_id": run_id,
         }
-        cfg.custom_config_path = hook_knobs  # materialized to a YAML path below; keep the mapping for claim
+        cfg.custom_config_path = (
+            hook_knobs  # materialized to a YAML path below; keep the mapping for claim
+        )
         launch.resolve_config(cfg, tempfile.mkdtemp(), YAML_CONFIG_FIELDS)
         cmd = launch.build_train_cmd(cfg, SLIME_ROOT, "slime_model_script")
 
         # Claim the pool before slime publishes: reset every replica to base for this run.
         from cookbook.common import hooks
 
-        hooks.claim_pool(SimpleNamespace(update_weight_disk_dir=cfg.update_weight_disk_dir, **hook_knobs))
+        hooks.claim_pool(
+            SimpleNamespace(
+                update_weight_disk_dir=cfg.update_weight_disk_dir, **hook_knobs
+            )
+        )
 
-        print(f"Training {EXPERIMENT}: nodes={slime_cfg.n_train_nodes}, rollout_endpoint={cfg.rollout_endpoint_url}")
+        print(
+            f"Training {EXPERIMENT}: nodes={slime_cfg.n_train_nodes}, rollout_endpoint={cfg.rollout_endpoint_url}"
+        )
         print(f"Command: {cmd}")
         subprocess.run(["bash", "-lc", cmd], check=True)
 

--- a/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
+++ b/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
@@ -71,12 +71,14 @@ class _Slime(SlimeConfig):
     actor_num_nodes = 32  # 32x8 = 256 GPUs
     actor_num_gpus_per_node = 8
     colocate = False
-    rollout_num_gpus = 0                 # external rollout: the framework runs no local engines
-    rollout_num_gpus_per_engine = 4      # B200:4 per rollout container (native INT4 fits)
-    rollout_endpoint_url = None          # filled at launch from the pool gateway
+    rollout_num_gpus = 0  # external rollout: the framework runs no local engines
+    rollout_num_gpus_per_engine = 4  # B200:4 per rollout container (native INT4 fits)
+    rollout_endpoint_url = None  # filled at launch from the pool gateway
 
     # The three plug points stitch fills (slime's publish hook key is custom_delta_pre_push_path):
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     custom_delta_pre_push_path = "cookbook.common.hooks.commit_and_wake"
     rollout_request_weight_version_mode = "min"
     rollout_request_weight_version_lag = 1
@@ -90,7 +92,9 @@ class _Slime(SlimeConfig):
     update_weight_transport = "disk"
     update_weight_delta_encoding = "xor"
     update_weight_delta_checksum = "xxh3-128"
-    update_weight_disk_dir = DELTA_BULLETIN_ROOT  # run-scoped at launch to <root>/<run_id>
+    update_weight_disk_dir = (
+        DELTA_BULLETIN_ROOT  # run-scoped at launch to <root>/<run_id>
+    )
 
     prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"
     input_key = "prompt"
@@ -108,7 +112,9 @@ class _Slime(SlimeConfig):
     rollout_top_p = 1.0
     n_samples_per_prompt = 8
     over_sampling_batch_size = 256
-    dynamic_sampling_filter_path = "slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std"
+    dynamic_sampling_filter_path = (
+        "slime.rollout.filter_hub.dynamic_sampling_filters.check_reward_nonzero_std"
+    )
     num_steps_per_rollout = 4
     balance_data = True
     sglang_server_concurrency = 256

--- a/cookbook/slime_disagg/configs/moonlight.py
+++ b/cookbook/slime_disagg/configs/moonlight.py
@@ -55,7 +55,9 @@ class _Slime(SlimeConfig):
     rollout_num_gpus_per_engine = 1  # 1xH200 per rollout container (MLA -> cheap KV)
     rollout_endpoint_url = None
     # Staleness gate: pin each request to latest_published - lag; over-stale replicas 409 -> retry.
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     rollout_request_weight_version_mode = "min"
     rollout_request_weight_version_lag = 1
     rollout_request_retry_attempts = 240

--- a/cookbook/slime_disagg/configs/moonlight_int4.py
+++ b/cookbook/slime_disagg/configs/moonlight_int4.py
@@ -57,7 +57,9 @@ class _Slime(SlimeConfig):
     rollout_num_gpus = 0
     rollout_num_gpus_per_engine = 1  # 1xH200 per rollout container (16B INT4 fits)
     rollout_endpoint_url = None
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     rollout_request_weight_version_mode = "min"
     rollout_request_weight_version_lag = 1
     rollout_request_retry_attempts = 240

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
@@ -46,8 +46,12 @@ class _Slime(SlimeConfig):
     colocate = False
     rollout_num_gpus = 0
     rollout_num_gpus_per_engine = 1
-    rollout_endpoint_url = None  # publish-only: slime routes /generate to the Flash gateway
-    custom_rollout_request_hook_path = "cookbook.common.hooks.gated_rollout_request_hook"
+    rollout_endpoint_url = (
+        None  # publish-only: slime routes /generate to the Flash gateway
+    )
+    custom_rollout_request_hook_path = (
+        "cookbook.common.hooks.gated_rollout_request_hook"
+    )
     rollout_request_weight_version_mode = "exact"
     rollout_request_weight_version_lag = 0
     rollout_request_retry_attempts = 240

--- a/cookbook/slime_disagg/prep_app.py
+++ b/cookbook/slime_disagg/prep_app.py
@@ -20,23 +20,34 @@ import modal
 from cookbook.common.constants import DATA_PATH, HF_CACHE_PATH, MINUTES
 from cookbook.slime_disagg import trainer_image
 
-EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]  # required; a default would silently prep the wrong experiment
-SLIME_LOCAL_DIR = os.environ.get("SLIME_LOCAL_DIR")  # optional dev overlay of a local slime checkout
+EXPERIMENT = os.environ[
+    "EXPERIMENT_CONFIG"
+]  # required; a default would silently prep the wrong experiment
+SLIME_LOCAL_DIR = os.environ.get(
+    "SLIME_LOCAL_DIR"
+)  # optional dev overlay of a local slime checkout
 
 exp = importlib.import_module(f"cookbook.slime_disagg.configs.{EXPERIMENT}")
 slime_cfg = exp.slime
 
-image = trainer_image.build_trainer_image(hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, slime_local=SLIME_LOCAL_DIR)
+image = trainer_image.build_trainer_image(
+    hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, slime_local=SLIME_LOCAL_DIR
+)
 
-hf_cache_volume = modal.Volume.from_name("huggingface-cache", create_if_missing=True, version=2)
+hf_cache_volume = modal.Volume.from_name(
+    "huggingface-cache", create_if_missing=True, version=2
+)
 data_volume = modal.Volume.from_name("slime-data", create_if_missing=True, version=2)
 
 app = modal.App(f"{exp.APP_NAME}-prep")
 
 
 @app.function(
-    image=image, volumes={str(HF_CACHE_PATH): hf_cache_volume},
-    timeout=2 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+    image=image,
+    volumes={str(HF_CACHE_PATH): hf_cache_volume},
+    timeout=2 * 60 * MINUTES,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
 )
 def download_model() -> None:
     """Snapshot the served model into the HF cache (sglang serves it by repo id)."""
@@ -47,8 +58,11 @@ def download_model() -> None:
 
 
 @app.function(
-    image=image, volumes={str(DATA_PATH): data_volume},
-    timeout=2 * 60 * MINUTES, secrets=[modal.Secret.from_name("huggingface-secret")], include_source=False,
+    image=image,
+    volumes={str(DATA_PATH): data_volume},
+    timeout=2 * 60 * MINUTES,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
 )
 def prepare_dataset() -> None:
     data_volume.reload()

--- a/src/stitch/stores/modal_volume.py
+++ b/src/stitch/stores/modal_volume.py
@@ -44,7 +44,9 @@ class ModalVolumeStore(Store):
 
     def claim(self, run_id: str) -> None:
         if not run_id:
-            raise ValueError("claim requires a run_id (the run's per-launch epoch token)")
+            raise ValueError(
+                "claim requires a run_id (the run's per-launch epoch token)"
+            )
         self.advance_pointer(VersionRef(run_id, 0))
 
     def read_manifest(self, ref: VersionRef) -> VersionManifest:

--- a/src/stitch/stores/modal_volume_test.py
+++ b/src/stitch/stores/modal_volume_test.py
@@ -15,12 +15,21 @@ from stitch.stores.modal_volume import ModalVolumeStore
 from stitch.types import VersionKind, VersionRef
 
 
-def _write_version(root: Path, ref: VersionRef, *, base: int | None = None, diff: str | None = None) -> str:
+def _write_version(
+    root: Path, ref: VersionRef, *, base: int | None = None, diff: str | None = None
+) -> str:
     d = root / ref.identity
     d.mkdir(parents=True)
     meta: dict = {"version": ref.version}
     if diff:
-        meta.update({"delta_encoding": diff, "base_version": base, "compression_format": "zstd", "checksum_format": "xxh3-128"})
+        meta.update(
+            {
+                "delta_encoding": diff,
+                "base_version": base,
+                "compression_format": "zstd",
+                "checksum_format": "xxh3-128",
+            }
+        )
     (d / "model.safetensors.index.json").write_text(
         json.dumps({"metadata": meta, "weight_map": {"w": "model-00001.safetensors"}})
     )
@@ -36,7 +45,9 @@ def test_publish_full_roundtrip() -> None:
         vdir = _write_version(root, VersionRef("r1", 1))  # framework wrote it in place
         ref = publish_version(store, None, vdir, run_id="r1")
         assert ref == VersionRef("r1", 1)
-        assert store.read_pointer() == VersionRef("r1", 1)  # pointer parses back to the ref
+        assert store.read_pointer() == VersionRef(
+            "r1", 1
+        )  # pointer parses back to the ref
         man = store.read_manifest(ref)
         assert man.kind is VersionKind.FULL
         assert (Path(store.materialize(ref)) / "model.safetensors.index.json").exists()
@@ -48,8 +59,15 @@ def test_claim_then_delta_chain() -> None:
         store = ModalVolumeStore(root)
         store.claim("r1")
         assert store.read_pointer() == VersionRef("r1", 0)  # base before any publish
-        publish_version(store, None, _write_version(root, VersionRef("r1", 1)), run_id="r1")
-        publish_version(store, None, _write_version(root, VersionRef("r1", 2), base=1, diff="xor"), run_id="r1")
+        publish_version(
+            store, None, _write_version(root, VersionRef("r1", 1)), run_id="r1"
+        )
+        publish_version(
+            store,
+            None,
+            _write_version(root, VersionRef("r1", 2), base=1, diff="xor"),
+            run_id="r1",
+        )
         assert store.read_pointer() == VersionRef("r1", 2)
         man = store.read_manifest(VersionRef("r1", 2))
         assert man.kind is VersionKind.DELTA
@@ -60,9 +78,13 @@ def test_copies_when_files_dir_is_external() -> None:
         root, staging = Path(tmp) / "store", Path(tmp) / "staging"
         root.mkdir()
         store = ModalVolumeStore(root)
-        src = _write_version(staging, VersionRef("r1", 1))  # a staging dir, not the store layout
+        src = _write_version(
+            staging, VersionRef("r1", 1)
+        )  # a staging dir, not the store layout
         publish_version(store, None, src, run_id="r1")
-        assert (root / "r1" / "weight_v000001" / "model.safetensors.index.json").exists()
+        assert (
+            root / "r1" / "weight_v000001" / "model.safetensors.index.json"
+        ).exists()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Run the repository's configured Ruff formatter over the existing Python files touched by the follow-up cookbook changes.

This PR contains no handwritten or semantic changes. Separating it keeps both behavioral reviews focused.

## Stack

1. #97 — Ruff-only formatting (this PR)
2. #94 — storage and run-state contract
3. #96 — GLM-5.2 NVFP4 + SWE-bench Pro experiment

## Validation

- `uv run ruff format --check <changed Python files>`
- `uv run ruff check .`
- `uv run pytest` — 80 passed