### PR TITLE
style: format the Python codebase with Ruff

### DIFF
--- a/cookbook/common/launch.py
+++ b/cookbook/common/launch.py
@@ -41,7 +41,9 @@ def resolve_config(cfg: Any, tmpdir: str, yaml_fields: tuple[str, ...]) -> None:
             setattr(cfg, field, path)
 
 
-def materialize_node_local_yaml(cfg: Any, field: str, dest_dir: str = "/root/.node_yaml") -> None:
+def materialize_node_local_yaml(
+    cfg: Any, field: str, dest_dir: str = "/root/.node_yaml"
+) -> None:
     """Write an inline-dict config field to a deterministic node-local YAML path, so every Ray
     actor across nodes re-reads identical content at an identical path — unlike ``resolve_config``'s
     per-launch tmpdir. Call on every node (before the rank gate). No-op unless the field is a dict;
@@ -66,4 +68,6 @@ def deploy_pool_and_spawn(run: Any) -> None:
     run.app.deploy()
     await_pool_ready(ModalFlashPool(run.APP_NAME, "Server"))
     run.spawn_train()
-    print(f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; stop it with: modal app stop {run.APP_NAME}")
+    print(
+        f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; stop it with: modal app stop {run.APP_NAME}"
+    )

--- a/cookbook/common/ray_cluster.py
+++ b/cookbook/common/ray_cluster.py
@@ -28,7 +28,9 @@ def get_modal_cluster_context(n_nodes: int) -> tuple[int, str, str]:
         ip = _local_ip()
         return 0, ip, ip
     if actual != n_nodes:
-        raise RuntimeError(f"cluster size mismatch: expected {n_nodes} node(s), got {actual}")
+        raise RuntimeError(
+            f"cluster size mismatch: expected {n_nodes} node(s), got {actual}"
+        )
     return info.rank, info.container_ipv4_ips[0], info.container_ipv4_ips[info.rank]
 
 
@@ -46,9 +48,17 @@ def start_ray_head(my_ip: str, n_nodes: int, *, ray_port: int) -> None:
 
     try:
         subprocess.run(
-            ["ray", "start", "--head", f"--node-ip-address={my_ip}", f"--port={ray_port}",
-             "--disable-usage-stats", "--include-dashboard=false"],
-            check=True, timeout=RAY_START_TIMEOUT,
+            [
+                "ray",
+                "start",
+                "--head",
+                f"--node-ip-address={my_ip}",
+                f"--port={ray_port}",
+                "--disable-usage-stats",
+                "--include-dashboard=false",
+            ],
+            check=True,
+            timeout=RAY_START_TIMEOUT,
         )
     except (subprocess.TimeoutExpired, subprocess.CalledProcessError) as exc:
         _print_ray_logs()
@@ -78,23 +88,42 @@ def start_ray_head(my_ip: str, n_nodes: int, *, ray_port: int) -> None:
 
 def start_ray_worker(my_ip: str, master_addr: str, *, ray_port: int) -> None:
     subprocess.run(
-        ["ray", "start", f"--node-ip-address={my_ip}", "--address", f"{master_addr}:{ray_port}",
-         "--disable-usage-stats"],
-        check=True, timeout=RAY_START_TIMEOUT,
+        [
+            "ray",
+            "start",
+            f"--node-ip-address={my_ip}",
+            "--address",
+            f"{master_addr}:{ray_port}",
+            "--disable-usage-stats",
+        ],
+        check=True,
+        timeout=RAY_START_TIMEOUT,
     )
 
 
-def start_ray_node(rank: int, master_addr: str, my_ip: str, *, n_nodes: int, ray_port: int,
-                   extra_env: dict[str, str] | None = None) -> None:
+def start_ray_node(
+    rank: int,
+    master_addr: str,
+    my_ip: str,
+    *,
+    n_nodes: int,
+    ray_port: int,
+    extra_env: dict[str, str] | None = None,
+) -> None:
     """Set this node's Ray/NCCL env, then bring Ray up (head on rank 0, worker otherwise).
     ``extra_env`` overlays the framework-specific vars a recipe adds — its own HOST_IP alias, a
     PYTHONPATH, its training ``environment``."""
-    os.environ.update({
-        "SGLANG_HOST_IP": my_ip, "HOST_IP": my_ip,
-        "MASTER_ADDR": master_addr, "RAY_ADDRESS": f"{master_addr}:{ray_port}",
-        "no_proxy": f"127.0.0.1,{master_addr},{my_ip}", "NO_PROXY": f"127.0.0.1,{master_addr},{my_ip}",
-        **(extra_env or {}),
-    })
+    os.environ.update(
+        {
+            "SGLANG_HOST_IP": my_ip,
+            "HOST_IP": my_ip,
+            "MASTER_ADDR": master_addr,
+            "RAY_ADDRESS": f"{master_addr}:{ray_port}",
+            "no_proxy": f"127.0.0.1,{master_addr},{my_ip}",
+            "NO_PROXY": f"127.0.0.1,{master_addr},{my_ip}",
+            **(extra_env or {}),
+        }
+    )
     if rank == 0:
         start_ray_head(my_ip, n_nodes, ray_port=ray_port)
     else:
@@ -103,7 +132,13 @@ def start_ray_node(rank: int, master_addr: str, my_ip: str, *, n_nodes: int, ray
 
 def _print_ray_logs() -> None:
     log_dir = Path("/tmp/ray/session_latest/logs")
-    for name in ("gcs_server.out", "gcs_server.err", "raylet.out", "raylet.err", "monitor.err"):
+    for name in (
+        "gcs_server.out",
+        "gcs_server.err",
+        "raylet.out",
+        "raylet.err",
+        "monitor.err",
+    ):
         path = log_dir / name
         if not path.exists():
             continue

--- a/cookbook/common/smoke.py
+++ b/cookbook/common/smoke.py
@@ -15,7 +15,14 @@ class VersionAheadError(RuntimeError):
     """A monotonic pool has already advanced past the smoke's expected version."""
 
 
-def smoke_flash_pool(*, app_name: str, cls_name: str, model_name: str, weight_version: int, timeout_seconds: int) -> None:
+def smoke_flash_pool(
+    *,
+    app_name: str,
+    cls_name: str,
+    model_name: str,
+    weight_version: int,
+    timeout_seconds: int,
+) -> None:
     """Poll until the pool serves completions at ``weight_version`` — through the gateway (Flash
     holds the request through a scaled-down pool's cold start) and then each live replica's
     ``/server_info``."""
@@ -33,11 +40,19 @@ def smoke_flash_pool(*, app_name: str, cls_name: str, model_name: str, weight_ve
                     raise RuntimeError(
                         f"pool is unclaimed; cannot serve expected weight version {weight_version}"
                     )
-                data = _post_json(f"{gateway}/v1/chat/completions", _completion(model_name), timeout=900)
+                data = _post_json(
+                    f"{gateway}/v1/chat/completions",
+                    _completion(model_name),
+                    timeout=900,
+                )
                 _check_serves(data)
                 print(f"Pool serves base (unclaimed): {data.get('choices')}")
                 return
-            data = _post_json(f"{gateway}/v1/chat/completions", _completion(model_name, weight_version), timeout=900)
+            data = _post_json(
+                f"{gateway}/v1/chat/completions",
+                _completion(model_name, weight_version),
+                timeout=900,
+            )
             print(f"Gateway completion: {data}")
             _check_completion(data, weight_version)
             for target in pool.discover_replicas():
@@ -50,7 +65,9 @@ def smoke_flash_pool(*, app_name: str, cls_name: str, model_name: str, weight_ve
         except Exception as exc:  # noqa: BLE001
             last_error = f"{type(exc).__name__}: {exc}"
         if time.time() >= deadline:
-            raise TimeoutError(f"Flash pool smoke did not pass before timeout: {last_error}")
+            raise TimeoutError(
+                f"Flash pool smoke did not pass before timeout: {last_error}"
+            )
         print(f"Waiting for Flash pool readiness: {last_error}")
         time.sleep(10)
 
@@ -62,15 +79,22 @@ def _applied_version(info: dict) -> int:
 
 def _check_version(current: int, expected: int, target: str) -> None:
     if current > expected:
-        raise VersionAheadError(f"{target} applied={current} already past expected {expected}")
+        raise VersionAheadError(
+            f"{target} applied={current} already past expected {expected}"
+        )
     if current != expected:
         raise RuntimeError(f"{target} applied={current}, expected {expected}")
 
 
 def _check_completion(data: dict, expected: int) -> None:
-    start, end = int(data.get("weight_version_start", -1)), int(data.get("weight_version_end", -1))
+    start, end = (
+        int(data.get("weight_version_start", -1)),
+        int(data.get("weight_version_end", -1)),
+    )
     if start > expected or end > expected:
-        raise VersionAheadError(f"gateway served {start}->{end}, already past expected {expected}")
+        raise VersionAheadError(
+            f"gateway served {start}->{end}, already past expected {expected}"
+        )
     if start != expected or end != expected:
         raise RuntimeError(f"unexpected gateway weight metadata: {data}")
 
@@ -100,7 +124,11 @@ def _get_json(url: str, *, timeout: float) -> dict:
 
 
 def _post_json(url: str, payload: dict, *, timeout: float) -> dict:
-    request = urllib.request.Request(url, data=json.dumps(payload).encode(), headers={"Content-Type": "application/json"})
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
     with urllib.request.urlopen(request, timeout=timeout) as resp:
         return json.load(resp)
 

--- a/cookbook/miles_disagg/config.py
+++ b/cookbook/miles_disagg/config.py
@@ -22,11 +22,15 @@ class MilesConfig:
     become miles CLI args via ``cli_args``."""
 
     environment: dict = {}
-    async_mode: bool = False       # True -> train_async.py
-    miles_model_script: str = ""   # shell script (relative to the miles root) defining MODEL_ARGS
+    async_mode: bool = False  # True -> train_async.py
+    miles_model_script: str = (
+        ""  # shell script (relative to the miles root) defining MODEL_ARGS
+    )
 
     def __init__(self, **kwargs: Any) -> None:
-        self.environment = dict(type(self).environment)  # fresh per instance; never mutate the class default
+        self.environment = dict(
+            type(self).environment
+        )  # fresh per instance; never mutate the class default
         for k, v in kwargs.items():
             setattr(self, k, v)
 
@@ -34,7 +38,10 @@ class MilesConfig:
     def n_train_nodes(self) -> int:
         """Trainer node count: actor nodes, plus critic nodes for PPO/critic setups."""
         nodes = int(getattr(self, "actor_num_nodes", 1))
-        if getattr(self, "use_critic", False) or getattr(self, "advantage_estimator", None) == "ppo":
+        if (
+            getattr(self, "use_critic", False)
+            or getattr(self, "advantage_estimator", None) == "ppo"
+        ):
             nodes += int(getattr(self, "critic_num_nodes", nodes))
         return nodes
 

--- a/cookbook/slime_disagg/config.py
+++ b/cookbook/slime_disagg/config.py
@@ -19,11 +19,15 @@ class SlimeConfig:
     become slime CLI args via ``cli_args``."""
 
     environment: dict = {}
-    async_mode: bool = False       # True -> train_async.py
-    slime_model_script: str = ""   # shell script (relative to the slime root) defining MODEL_ARGS
+    async_mode: bool = False  # True -> train_async.py
+    slime_model_script: str = (
+        ""  # shell script (relative to the slime root) defining MODEL_ARGS
+    )
 
     def __init__(self, **kwargs: Any) -> None:
-        self.environment = dict(type(self).environment)  # fresh per instance; never mutate the class default
+        self.environment = dict(
+            type(self).environment
+        )  # fresh per instance; never mutate the class default
         for k, v in kwargs.items():
             setattr(self, k, v)
 
@@ -31,7 +35,10 @@ class SlimeConfig:
     def n_train_nodes(self) -> int:
         """Trainer node count: actor nodes, plus critic nodes for PPO/critic setups."""
         nodes = int(getattr(self, "actor_num_nodes", 1))
-        if getattr(self, "use_critic", False) or getattr(self, "advantage_estimator", None) == "ppo":
+        if (
+            getattr(self, "use_critic", False)
+            or getattr(self, "advantage_estimator", None) == "ppo"
+        ):
             nodes += int(getattr(self, "critic_num_nodes", nodes))
         return nodes
 

--- a/src/stitch/engines/base.py
+++ b/src/stitch/engines/base.py
@@ -60,7 +60,9 @@ class Engine:
         Mutates ``request`` in place."""
         raise NotImplementedError
 
-    def stamp_response(self, response: dict[str, Any], served: VersionRef, current: VersionRef) -> None:
+    def stamp_response(
+        self, response: dict[str, Any], served: VersionRef, current: VersionRef
+    ) -> None:
         """Record which version generated a response, in the engine's response shape
         (e.g. sglang's meta_info vs OpenAI top-level). Mutates ``response`` in place."""
         raise NotImplementedError

--- a/src/stitch/engines/vllm.py
+++ b/src/stitch/engines/vllm.py
@@ -68,6 +68,8 @@ class VLLMEngine(Engine):
         # sglang's extra_key — e.g. a prefix-cache salt / request tag). Mutates request in place.
         raise NotImplementedError("VLLMEngine.stamp_request: TODO")
 
-    def stamp_response(self, response: dict[str, Any], served: VersionRef, current: VersionRef) -> None:
+    def stamp_response(
+        self, response: dict[str, Any], served: VersionRef, current: VersionRef
+    ) -> None:
         # TODO: record which version generated the response, in vLLM's response shape.
         raise NotImplementedError("VLLMEngine.stamp_response: TODO")

--- a/src/stitch/pools/base_test.py
+++ b/src/stitch/pools/base_test.py
@@ -37,7 +37,11 @@ def test_async_defaults_delegate_to_sync_impls_off_loop() -> None:
 
     url, replicas = asyncio.run(drive())  # the loop runs on THIS thread
     assert (url, replicas) == ("https://gw", ["https://r1", "https://r2"])
-    assert [name for name, _ in pool.calls] == ["gateway_url", "discover_replicas", "wake"]
+    assert [name for name, _ in pool.calls] == [
+        "gateway_url",
+        "discover_replicas",
+        "wake",
+    ]
     # the sync impls must have run on worker threads, never on the loop's thread
     assert all(ident != threading.get_ident() for _, ident in pool.calls)
 

--- a/src/stitch/pools/modal_flash.py
+++ b/src/stitch/pools/modal_flash.py
@@ -53,13 +53,19 @@ class ModalFlashPool(Pool):
         import modal.experimental
 
         self._cls()  # resolve first: clear error if not deployed
-        return _replica_urls(modal.experimental.flash_get_containers(self.app_name, self.cls_name))
+        return _replica_urls(
+            modal.experimental.flash_get_containers(self.app_name, self.cls_name)
+        )
 
     async def discover_replicas_async(self) -> list[str]:
         import modal.experimental
 
         self._cls()  # resolve first: clear error if not deployed
-        return _replica_urls(await modal.experimental.flash_get_containers.aio(self.app_name, self.cls_name))
+        return _replica_urls(
+            await modal.experimental.flash_get_containers.aio(
+                self.app_name, self.cls_name
+            )
+        )
 
     def wake(self, replicas: list[str], ref: VersionRef) -> None:
         # Fan out (this is on the publish hot path); each replica re-reads the pointer, so no version in the body.
@@ -73,7 +79,9 @@ class ModalFlashPool(Pool):
                 try:
                     client.post(f"{url}/wake").raise_for_status()
                 except Exception as exc:  # noqa: BLE001
-                    logger.warning("failed to wake %s for %s: %s", url, ref.identity, exc)
+                    logger.warning(
+                        "failed to wake %s for %s: %s", url, ref.identity, exc
+                    )
 
             with ThreadPoolExecutor(max_workers=min(16, len(replicas))) as pool:
                 list(pool.map(wake_one, replicas))
@@ -89,7 +97,9 @@ class ModalFlashPool(Pool):
                 try:
                     (await client.post(f"{url}/wake")).raise_for_status()
                 except Exception as exc:  # noqa: BLE001
-                    logger.warning("failed to wake %s for %s: %s", url, ref.identity, exc)
+                    logger.warning(
+                        "failed to wake %s for %s: %s", url, ref.identity, exc
+                    )
 
             await asyncio.gather(*(wake_one(url) for url in replicas))
 

--- a/src/stitch/publish.py
+++ b/src/stitch/publish.py
@@ -51,7 +51,9 @@ def claim_run(store: Store, pool: Pool | None, run_id: str) -> None:
     pool, so every replica (cold or warm on a finished run) resets to base up front. A
     reused ``run_id`` (the run's per-launch fence token) is a rewind — rejected here so a
     restart can't leave the pool pinned to a dead incarnation's high-water mark."""
-    decide_pointer_move(store.read_pointer(), VersionRef(run_id, 0))  # rewind guard (a reused run_id)
+    decide_pointer_move(
+        store.read_pointer(), VersionRef(run_id, 0)
+    )  # rewind guard (a reused run_id)
     store.claim(run_id)
     _wake(pool, VersionRef(run_id, 0))
     logger.info("claimed run %s at base", run_id)
@@ -65,7 +67,11 @@ def _wake(pool: Pool | None, ref: VersionRef) -> None:
     try:
         pool.wake(pool.discover_replicas(), ref)
     except Exception:  # noqa: BLE001
-        logger.warning("pool wake failed for %s; replicas will self-sync", ref.identity, exc_info=True)
+        logger.warning(
+            "pool wake failed for %s; replicas will self-sync",
+            ref.identity,
+            exc_info=True,
+        )
 
 
 def constrain_request(

--- a/src/stitch/publish_test.py
+++ b/src/stitch/publish_test.py
@@ -41,12 +41,21 @@ class FakePool(Pool):
         self.woke.append(ref)
 
 
-def _version_dir(tmp: str, *, version: int, base: int | None = None, diff: str | None = None) -> str:
+def _version_dir(
+    tmp: str, *, version: int, base: int | None = None, diff: str | None = None
+) -> str:
     d = Path(tmp) / f"weight_v{version:06d}"
     d.mkdir()
     meta: dict = {"version": version}
     if diff:
-        meta.update({"delta_encoding": diff, "base_version": base, "compression_format": "zstd", "checksum_format": "xxh3-128"})
+        meta.update(
+            {
+                "delta_encoding": diff,
+                "base_version": base,
+                "compression_format": "zstd",
+                "checksum_format": "xxh3-128",
+            }
+        )
     index = {"metadata": meta, "weight_map": {"w": "model-00001.safetensors"}}
     (d / "model.safetensors.index.json").write_text(json.dumps(index))
     return str(d)
@@ -66,7 +75,9 @@ def test_publish_full() -> None:
 def test_publish_delta() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         store = FakeStore(VersionRef("r1", 1))
-        publish_version(store, None, _version_dir(tmp, version=2, base=1, diff="xor"), run_id="r1")
+        publish_version(
+            store, None, _version_dir(tmp, version=2, base=1, diff="xor"), run_id="r1"
+        )
         man = store.published[0]
         assert man.kind.value == "delta"
         assert store._pointer == VersionRef("r1", 2)
@@ -100,7 +111,9 @@ def test_claim_rewind_rejected() -> None:
 
 def test_constrain_lag() -> None:
     payload, headers = {}, {}
-    constrain_request(payload, headers, latest=10, lag=2, session_id="g1", affinity_header="X-Session")
+    constrain_request(
+        payload, headers, latest=10, lag=2, session_id="g1", affinity_header="X-Session"
+    )
     assert payload["weight_version"] == {"min_version": 8, "exact_version": None}
     assert headers["X-Session"] == "g1"
 

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -88,7 +88,10 @@ def create_app(
         # catch-up). A fresh boot clears at once; a mid-run joiner waits until it has applied the
         # live version. Liveness/boot checks use /server_info instead.
         if not reconciler.ready:
-            return JSONResponse({"ready": False, "reason": reconciler.readiness_reason()}, status_code=503)
+            return JSONResponse(
+                {"ready": False, "reason": reconciler.readiness_reason()},
+                status_code=503,
+            )
         return JSONResponse({"ready": True})
 
     @app.get("/server_info")
@@ -110,18 +113,29 @@ def create_app(
         route = path.strip("/")
         if route in blocked:
             return JSONResponse(
-                {"error": {"type": "RouteBlocked", "message": f"/{route} is managed by the sidecar"}},
+                {
+                    "error": {
+                        "type": "RouteBlocked",
+                        "message": f"/{route} is managed by the sidecar",
+                    }
+                },
                 status_code=403,
             )
 
         body = await request.body()
         payload: dict[str, Any] | None = None
-        if body and request.headers.get("content-type", "").startswith("application/json"):
+        if body and request.headers.get("content-type", "").startswith(
+            "application/json"
+        ):
             parsed = await request.json()
             payload = parsed if isinstance(parsed, dict) else None
 
         is_versioned = route in versioned
-        constraint = VersionConstraint.from_payload(payload) if is_versioned else VersionConstraint()
+        constraint = (
+            VersionConstraint.from_payload(payload)
+            if is_versioned
+            else VersionConstraint()
+        )
 
         # rid lets us abort the upstream generation on client disconnect, else it holds the quiesce point.
         rid = None
@@ -129,19 +143,31 @@ def create_app(
             payload.pop("weight_version", None)
             rid = payload.setdefault("rid", uuid.uuid4().hex)
 
-        headers = {k: v for k, v in request.headers.items() if k.lower() not in _DROP_HEADERS}
+        headers = {
+            k: v for k, v in request.headers.items() if k.lower() not in _DROP_HEADERS
+        }
 
         try:
             async with reconciler.admit(constraint if is_versioned else None) as served:
                 if is_versioned and payload is not None and served is not None:
                     engine.stamp_request(payload, served)
-                kwargs: dict[str, Any] = {"params": request.query_params, "headers": headers}
-                kwargs["json" if payload is not None else "content"] = payload if payload is not None else body
+                kwargs: dict[str, Any] = {
+                    "params": request.query_params,
+                    "headers": headers,
+                }
+                kwargs["json" if payload is not None else "content"] = (
+                    payload if payload is not None else body
+                )
 
-                upstream_task = asyncio.ensure_future(client().request(request.method, f"{engine_url}/{path}", **kwargs))
+                upstream_task = asyncio.ensure_future(
+                    client().request(request.method, f"{engine_url}/{path}", **kwargs)
+                )
                 disconnect_task = asyncio.ensure_future(_watch_disconnect(request))
                 try:
-                    await asyncio.wait({upstream_task, disconnect_task}, return_when=asyncio.FIRST_COMPLETED)
+                    await asyncio.wait(
+                        {upstream_task, disconnect_task},
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
                     if not upstream_task.done():
                         upstream_task.cancel()
                         with contextlib.suppress(BaseException):
@@ -163,7 +189,11 @@ def create_app(
                     # retain the admission lease until the best-effort abort has completed.
                     logger.warning(
                         "local engine request failed method=%s route=/%s rid=%s error=%s: %s",
-                        request.method, route, rid, type(exc).__name__, exc,
+                        request.method,
+                        route,
+                        rid,
+                        type(exc).__name__,
+                        exc,
                     )
                     if rid is not None:
                         await _abort(client(), engine_url, rid)
@@ -179,14 +209,24 @@ def create_app(
                         headers={"Retry-After": "1"},
                     )
                 if "application/json" not in resp.headers.get("content-type", ""):
-                    return Response(content=resp.content, status_code=resp.status_code,
-                                    media_type=resp.headers.get("content-type") or None)
+                    return Response(
+                        content=resp.content,
+                        status_code=resp.status_code,
+                        media_type=resp.headers.get("content-type") or None,
+                    )
                 data = resp.json()
-                current = reconciler.applied  # capture while still pinned, before a commit advances it
+                current = (
+                    reconciler.applied
+                )  # capture while still pinned, before a commit advances it
         except ConstraintUnmet as exc:
             return JSONResponse(exc.error, status_code=409)
 
-        if is_versioned and isinstance(data, dict) and served is not None and current is not None:
+        if (
+            is_versioned
+            and isinstance(data, dict)
+            and served is not None
+            and current is not None
+        ):
             engine.stamp_response(data, served, current)
         return JSONResponse(data, status_code=resp.status_code)
 
@@ -195,10 +235,15 @@ def create_app(
 
 async def _abort(client: Any, engine_url: str, rid: str) -> None:
     try:
-        await client.request("POST", f"{engine_url}/abort_request", json={"rid": rid}, timeout=10.0)
+        await client.request(
+            "POST", f"{engine_url}/abort_request", json={"rid": rid}, timeout=10.0
+        )
     except Exception as exc:  # noqa: BLE001
         logger.warning(
-            "failed to abort upstream rid=%s error=%s: %s", rid, type(exc).__name__, exc,
+            "failed to abort upstream rid=%s error=%s: %s",
+            rid,
+            type(exc).__name__,
+            exc,
         )
 
 
@@ -219,9 +264,13 @@ def serve(
     import uvicorn
 
     reconciler = Reconciler(
-        store=store, engine=engine, run_id=run_id, commit_mode=commit_mode,
+        store=store,
+        engine=engine,
+        run_id=run_id,
+        commit_mode=commit_mode,
         flush_cache_on_commit=flush_cache_on_commit,
-        debug_requests=debug_requests, reconcile_interval=reconcile_interval,
+        debug_requests=debug_requests,
+        reconcile_interval=reconcile_interval,
     )
     uvicorn.run(create_app(reconciler, engine), host=host, port=port, log_level="info")
 
@@ -236,7 +285,9 @@ async def readiness(pool: Pool, *, timeout: float = 15.0) -> PoolState:
             resp = await c.get(f"{url.rstrip('/')}/server_info", timeout=timeout)
             return ReplicaState.from_dict(resp.json())
         except Exception as exc:  # noqa: BLE001
-            return ReplicaState(reason=str(exc)[:80])  # applied=None => counts as not at any version
+            return ReplicaState(
+                reason=str(exc)[:80]
+            )  # applied=None => counts as not at any version
 
     async with httpx.AsyncClient(trust_env=False) as c:
         # the async variant keeps pool-client I/O off this event loop (native or threaded per pool)
@@ -265,13 +316,15 @@ def sync_in_progress(server_info_url: str, *, timeout: float = 5.0) -> bool:
             info = json.loads(resp.read())
     except Exception:  # noqa: BLE001
         return False
-    initializing = not info.get(
-        "update_destination_ready", True
-    ) and not info.get("update_destination_error")
+    initializing = not info.get("update_destination_ready", True) and not info.get(
+        "update_destination_error"
+    )
     return bool(initializing or info.get("sync_state") in _SYNCING_STATES)
 
 
-def await_pool_ready(pool: Pool, *, timeout: float = 20 * 60, interval: float = 30.0) -> bool:
+def await_pool_ready(
+    pool: Pool, *, timeout: float = 20 * 60, interval: float = 30.0
+) -> bool:
     """Block until the pool's gateway answers /health 200 — Flash holds requests through a
     cold-starting pool, so the first rollout/hot-load meets a ready pool instead of a 5xx storm
     while engines load. Returns True when ready; on timeout, warns and returns False (the caller
@@ -287,5 +340,7 @@ def await_pool_ready(pool: Pool, *, timeout: float = 20 * 60, interval: float = 
         except Exception:  # noqa: BLE001
             pass
         time.sleep(interval)
-    print(f"WARNING: pool at {gateway} not ready after {timeout:.0f}s; proceeding (the trainer retries)")
+    print(
+        f"WARNING: pool at {gateway} not ready after {timeout:.0f}s; proceeding (the trainer retries)"
+    )
     return False

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -30,7 +30,9 @@ class _ProxyEngine(Engine):
     def stamp_request(self, request: dict[str, Any], served: VersionRef) -> None:
         request["served_version"] = served.version
 
-    def stamp_response(self, response: dict[str, Any], served: VersionRef, current: VersionRef) -> None:
+    def stamp_response(
+        self, response: dict[str, Any], served: VersionRef, current: VersionRef
+    ) -> None:
         response["served_version"] = served.version
 
 
@@ -48,7 +50,9 @@ class _FailingUpstream:
             return httpx.Response(200)
         self.started.set()
         await self.fail.wait()
-        raise httpx.ConnectError("all connection attempts failed", request=httpx.Request(method, url))
+        raise httpx.ConnectError(
+            "all connection attempts failed", request=httpx.Request(method, url)
+        )
 
 
 class _HangingUpstream:
@@ -71,7 +75,9 @@ class _HangingUpstream:
             raise
 
 
-async def _asgi_post(app: Any, payload: dict[str, Any], *, disconnect_on: asyncio.Event | None = None):
+async def _asgi_post(
+    app: Any, payload: dict[str, Any], *, disconnect_on: asyncio.Event | None = None
+):
     """Issue one request directly to the ASGI app, optionally disconnecting after its body."""
     body = json.dumps(payload).encode()
     body_sent = False
@@ -93,22 +99,32 @@ async def _asgi_post(app: Any, payload: dict[str, Any], *, disconnect_on: asynci
 
     await app(
         {
-            "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
-            "method": "POST", "scheme": "http", "path": "/generate",
-            "raw_path": b"/generate", "query_string": b"",
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/generate",
+            "raw_path": b"/generate",
+            "query_string": b"",
             "headers": [(b"content-type", b"application/json")],
-            "client": ("127.0.0.1", 1234), "server": ("sidecar", 8000),
+            "client": ("127.0.0.1", 1234),
+            "server": ("sidecar", 8000),
         },
         receive,
         send,
     )
     start = next(m for m in sent if m["type"] == "http.response.start")
-    response_body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+    response_body = b"".join(
+        m.get("body", b"") for m in sent if m["type"] == "http.response.body"
+    )
     headers = {k.decode().lower(): v.decode() for k, v in start["headers"]}
     return start["status"], headers, response_body
 
 
-def test_upstream_transport_failure_is_retryable_and_releases_admission(monkeypatch, caplog):
+def test_upstream_transport_failure_is_retryable_and_releases_admission(
+    monkeypatch, caplog
+):
     async def go():
         upstream = _FailingUpstream()
         gate = AdmissionGate()
@@ -140,7 +156,9 @@ def test_upstream_transport_failure_is_retryable_and_releases_admission(monkeypa
     }
     records = [r for r in caplog.records if "local engine request failed" in r.message]
     assert len(records) == 1
-    assert records[0].exc_info is None  # concise per-request signal, not a traceback storm
+    assert (
+        records[0].exc_info is None
+    )  # concise per-request signal, not a traceback storm
 
 
 def test_client_disconnect_cancels_aborts_and_releases_admission(monkeypatch):
@@ -171,6 +189,7 @@ def test_client_disconnect_cancels_aborts_and_releases_admission(monkeypatch):
 @contextlib.contextmanager
 def _server_info(payload):
     """Serve ``payload`` as JSON at /server_info on a throwaway localhost port."""
+
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self):  # noqa: N802
             self.send_response(200)

--- a/src/stitch/stores/s3_test.py
+++ b/src/stitch/stores/s3_test.py
@@ -46,7 +46,11 @@ class _FakeS3:
 
         class _Paginator:
             def paginate(self, Bucket, Prefix):
-                contents = [{"Key": k, "Size": len(v)} for (b, k), v in objs.items() if b == Bucket and k.startswith(Prefix)]
+                contents = [
+                    {"Key": k, "Size": len(v)}
+                    for (b, k), v in objs.items()
+                    if b == Bucket and k.startswith(Prefix)
+                ]
                 return [{"Contents": contents}]
 
         return _Paginator()
@@ -63,11 +67,18 @@ def _write_local_version(root: Path, ref: VersionRef) -> str:
     d = root / ref.identity
     d.mkdir(parents=True)
     (d / "model.safetensors.index.json").write_text(
-        json.dumps({
-            "metadata": {"version": ref.version, "base_version": ref.version - 1, "delta_encoding": "xor",
-                         "compression_format": "zstd", "checksum_format": "xxh3-128"},
-            "weight_map": {"w": "model-00001-of-00001.safetensors"},
-        })
+        json.dumps(
+            {
+                "metadata": {
+                    "version": ref.version,
+                    "base_version": ref.version - 1,
+                    "delta_encoding": "xor",
+                    "compression_format": "zstd",
+                    "checksum_format": "xxh3-128",
+                },
+                "weight_map": {"w": "model-00001-of-00001.safetensors"},
+            }
+        )
     )
     (d / "model-00001-of-00001.safetensors").write_bytes(b"\x00\x11\x22\x33")
     return str(d)
@@ -97,7 +108,9 @@ def test_s3_publish_manifest_materialize() -> None:
 
         version_dir = Path(store.materialize(ref))
         assert version_dir == store.cache_dir / ref.identity
-        assert (version_dir / "model-00001-of-00001.safetensors").read_bytes() == b"\x00\x11\x22\x33"
+        assert (
+            version_dir / "model-00001-of-00001.safetensors"
+        ).read_bytes() == b"\x00\x11\x22\x33"
 
 
 if __name__ == "__main__":

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -448,9 +448,7 @@ class Reconciler(AdmissionGate):
             if pointer != initial_pointer:
                 m["initial_target_version"] = initial_pointer.version
                 m["target_version"] = pointer.version
-                m["coalesced_versions"] = (
-                    pointer.version - initial_pointer.version
-                )
+                m["coalesced_versions"] = pointer.version - initial_pointer.version
             logger.info("catch-up: loading v%d into the engine", pointer.version)
 
             async def apply() -> None:

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -21,7 +21,9 @@ from stitch.types import (
 
 
 class FakeStore(Store):
-    def __init__(self, pointer: VersionRef | None = None, *manifests: VersionManifest) -> None:
+    def __init__(
+        self, pointer: VersionRef | None = None, *manifests: VersionManifest
+    ) -> None:
         self._pointer = pointer
         self._manifests = {(m.ref.run_id, m.ref.version): m for m in manifests}
         self.refreshed = 0
@@ -93,7 +95,9 @@ class FakeEngine(Engine):
 
 
 def _full(run: str, version: int) -> VersionManifest:
-    return VersionManifest(VersionRef(run, version), VersionKind.FULL, ["model.safetensors"])
+    return VersionManifest(
+        VersionRef(run, version), VersionKind.FULL, ["model.safetensors"]
+    )
 
 
 def _delta(run: str, version: int, *, files: list[str]) -> VersionManifest:
@@ -108,22 +112,32 @@ def _run(coro) -> None:
 def test_fresh_reconcile() -> None:
     async def go() -> None:
         engine = FakeEngine()
-        r = Reconciler(store=FakeStore(VersionRef("r1", 3), _full("r1", 3)), engine=engine, commit_mode="quiesce")
+        r = Reconciler(
+            store=FakeStore(VersionRef("r1", 3), _full("r1", 3)),
+            engine=engine,
+            commit_mode="quiesce",
+        )
         await r.startup()
         assert r.applied == VersionRef("r1", 3)
         assert engine.staged[-1] == VersionRef("r1", 3)
         assert VersionRef("r1", 3) in engine.committed
         assert r.sync_state is SyncState.IDLE
         assert r.ready
-        assert "flush_cache" not in engine.calls  # flushing is not automatic; it rides commit(flush_cache=…)
+        assert (
+            "flush_cache" not in engine.calls
+        )  # flushing is not automatic; it rides commit(flush_cache=…)
 
     _run(go())
 
 
 def test_reconcile_latches_ready() -> None:
     async def go() -> None:
-        r = Reconciler(store=FakeStore(VersionRef("r1", 2), _full("r1", 2)), engine=FakeEngine())
-        assert not r.ready  # /health keeps a replica out of Flash rotation until it has caught up
+        r = Reconciler(
+            store=FakeStore(VersionRef("r1", 2), _full("r1", 2)), engine=FakeEngine()
+        )
+        assert (
+            not r.ready
+        )  # /health keeps a replica out of Flash rotation until it has caught up
         await r.reconcile()
         assert r.ready
 
@@ -133,7 +147,9 @@ def test_reconcile_latches_ready() -> None:
 def test_startup_initializes_update_destination() -> None:
     async def go() -> None:
         engine = FakeEngine()
-        r = Reconciler(store=FakeStore(), engine=engine)  # unclaimed pool: reconcile is a no-op
+        r = Reconciler(
+            store=FakeStore(), engine=engine
+        )  # unclaimed pool: reconcile is a no-op
         await r.startup()
         await r._destination_init_task
         assert "initialize_update_destination" in engine.calls
@@ -144,18 +160,24 @@ def test_startup_initializes_update_destination() -> None:
 def test_catch_up() -> None:
     async def go() -> None:
         engine = FakeEngine()
-        r = Reconciler(store=FakeStore(VersionRef("r1", 5), _full("r1", 5)), engine=engine)
+        r = Reconciler(
+            store=FakeStore(VersionRef("r1", 5), _full("r1", 5)), engine=engine
+        )
         r.applied = VersionRef("r1", 3)
         await r.reconcile()
         assert r.applied == VersionRef("r1", 5)
-        assert engine.committed == [VersionRef("r1", 5)]  # one staged chain and one commit
+        assert engine.committed == [
+            VersionRef("r1", 5)
+        ]  # one staged chain and one commit
 
     _run(go())
 
 
 def test_latest_advance_during_stage_coalesces_before_commit() -> None:
     async def go() -> None:
-        manifests = [_delta("r1", version, files=[f"v{version}"]) for version in range(7, 11)]
+        manifests = [
+            _delta("r1", version, files=[f"v{version}"]) for version in range(7, 11)
+        ]
         store = FakeStore(VersionRef("r1", 7), *manifests)
         engine = FakeEngine()
         stage_started = asyncio.Event()
@@ -192,10 +214,7 @@ def test_continuous_publishing_cannot_starve_commit() -> None:
     async def go() -> None:
         store = FakeStore(
             VersionRef("r1", 1),
-            *(
-                _delta("r1", version, files=[f"v{version}"])
-                for version in range(1, 4)
-            ),
+            *(_delta("r1", version, files=[f"v{version}"]) for version in range(1, 4)),
         )
         engine = FakeEngine()
         stage = engine.stage
@@ -206,9 +225,7 @@ def test_continuous_publishing_cannot_starve_commit() -> None:
         ) -> None:
             await stage(manifest, source_dir)
             if manifest.ref.version < 3:
-                store.advance_pointer(
-                    VersionRef("r1", manifest.ref.version + 1)
-                )
+                store.advance_pointer(VersionRef("r1", manifest.ref.version + 1))
 
         engine.stage = advancing_stage  # type: ignore[method-assign]
         r = Reconciler(store=store, engine=engine)
@@ -282,13 +299,23 @@ def test_coalesce_observation_failure_commits_staged_target() -> None:
 def test_run_switch_resets_in_place() -> None:
     async def go() -> None:
         engine = FakeEngine()
-        r = Reconciler(store=FakeStore(VersionRef("r2", 2), _full("r2", 2)), engine=engine, commit_mode="in_place")
+        r = Reconciler(
+            store=FakeStore(VersionRef("r2", 2), _full("r2", 2)),
+            engine=engine,
+            commit_mode="in_place",
+        )
         r.applied = VersionRef("r1", 5)
         await r.reconcile()
         assert r.applied == VersionRef("r2", 2)
         assert "reset" in engine.calls  # was patched -> reseed base for the new run
-        assert engine.calls.index("pause") < engine.calls.index("reset") < engine.calls.index("resume")
-        assert "flush_cache" not in engine.calls  # cache flushing is an explicit commit policy
+        assert (
+            engine.calls.index("pause")
+            < engine.calls.index("reset")
+            < engine.calls.index("resume")
+        )
+        assert (
+            "flush_cache" not in engine.calls
+        )  # cache flushing is an explicit commit policy
 
     _run(go())
 
@@ -297,7 +324,11 @@ def test_run_switch_drains_rolling_requests() -> None:
     # Base reset is incompatible: even in in_place, no rolling request crosses the wipe (drain_all; stitch#32).
     async def go() -> None:
         engine = FakeEngine()
-        r = Reconciler(store=FakeStore(VersionRef("r2", 1), _full("r2", 1)), engine=engine, commit_mode="in_place")
+        r = Reconciler(
+            store=FakeStore(VersionRef("r2", 1), _full("r2", 1)),
+            engine=engine,
+            commit_mode="in_place",
+        )
         r.applied = VersionRef("r1", 5)
         release = asyncio.Event()
         late_served: list[VersionRef | None] = []
@@ -313,7 +344,9 @@ def test_run_switch_drains_rolling_requests() -> None:
         req = asyncio.create_task(rolling())
         await asyncio.sleep(0)  # admitted before the switch begins
         sync = asyncio.create_task(r.reconcile())
-        for _ in range(1000):  # bounded: without drain_all the switch completes without draining
+        for _ in range(
+            1000
+        ):  # bounded: without drain_all the switch completes without draining
             if r._committing:
                 break
             await asyncio.sleep(0.001)
@@ -324,7 +357,9 @@ def test_run_switch_drains_rolling_requests() -> None:
         release.set()
         await asyncio.gather(req, sync, late_task)
         assert "reset" in engine.calls
-        assert late_served[0] is not None and late_served[0].run_id == "r2"  # admitted post-wipe
+        assert (
+            late_served[0] is not None and late_served[0].run_id == "r2"
+        )  # admitted post-wipe
 
     _run(go())
 
@@ -333,7 +368,11 @@ def test_rolling_requests_cross_in_place_commit() -> None:
     # Counterpart: a compatible in_place commit applies while rolling traffic keeps decoding; only a base reset drains.
     async def go() -> None:
         engine = FakeEngine()
-        r = Reconciler(store=FakeStore(VersionRef("r1", 4), _full("r1", 4)), engine=engine, commit_mode="in_place")
+        r = Reconciler(
+            store=FakeStore(VersionRef("r1", 4), _full("r1", 4)),
+            engine=engine,
+            commit_mode="in_place",
+        )
         r.applied = VersionRef("r1", 3)
         release = asyncio.Event()
 
@@ -406,7 +445,10 @@ def test_new_request_waits_for_in_place_commit() -> None:
 def test_empty_delta_skips_commit() -> None:
     async def go() -> None:
         engine = FakeEngine()
-        r = Reconciler(store=FakeStore(VersionRef("r1", 4), _delta("r1", 4, files=[])), engine=engine)
+        r = Reconciler(
+            store=FakeStore(VersionRef("r1", 4), _delta("r1", 4, files=[])),
+            engine=engine,
+        )
         r.applied = VersionRef("r1", 3)
         await r.reconcile()
         assert r.applied == VersionRef("r1", 4)
@@ -489,16 +531,20 @@ def test_stage_waits_for_update_destination() -> None:
             await initialize()
 
         engine.initialize_update_destination = slow_initialize  # type: ignore[method-assign]
-        r = Reconciler(store=FakeStore(VersionRef("r1", 2), _full("r1", 2)), engine=engine, reconcile_interval=0.0)
+        r = Reconciler(
+            store=FakeStore(VersionRef("r1", 2), _full("r1", 2)),
+            engine=engine,
+            reconcile_interval=0.0,
+        )
         r.applied = VersionRef("r1", 0)  # same run, behind -> stage v2 (no run switch)
         task = asyncio.create_task(r.startup())
         await asyncio.sleep(0.05)
         assert "stage:2" not in engine.calls
         release.set()
         await task
-        assert engine.calls.index(
-            "initialize_update_destination"
-        ) < engine.calls.index("stage:2")
+        assert engine.calls.index("initialize_update_destination") < engine.calls.index(
+            "stage:2"
+        )
         assert r.metrics["destination_init_wait_s"] > 0
         await r.shutdown()
 
@@ -583,9 +629,14 @@ class FlakyStore(FakeStore):
 
 
 async def _heals_transient_error(interval: float) -> bool:
-    r = Reconciler(store=FlakyStore(VersionRef("r1", 1), _full("r1", 1)), engine=FakeEngine(),
-                   reconcile_interval=interval)
-    await r.startup()  # the pass hits the error -> ERROR; the store is healed from here on
+    r = Reconciler(
+        store=FlakyStore(VersionRef("r1", 1), _full("r1", 1)),
+        engine=FakeEngine(),
+        reconcile_interval=interval,
+    )
+    await (
+        r.startup()
+    )  # the pass hits the error -> ERROR; the store is healed from here on
     async with r.admit(None):
         pass  # unconstrained traffic never 409s, so it nudges nothing
     ok = await _converged(r, VersionRef("r1", 1))
@@ -595,7 +646,9 @@ async def _heals_transient_error(interval: float) -> bool:
 
 def test_transient_error_recovery_needs_backstop() -> None:
     assert asyncio.run(_heals_transient_error(0.05))
-    assert not asyncio.run(_heals_transient_error(0))  # ERROR retries only on external wake
+    assert not asyncio.run(
+        _heals_transient_error(0)
+    )  # ERROR retries only on external wake
 
 
 class HostViewStore(FakeStore):
@@ -605,7 +658,9 @@ class HostViewStore(FakeStore):
 
     refresh_gate: queue.Queue[threading.Event] | None = None
 
-    def __init__(self, pointer: VersionRef | None = None, *manifests: VersionManifest) -> None:
+    def __init__(
+        self, pointer: VersionRef | None = None, *manifests: VersionManifest
+    ) -> None:
         super().__init__(None, *manifests)
         self.remote_pointer = pointer
 
@@ -628,8 +683,12 @@ async def _heals_dropped_wake(interval: float) -> bool:
 
     gate = store.refresh_gate = queue.Queue()
     r.wake()  # start an idle pass
-    (await asyncio.to_thread(gate.get, True, 10)).set()  # release its pass-start refresh
-    recheck = await asyncio.to_thread(gate.get, True, 10)  # its recheck: snapshotted v1, held
+    (
+        await asyncio.to_thread(gate.get, True, 10)
+    ).set()  # release its pass-start refresh
+    recheck = await asyncio.to_thread(
+        gate.get, True, 10
+    )  # its recheck: snapshotted v1, held
     store.advance_pointer(VersionRef("r1", 2))
     r.wake()  # v2's wake: delivered mid-pass -> dropped; the pass idles on its v1 snapshot
     recheck.set()
@@ -648,8 +707,11 @@ def test_constrained_409_recovers_without_backstop() -> None:
     """The event-driven channel: a min_version 409 self-wakes a stale ERROR replica."""
 
     async def go() -> None:
-        r = Reconciler(store=FlakyStore(VersionRef("r1", 1), _full("r1", 1)), engine=FakeEngine(),
-                       reconcile_interval=0)
+        r = Reconciler(
+            store=FlakyStore(VersionRef("r1", 1), _full("r1", 1)),
+            engine=FakeEngine(),
+            reconcile_interval=0,
+        )
         await r.startup()
         assert r.sync_state is SyncState.ERROR
         try:
@@ -675,7 +737,9 @@ def test_admit_satisfied() -> None:
 
 def test_admit_rejected_triggers_wake() -> None:
     async def go() -> None:
-        r = Reconciler(store=FakeStore(VersionRef("r1", 5), _full("r1", 5)), engine=FakeEngine())
+        r = Reconciler(
+            store=FakeStore(VersionRef("r1", 5), _full("r1", 5)), engine=FakeEngine()
+        )
         r.applied = VersionRef("r1", 2)
         try:
             async with r.admit(VersionConstraint(min_version=5)):
@@ -706,7 +770,11 @@ def test_unapplied_replica_rejects() -> None:
 def test_version_flips_before_resume() -> None:
     async def go() -> None:
         engine = FakeEngine()
-        r = Reconciler(store=FakeStore(VersionRef("r1", 4), _full("r1", 4)), engine=engine, commit_mode="in_place")
+        r = Reconciler(
+            store=FakeStore(VersionRef("r1", 4), _full("r1", 4)),
+            engine=engine,
+            commit_mode="in_place",
+        )
         r.applied = VersionRef("r1", 3)
         seen: dict[str, VersionRef | None] = {}
         base_resume = engine.resume
@@ -717,7 +785,9 @@ def test_version_flips_before_resume() -> None:
 
         engine.resume = resume_spy  # type: ignore[method-assign]
         await r.reconcile()
-        assert seen["applied"] == VersionRef("r1", 4)  # flipped under the gate, before resume
+        assert seen["applied"] == VersionRef(
+            "r1", 4
+        )  # flipped under the gate, before resume
 
     _run(go())
 

--- a/src/stitch/types.py
+++ b/src/stitch/types.py
@@ -40,15 +40,19 @@ class VersionRef:
         # raises — never fall back to base and serve the wrong weights (stitch#31).
         text = (text or "").strip()
         run_id, _, tail = text.rpartition("/")
-        digits = tail[len(_WEIGHT_PREFIX):] if tail.startswith(_WEIGHT_PREFIX) else tail
+        digits = (
+            tail[len(_WEIGHT_PREFIX) :] if tail.startswith(_WEIGHT_PREFIX) else tail
+        )
         if not digits.isdigit():
             raise ValueError(f"unparseable snapshot pointer: {text!r}")
         return cls(run_id or None, int(digits))
 
 
 class VersionKind(str, Enum):
-    FULL = "full"    # an anchor: the version's files are the weights
-    DELTA = "delta"  # a diff against base_version (same run), chaining back to an anchor
+    FULL = "full"  # an anchor: the version's files are the weights
+    DELTA = (
+        "delta"  # a diff against base_version (same run), chaining back to an anchor
+    )
 
 
 @dataclass(frozen=True)
@@ -67,11 +71,15 @@ class VersionManifest:
     files: list[str]
 
     @classmethod
-    def from_hf_index(cls, version_dir: str | Path, *, run_id: str | None = None) -> VersionManifest:
+    def from_hf_index(
+        cls, version_dir: str | Path, *, run_id: str | None = None
+    ) -> VersionManifest:
         # model.safetensors.index.json holds the version number under `metadata` and the
         # files as `weight_map` values; a `delta_encoding` key (the same one the engine's
         # applier reads) marks a delta.
-        index = json.loads((Path(version_dir) / "model.safetensors.index.json").read_text())
+        index = json.loads(
+            (Path(version_dir) / "model.safetensors.index.json").read_text()
+        )
         meta = index.get("metadata") or {}
         weight_map = index.get("weight_map") or {}
         return cls(
@@ -96,7 +104,9 @@ class VersionConstraint:
         raw = (payload or {}).get("weight_version")
         raw = raw if isinstance(raw, dict) else {}
         mn, ex = raw.get("min_version"), raw.get("exact_version")
-        return cls(int(mn) if mn is not None else None, int(ex) if ex is not None else None)
+        return cls(
+            int(mn) if mn is not None else None, int(ex) if ex is not None else None
+        )
 
     def to_payload(self) -> dict[str, int | None]:
         return {"min_version": self.min_version, "exact_version": self.exact_version}
@@ -180,7 +190,9 @@ class PointerMove:
     reset: bool  # crossed to a new run -> reset to base
 
 
-def decide_pointer_move(current: VersionRef | None, proposed: VersionRef) -> PointerMove:
+def decide_pointer_move(
+    current: VersionRef | None, proposed: VersionRef
+) -> PointerMove:
     """A different run forks at base (a reset, even at a lower number); within the
     same run the move must be strictly newer, else :class:`PointerRewind`."""
     current_run = current.run_id if current is not None else None

--- a/tools/probes/app.py
+++ b/tools/probes/app.py
@@ -16,7 +16,9 @@ RESULTS_ROOT = "/probe-results"
 MINUTES = 60
 
 app = modal.App("stitch-probes")
-results_volume = modal.Volume.from_name("stitch-probe-results", version=2, create_if_missing=True)
+results_volume = modal.Volume.from_name(
+    "stitch-probe-results", version=2, create_if_missing=True
+)
 
 image = (
     modal.Image.debian_slim(python_version="3.12")
@@ -25,17 +27,31 @@ image = (
 )
 
 
-@app.function(image=image, volumes={RESULTS_ROOT: results_volume}, timeout=120 * MINUTES)
-def poll(pool_app: str, pool_cls: str = "Server", interval: float = 2.0, duration: float = 3600.0, tag: str = "run") -> None:
+@app.function(
+    image=image, volumes={RESULTS_ROOT: results_volume}, timeout=120 * MINUTES
+)
+def poll(
+    pool_app: str,
+    pool_cls: str = "Server",
+    interval: float = 2.0,
+    duration: float = 3600.0,
+    tag: str = "run",
+) -> None:
     from tools.probes import poller
 
     out = f"{RESULTS_ROOT}/{tag}/server_info.jsonl"
-    asyncio.run(poller.poll(pool_app, pool_cls, interval=interval, duration=duration, out_path=out))
+    asyncio.run(
+        poller.poll(
+            pool_app, pool_cls, interval=interval, duration=duration, out_path=out
+        )
+    )
     results_volume.commit()
     print(json.dumps(poller.summarize(out), indent=2))
 
 
-@app.function(image=image, volumes={RESULTS_ROOT: results_volume}, timeout=120 * MINUTES)
+@app.function(
+    image=image, volumes={RESULTS_ROOT: results_volume}, timeout=120 * MINUTES
+)
 def traffic(
     pool_app: str,
     pool_cls: str = "Server",
@@ -51,8 +67,16 @@ def traffic(
 
     gateway = ModalFlashPool(pool_app, pool_cls).gateway_url()
     out = f"{RESULTS_ROOT}/{tag}/traffic-{shape}.jsonl"
-    summary = asyncio.run(traffic_mod.run(
-        gateway, model, shape=shape, concurrency=concurrency, duration=duration, lag=lag, out_path=out,
-    ))
+    summary = asyncio.run(
+        traffic_mod.run(
+            gateway,
+            model,
+            shape=shape,
+            concurrency=concurrency,
+            duration=duration,
+            lag=lag,
+            out_path=out,
+        )
+    )
     results_volume.commit()
     print(json.dumps(summary, indent=2))

--- a/tools/probes/poller.py
+++ b/tools/probes/poller.py
@@ -14,7 +14,9 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
-REDISCOVER_EVERY = 30.0  # seconds between replica-list refreshes (containers come and go)
+REDISCOVER_EVERY = (
+    30.0  # seconds between replica-list refreshes (containers come and go)
+)
 
 
 async def poll(
@@ -42,10 +44,14 @@ async def poll(
     async with httpx.AsyncClient(timeout=10.0, trust_env=False) as client:
         with out.open("a") as f:
             while deadline is None or time.time() < deadline:
-                if pool is not None and (not replicas or time.time() - last_discover >= REDISCOVER_EVERY):
+                if pool is not None and (
+                    not replicas or time.time() - last_discover >= REDISCOVER_EVERY
+                ):
                     replicas = await asyncio.to_thread(pool.discover_replicas)
                     last_discover = time.time()
-                for row in await asyncio.gather(*(_probe(client, url) for url in replicas)):
+                for row in await asyncio.gather(
+                    *(_probe(client, url) for url in replicas)
+                ):
                     f.write(json.dumps(row) + "\n")
                 f.flush()
                 await asyncio.sleep(interval)
@@ -64,9 +70,15 @@ def summarize(path: str) -> dict[str, Any]:
     """Reduce a poll JSONL to the certification quantities."""
     from stitch.types import VersionRef
 
-    first_seen: dict[str, dict[int, float]] = defaultdict(dict)  # replica -> version -> t
-    timings: dict[tuple[str, float], dict[str, Any]] = {}  # (replica, metrics.at) -> metrics
-    unready: dict[str, float] = defaultdict(float)  # replica -> seconds observed not ready
+    first_seen: dict[str, dict[int, float]] = defaultdict(
+        dict
+    )  # replica -> version -> t
+    timings: dict[
+        tuple[str, float], dict[str, Any]
+    ] = {}  # (replica, metrics.at) -> metrics
+    unready: dict[str, float] = defaultdict(
+        float
+    )  # replica -> seconds observed not ready
     prev_t: dict[str, float] = {}
     errors = 0
 
@@ -88,8 +100,11 @@ def summarize(path: str) -> dict[str, Any]:
 
     versions = sorted({v for per in first_seen.values() for v in per})
     convergence = {
-        v: round(max(per[v] for per in first_seen.values() if v in per)
-                 - min(per[v] for per in first_seen.values() if v in per), 3)
+        v: round(
+            max(per[v] for per in first_seen.values() if v in per)
+            - min(per[v] for per in first_seen.values() if v in per),
+            3,
+        )
         for v in versions
         if sum(v in per for per in first_seen.values()) > 1
     }
@@ -109,7 +124,12 @@ def summarize(path: str) -> dict[str, Any]:
 def _dist(xs: list[float]) -> dict[str, float] | None:
     if not xs:
         return None
-    return {"n": len(xs), "p50": xs[len(xs) // 2], "p95": xs[int(len(xs) * 0.95)], "max": xs[-1]}
+    return {
+        "n": len(xs),
+        "p50": xs[len(xs) // 2],
+        "p95": xs[int(len(xs) * 0.95)],
+        "max": xs[-1],
+    }
 
 
 if __name__ == "__main__":
@@ -127,6 +147,14 @@ if __name__ == "__main__":
     s.add_argument("path")
     args = ap.parse_args()
     if args.cmd == "poll":
-        asyncio.run(poll(args.app, args.cls, interval=args.interval, duration=args.duration, out_path=args.out))
+        asyncio.run(
+            poll(
+                args.app,
+                args.cls,
+                interval=args.interval,
+                duration=args.duration,
+                out_path=args.out,
+            )
+        )
     else:
         print(json.dumps(summarize(args.path), indent=2))

--- a/tools/probes/traffic.py
+++ b/tools/probes/traffic.py
@@ -24,8 +24,10 @@ from typing import Any
 AFFINITY_HEADER = "Modal-Session-ID"  # what the cookbook configs use
 RETRY_409_SLEEP = 1.0
 RETRY_409_LIMIT = 120
-_WORDS = ("the model weights version pool replica delta chain anchor policy rollout "
-          "context token prefill decode publish commit stage pointer session request").split()
+_WORDS = (
+    "the model weights version pool replica delta chain anchor policy rollout "
+    "context token prefill decode publish commit stage pointer session request"
+).split()
 
 
 @dataclass(frozen=True)
@@ -39,13 +41,20 @@ class Shape:
 SHAPES: dict[str, Shape] = {
     "long_decode": Shape(prompt_tokens=(200, 800), max_tokens=(4096, 12288)),
     "long_prefill": Shape(prompt_tokens=(8_000, 24_000), max_tokens=(256, 1024)),
-    "agentic": Shape(prompt_tokens=(1_000, 3_000), max_tokens=(256, 1536), turns=(4, 12), tool_tokens=(500, 4_000)),
+    "agentic": Shape(
+        prompt_tokens=(1_000, 3_000),
+        max_tokens=(256, 1536),
+        turns=(4, 12),
+        tool_tokens=(500, 4_000),
+    ),
 }
 MIXED_WEIGHTS = {"long_decode": 0.4, "long_prefill": 0.2, "agentic": 0.4}
 
 
 def _filler(rng: random.Random, tokens: int) -> str:
-    return " ".join(rng.choices(_WORDS, k=max(1, int(tokens * 0.75))))  # ~0.75 words/token
+    return " ".join(
+        rng.choices(_WORDS, k=max(1, int(tokens * 0.75)))
+    )  # ~0.75 words/token
 
 
 def _estimate_tokens(messages: list[dict[str, str]]) -> int:
@@ -59,7 +68,8 @@ async def run(
     shape: str = "mixed",
     concurrency: int = 16,
     duration: float = 600.0,
-    lag: int | None = None,  # floor requests at (gateway-observed version - lag); None = unconstrained
+    lag: int
+    | None = None,  # floor requests at (gateway-observed version - lag); None = unconstrained
     context_limit: int = 16384,  # engine --context-length; sessions stop growing before it
     out_path: str | None = None,
     seed: int = 0,
@@ -74,7 +84,19 @@ async def run(
             await floor.start(client)
         workers = [
             asyncio.create_task(
-                _worker(client, gateway, model, shape, deadline, rows, floor, lag, context_limit, i, random.Random(seed + i))
+                _worker(
+                    client,
+                    gateway,
+                    model,
+                    shape,
+                    deadline,
+                    rows,
+                    floor,
+                    lag,
+                    context_limit,
+                    i,
+                    random.Random(seed + i),
+                )
             )
             for i in range(concurrency)
         ]
@@ -88,7 +110,19 @@ async def run(
     return summarize(rows)
 
 
-async def _worker(client, gateway, model, shape_name, deadline, rows, floor, lag, context_limit, worker_id, rng) -> None:  # noqa: ANN001
+async def _worker(
+    client,
+    gateway,
+    model,
+    shape_name,
+    deadline,
+    rows,
+    floor,
+    lag,
+    context_limit,
+    worker_id,
+    rng,
+) -> None:  # noqa: ANN001
     n = 0  # one worker = sequential sessions
     while time.time() < deadline:
         name = (
@@ -97,14 +131,27 @@ async def _worker(client, gateway, model, shape_name, deadline, rows, floor, lag
             else rng.choices(*zip(*MIXED_WEIGHTS.items(), strict=True))[0]
         )
         await _session(
-            client, gateway, model, name, SHAPES[name], rng, rows, floor, lag, context_limit,
+            client,
+            gateway,
+            model,
+            name,
+            SHAPES[name],
+            rng,
+            rows,
+            floor,
+            lag,
+            context_limit,
             session_id=f"w{worker_id}-{n}",
         )
         n += 1
 
 
-async def _session(client, gateway, model, name, spec, rng, rows, floor, lag, context_limit, session_id) -> None:  # noqa: ANN001
-    prompt_tokens = min(rng.randint(*spec.prompt_tokens), context_limit - max(spec.max_tokens) - 256)
+async def _session(
+    client, gateway, model, name, spec, rng, rows, floor, lag, context_limit, session_id
+) -> None:  # noqa: ANN001
+    prompt_tokens = min(
+        rng.randint(*spec.prompt_tokens), context_limit - max(spec.max_tokens) - 256
+    )
     messages = [{"role": "user", "content": _filler(rng, prompt_tokens)}]
     headers = {AFFINITY_HEADER: session_id}
     for turn in range(rng.randint(*spec.turns)):
@@ -118,21 +165,41 @@ async def _session(client, gateway, model, name, spec, rng, rows, floor, lag, co
             "temperature": 0.8,
         }
         if floor is not None and floor.version is not None:
-            payload["weight_version"] = {"min_version": max(0, floor.version - (lag or 0))}
-        row = {"t": time.time(), "shape": name, "session": session_id, "turn": turn, "retries_409": 0}
-        data = await _post_with_retry(client, f"{gateway}/v1/chat/completions", payload, headers, row)
+            payload["weight_version"] = {
+                "min_version": max(0, floor.version - (lag or 0))
+            }
+        row = {
+            "t": time.time(),
+            "shape": name,
+            "session": session_id,
+            "turn": turn,
+            "retries_409": 0,
+        }
+        data = await _post_with_retry(
+            client, f"{gateway}/v1/chat/completions", payload, headers, row
+        )
         rows.append(row)
         if data is None:
             return  # session dies with its failed request
         row.update(
             wv_start=data.get("weight_version_start"),
             wv_end=data.get("weight_version_end"),
-            straddled=data.get("weight_version_start") != data.get("weight_version_end"),
+            straddled=data.get("weight_version_start")
+            != data.get("weight_version_end"),
         )
-        content = (data.get("choices") or [{}])[0].get("message", {}).get("content") or ""
+        content = (data.get("choices") or [{}])[0].get("message", {}).get(
+            "content"
+        ) or ""
         messages.append({"role": "assistant", "content": content})
-        if spec.tool_tokens[1]:  # agentic: the "tool result" grows the context every turn
-            messages.append({"role": "user", "content": f"tool result:\n{_filler(rng, rng.randint(*spec.tool_tokens))}\ncontinue."})
+        if spec.tool_tokens[
+            1
+        ]:  # agentic: the "tool result" grows the context every turn
+            messages.append(
+                {
+                    "role": "user",
+                    "content": f"tool result:\n{_filler(rng, rng.randint(*spec.tool_tokens))}\ncontinue.",
+                }
+            )
         else:
             break
 

--- a/tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
+++ b/tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
@@ -222,7 +222,9 @@ def benchmark(
         server_args["--cpu-weight-cache-max-compile-group-gb"] = CPU_CACHE_GROUP_GB
         storage = canonical_storage if canonical_storage is not None else "disk"
         if storage == "disk":
-            server_args["--cpu-weight-cache-canonical-checkpoint-dir"] = CANONICAL_CHECKPOINT_DIR
+            server_args["--cpu-weight-cache-canonical-checkpoint-dir"] = (
+                CANONICAL_CHECKPOINT_DIR
+            )
         elif storage != "memory":
             raise ValueError("canonical_storage must be 'memory' or 'disk'")
     elif canonical_storage is not None:


### PR DESCRIPTION
## Summary

Run the repository's configured Ruff formatter over the entire Python codebase.

This PR contains only formatter output and no semantic changes. The behavioral cookbook PRs are based on this branch so their diffs do not carry pre-existing formatting changes.

## Stack

1. #98 — repository-wide Ruff formatting (this PR)
2. #94 — storage and run-state contract
3. #96 — GLM-5.2 NVFP4 + SWE-bench Pro experiment

## Validation

- `uv run ruff format --check .` — 80 files already formatted
- `uv run ruff check .`
- `uv run pytest` — 80 passed