### PR TITLE
Migrate rollout services to Modal Servers

### DIFF
--- a/cookbook/common/config.py
+++ b/cookbook/common/config.py
@@ -26,7 +26,7 @@ class ModalConfig:
     # Flash autoscaler target: keep well below sglang engine concurrency so Flash adds
     # containers instead of packing requests until KV saturates.
     rollout_target_inputs: int | None = None
-    proxy_regions: list[str] = ["us-west"]
+    routing_region: str = "us-east"
     rollout_ephemeral_disk_mib: int | None = None
     rollout_memory_mib: tuple[int, int] | None = None
     torch_dist_prep_nodes: int = 2

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -137,13 +137,13 @@ SGLANG_SERVER_ARGS = {
 }
 
 
-# The rollout Server: a thin module-level class (Modal requires @app.cls at global scope)
-# whose enter/exit delegate to the shared common.server logic. sglang + the stitch sidecar.
-@app.cls(
+# The rollout Server is a thin module-level class whose lifecycle delegates to the
+# shared common.server logic: sglang plus the stitch sidecar.
+@app.server(
     image=server_image,
     gpu=f"{modal_cfg.gpu}:{miles_cfg.rollout_num_gpus_per_engine}",
     cloud=modal_cfg.cloud,
-    region=modal_cfg.region,
+    compute_region=modal_cfg.region,
     volumes={
         str(HF_CACHE_PATH): hf_cache_volume,
         str(CHECKPOINTS_PATH): checkpoint_volume,
@@ -153,19 +153,17 @@ SGLANG_SERVER_ARGS = {
     },
     min_containers=modal_cfg.rollout_min_containers,
     max_containers=modal_cfg.rollout_max_containers,
-    timeout=40 * MINUTES,
+    target_concurrency=ROLLOUT_CONCURRENCY,
     scaledown_window=15 * MINUTES,
     ephemeral_disk=modal_cfg.rollout_ephemeral_disk_mib,
     memory=modal_cfg.rollout_memory_mib,
     include_source=False,
-)
-@modal.experimental.http_server(
     port=SIDECAR_PORT,
-    proxy_regions=modal_cfg.proxy_regions,
-    exit_grace_period=25,
+    routing_region=modal_cfg.routing_region,
+    unauthenticated=True,
+    exit_grace_period=60 * MINUTES,
     startup_timeout=SERVER_STARTUP_TIMEOUT,
 )
-@modal.concurrent(target_inputs=ROLLOUT_CONCURRENCY)
 class Server:
     @modal.enter()
     def startup(self) -> None:

--- a/cookbook/miles_disagg/configs/glm45_air_bf16.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16.py
@@ -48,7 +48,6 @@ modal = ModalConfig(
     trainer_memory_mib=(1024, int(2 * 1024 * 1024)),
     rollout_min_containers=1,
     rollout_target_inputs=32,
-    proxy_regions=["us-west"],
     # cpu persist ≈ 2x the 207.5 GiB canonical checkpoint; request covers staging + serving baseline.
     rollout_memory_mib=(1024 * 1024, 3 * 1024 * 1024),
     # cpu updates stage nothing local; disk is runtime + spill only.

--- a/cookbook/miles_disagg/configs/glm45_air_fp8.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8.py
@@ -176,7 +176,6 @@ modal = ModalConfig(
     rollout_min_containers=2,
     rollout_max_containers=4,  # start at 2; scale to 4 mid-run to exercise elastic join
     rollout_target_inputs=32,
-    proxy_regions=["us-west"],
     rollout_ephemeral_disk_mib=524_288,
     rollout_memory_mib=(512 * 1024, 2 * 1024 * 1024),
     torch_dist_prep_nodes=4,

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -65,7 +65,6 @@ modal = ModalConfig(
     rollout_target_inputs=32,
     # cpu persist ≈ 862 GiB measured (canonical + TP rank images), ~995 GB observed after staging.
     rollout_memory_mib=(1024 * 1024, 3 * 1024 * 1024),
-    proxy_regions=["us-west"],
     # cpu updates stage nothing local; disk is runtime + spill only.
     rollout_ephemeral_disk_mib=524_288,
     trainer_ephemeral_disk_mib=2_097_152,

--- a/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
@@ -51,7 +51,6 @@ modal = ModalConfig(
     rollout_min_containers=1,
     # cpu persist ≈ 2x the 15.3 GiB canonical checkpoint; request covers staging + serving baseline.
     rollout_memory_mib=(128 * 1024, 512 * 1024),
-    proxy_regions=["us-west"],
     # 2-layer model fits 1 GPU for the torch_dist conversion (pp=world_size <= 2).
     torch_dist_prep_nodes=1,
     torch_dist_prep_gpus_per_node=1,

--- a/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
@@ -59,7 +59,6 @@ modal = ModalConfig(
     rollout_min_containers=4,
     rollout_max_containers=4,
     rollout_target_inputs=32,
-    proxy_regions=["us-west"],
     # Local disk holds runtime files and spill; CPU delta updates do not
     # materialize a target checkpoint.
     rollout_ephemeral_disk_mib=524_288,

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4.py
@@ -52,7 +52,6 @@ modal = ModalConfig(
     rollout_min_containers=1,
     # cpu persist ≈ 2x the ~10 GiB canonical checkpoint; request covers staging + serving baseline.
     rollout_memory_mib=(64 * 1024, 256 * 1024),
-    proxy_regions=["us-west"],
 )
 
 

--- a/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
+++ b/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
@@ -125,7 +125,6 @@ modal = ModalConfig(
     rollout_target_inputs=24,
     # cpu persist ≈ 2x the 23.5 GiB canonical checkpoint; request covers staging + serving baseline.
     rollout_memory_mib=(128 * 1024, 512 * 1024),
-    proxy_regions=["us-west"],
 )
 
 

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -137,14 +137,14 @@ SGLANG_SERVER_ARGS = {
 }
 
 
-# The rollout Server: a thin module-level class (Modal requires @app.cls at global scope)
-# whose enter/exit delegate to the shared common.server logic. sglang + the stitch sidecar.
-@app.cls(
+# The rollout Server is a thin module-level class whose lifecycle delegates to the
+# shared common.server logic: sglang plus the stitch sidecar.
+@app.server(
     image=server_image,
     gpu=f"{modal_cfg.gpu}:{slime_cfg.rollout_num_gpus_per_engine}",
     cpu=modal_cfg.rollout_cpu,
     cloud=modal_cfg.cloud,
-    region=modal_cfg.region,
+    compute_region=modal_cfg.region,
     volumes={
         str(HF_CACHE_PATH): hf_cache_volume,
         str(CHECKPOINTS_PATH): checkpoint_volume,
@@ -154,19 +154,17 @@ SGLANG_SERVER_ARGS = {
     },
     min_containers=modal_cfg.rollout_min_containers,
     max_containers=modal_cfg.rollout_max_containers,
-    timeout=40 * MINUTES,
+    target_concurrency=ROLLOUT_CONCURRENCY,
     scaledown_window=15 * MINUTES,
     ephemeral_disk=modal_cfg.rollout_ephemeral_disk_mib,
     memory=modal_cfg.rollout_memory_mib,
     include_source=False,
-)
-@modal.experimental.http_server(
     port=SIDECAR_PORT,
-    proxy_regions=modal_cfg.proxy_regions,
-    exit_grace_period=25,
+    routing_region=modal_cfg.routing_region,
+    unauthenticated=True,
+    exit_grace_period=60 * MINUTES,
     startup_timeout=SERVER_STARTUP_TIMEOUT,
 )
-@modal.concurrent(target_inputs=ROLLOUT_CONCURRENCY)
 class Server:
     @modal.enter()
     def startup(self) -> None:

--- a/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
+++ b/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
@@ -56,7 +56,6 @@ modal = ModalConfig(
     rollout_target_inputs=256,
     # cpu persist ≈ 2x the ~550 GiB INT4 canonical checkpoint (same class as the miles NVFP4 config).
     rollout_memory_mib=(1536 * 1024, 3 * 1024 * 1024),
-    proxy_regions=["us-west"],
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = []
 
 [project.optional-dependencies]
 # httpx is the pool wake (pools/modal_flash.py).
-modal = ["modal>=1.5.1.dev9", "httpx"]
+modal = ["modal>=1.5.4.dev11", "httpx"]
 # fastapi + httpx only; Modal images install uvicorn separately.
 sglang = ["fastapi", "httpx"]
 
@@ -15,7 +15,7 @@ sglang = ["fastapi", "httpx"]
 dev = [
     "pytest",
     "ruff==0.15.1",
-    "modal>=1.5.1.dev9",
+    "modal>=1.5.4.dev11",
     "fastapi",
     "httpx",
 ]

--- a/src/stitch/pools/modal_flash.py
+++ b/src/stitch/pools/modal_flash.py
@@ -26,33 +26,27 @@ class ModalFlashPool(Pool):
         self.app_name = app_name
         self.cls_name = cls_name
 
-    def _cls(self):
+    def _server(self):
         import modal
 
-        try:
-            return modal.Cls.from_name(self.app_name, self.cls_name)
-        except Exception as exc:  # NotFoundError etc.
-            raise RuntimeError(
-                f"cannot resolve {self.app_name}.{self.cls_name} — is the Server pool deployed?"
-            ) from exc
+        return modal.Server.from_name(self.app_name, self.cls_name)
 
     def gateway_url(self) -> str:
-        return self._pick_gateway(self._cls()._experimental_get_flash_urls())
+        return self._require_gateway(self._server().get_url())
 
     async def gateway_url_async(self) -> str:
-        return self._pick_gateway(await self._cls()._experimental_get_flash_urls.aio())
+        return self._require_gateway(await self._server().get_url.aio())
 
-    def _pick_gateway(self, urls) -> str:
-        if not urls:
+    def _require_gateway(self, url: str | None) -> str:
+        if not url:
             raise RuntimeError(
-                f"no Flash gateway URL for {self.app_name}.{self.cls_name} — deploy the app first"
+                f"no gateway URL for {self.app_name}.{self.cls_name} — deploy the app first"
             )
-        return str(urls[0]).rstrip("/")
+        return str(url).rstrip("/")
 
     def discover_replicas(self) -> list[str]:
         import modal.experimental
 
-        self._cls()  # resolve first: clear error if not deployed
         return _replica_urls(
             modal.experimental.flash_get_containers(self.app_name, self.cls_name)
         )
@@ -60,10 +54,10 @@ class ModalFlashPool(Pool):
     async def discover_replicas_async(self) -> list[str]:
         import modal.experimental
 
-        self._cls()  # resolve first: clear error if not deployed
         return _replica_urls(
             await modal.experimental.flash_get_containers.aio(
-                self.app_name, self.cls_name
+                self.app_name,
+                self.cls_name,
             )
         )
 
@@ -104,14 +98,13 @@ class ModalFlashPool(Pool):
             await asyncio.gather(*(wake_one(url) for url in replicas))
 
     def scale(self, *, min: int | None = None, max: int | None = None) -> None:
-        fn = self._cls()._get_class_service_function()
         kwargs: dict[str, int] = {}
         if min is not None:
             kwargs["min_containers"] = min
         if max is not None:
             kwargs["max_containers"] = max
         if kwargs:
-            fn.update_autoscaler(**kwargs)
+            self._server().update_autoscaler(**kwargs)
 
 
 def _replica_urls(containers) -> list[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -507,7 +507,7 @@ wheels = [
 
 [[package]]
 name = "modal"
-version = "1.5.1.dev10"
+version = "1.5.4.dev11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -524,9 +524,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/d8/a411a2ab084a73bc028835a5f5e37217e26c1d711841a84640aa8f91bf68/modal-1.5.1.dev10.tar.gz", hash = "sha256:c36c15e1a60e031ab34ac9ee9109786a0363bf888ccc5ae4aeff6d795a94e81e", size = 787356, upload-time = "2026-06-19T01:29:55.396Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/fb/8e6f3fe3eac24cce398a7107efd1b3b1202848ea2cd2423522b62afdc78b/modal-1.5.4.dev11.tar.gz", hash = "sha256:64ce19f28f5136d07f5fbd8438ad8644b682ba0799be2c58b03f684fc2001cb9", size = 852557, upload-time = "2026-08-02T00:56:40.476Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/8f/dec98992d3f6cec2c43a2a0b06b7129f230c0179f3217ed1708fd53ac727/modal-1.5.1.dev10-py3-none-any.whl", hash = "sha256:8f87d256fae3a4a75502bf3eac9fdf5e8a89d355e5cfa8dbe61d99fc5354dec2", size = 898275, upload-time = "2026-06-19T01:29:52.473Z" },
+    { url = "https://files.pythonhosted.org/packages/95/4b/8907b96e9cad1af131a894f738eff7881be62b584e808b861355f28e7513/modal-1.5.4.dev11-py3-none-any.whl", hash = "sha256:fe8ac9c7c14887e240ad4d1d283505f39a0c9894c70ecf3691c620fdb1a9d0f6", size = 968325, upload-time = "2026-08-02T00:56:38.891Z" },
 ]
 
 [[package]]
@@ -1012,7 +1012,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'sglang'" },
     { name = "httpx", marker = "extra == 'modal'" },
     { name = "httpx", marker = "extra == 'sglang'" },
-    { name = "modal", marker = "extra == 'modal'", specifier = ">=1.5.1.dev9" },
+    { name = "modal", marker = "extra == 'modal'", specifier = ">=1.5.4.dev11" },
 ]
 provides-extras = ["modal", "sglang"]
 
@@ -1020,7 +1020,7 @@ provides-extras = ["modal", "sglang"]
 dev = [
     { name = "fastapi" },
     { name = "httpx" },
-    { name = "modal", specifier = ">=1.5.1.dev9" },
+    { name = "modal", specifier = ">=1.5.4.dev11" },
     { name = "pytest" },
     { name = "ruff", specifier = "==0.15.1" },
 ]


### PR DESCRIPTION
## Summary
- replace the legacy class + experimental HTTP server stack with app.server for Miles and Slime rollouts
- route Server traffic through us-east and configure target concurrency, public access, and a one-hour exit grace period
- use modal.Server for gateway/autoscaler operations while retaining modal.experimental.flash_get_containers, and bump the Modal SDK

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest (83 passed)
- CPU-only Modal Server probe in stitch-dev using us-east routing (HTTP 200, exit_grace_period=3600)