### PR TITLE
cookbook: support experiment-specific Miles runtimes

### DIFF
--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -76,7 +76,10 @@ image = trainer_image.build_trainer_image(
     hf_cache_path=str(HF_CACHE_PATH),
     experiment=EXPERIMENT,
     run_id=RUN_ID,
+    miles_repo_ref=getattr(exp, "MILES_REPO_REF", trainer_image.MILES_REPO_REF),
     miles_local=MILES_LOCAL_DIR,
+    extra_pip_packages=getattr(exp, "TRAINER_EXTRA_PIP_PACKAGES", ()),
+    image_run_commands=getattr(exp, "TRAINER_IMAGE_RUN_COMMANDS", ()),
 )
 server_image = serving_image.build_serving_image(
     hf_cache_path=str(HF_CACHE_PATH),
@@ -130,7 +133,11 @@ app = modal.App(APP_NAME)
 
 SGLANG_SERVER_ARGS = {
     "--served-model-name": miles_cfg.hf_checkpoint,
-    "--cuda-graph-max-bs-decode": str(ROLLOUT_CONCURRENCY),
+    **(
+        {}
+        if "--cuda-graph-config" in exp.SGLANG_SERVER_ARGS
+        else {"--cuda-graph-max-bs-decode": str(ROLLOUT_CONCURRENCY)}
+    ),
     "--max-running-requests": str(ROLLOUT_CONCURRENCY),
     "--trust-remote-code": "",
     **exp.SGLANG_SERVER_ARGS,
@@ -149,7 +156,11 @@ SGLANG_SERVER_ARGS = {
         str(CHECKPOINTS_PATH): checkpoint_volume,
         str(STITCH_PATH): run_volume,
         SGLANG_CACHE_PATH: sglang_cache_volume,
-        **({str(DRAFT_PATH): draft_volume} if draft_volume is not None else {}),
+        **(
+            {str(DRAFT_PATH): draft_volume.read_only()}
+            if draft_volume is not None
+            else {}
+        ),
     },
     min_containers=modal_cfg.rollout_min_containers,
     max_containers=modal_cfg.rollout_max_containers,
@@ -201,6 +212,11 @@ _MULTINODE = miles_cfg.n_train_nodes > 1
     cloud=modal_cfg.cloud,
     region=modal_cfg.region,
     volumes=train_volumes,
+    secrets=(
+        [modal.Secret.from_name("wandb-secret")]
+        if getattr(miles_cfg, "use_wandb", False)
+        else []
+    ),
     ephemeral_disk=modal_cfg.trainer_ephemeral_disk_mib,
     timeout=24 * 60 * MINUTES,
     startup_timeout=20 * MINUTES,

--- a/cookbook/miles_disagg/prep.py
+++ b/cookbook/miles_disagg/prep.py
@@ -132,6 +132,8 @@ def prepare_checkpoints(exp, checkpoint_volume) -> None:
         carveouts += ["--num-layers-at-start-in-bf16", str(n)]
     if (n := getattr(exp.miles, "num_layers_at_end_in_bf16", None)) is not None:
         carveouts += ["--num-layers-at-end-in-bf16", str(n)]
+    if layers := getattr(exp.miles, "extra_high_precision_layers_hf", None):
+        carveouts += ["--extra-high-precision-layers-hf", *layers]
 
     def _build_nvfp4(out: str) -> None:
         print(

--- a/cookbook/miles_disagg/prep_app.py
+++ b/cookbook/miles_disagg/prep_app.py
@@ -42,7 +42,10 @@ miles_cfg = exp.miles
 image = trainer_image.build_trainer_image(
     hf_cache_path=str(HF_CACHE_PATH),
     experiment=EXPERIMENT,
+    miles_repo_ref=getattr(exp, "MILES_REPO_REF", trainer_image.MILES_REPO_REF),
     miles_local=MILES_LOCAL_DIR,
+    extra_pip_packages=getattr(exp, "TRAINER_EXTRA_PIP_PACKAGES", ()),
+    image_run_commands=getattr(exp, "TRAINER_IMAGE_RUN_COMMANDS", ()),
 )
 
 hf_cache_volume = modal.Volume.from_name(
@@ -88,6 +91,7 @@ _TORCH_DIST_MULTINODE = modal_cfg.torch_dist_prep_nodes > 1
         str(HF_CACHE_PATH): hf_cache_volume,
         str(CHECKPOINTS_PATH): checkpoint_volume,
     },
+    memory=modal_cfg.trainer_memory_mib,
     timeout=6 * 60 * MINUTES,
     ephemeral_disk=(
         modal_cfg.torch_dist_prep_ephemeral_disk_mib

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -18,7 +18,7 @@ from cookbook.common import trainer_image as common_trainer_image
 
 # Dated tag, never `latest`: Modal caches from_registry per tag string and won't re-pull
 # a moved mutable tag, so `latest` silently serves whatever was first pulled.
-MILES_IMAGE_TAG = "radixark/miles:dev-202607260602"
+MILES_IMAGE_TAG = "radixark/miles:dev-202607290235"
 MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
 MILES_REPO_REF = "1eb7520018446cb94b7406715f66dff1a271b53b"  # stitch-weight-sync-v0516
 
@@ -37,7 +37,10 @@ def build_trainer_image(
     hf_cache_path: str,
     experiment: str,
     run_id: str | None = None,
+    miles_repo_ref: str = MILES_REPO_REF,
     miles_local: str | None = None,
+    extra_pip_packages: tuple[str, ...] = (),
+    image_run_commands: tuple[str, ...] = (),
     copy_source: bool = False,
 ) -> modal.Image:
     """The miles trainer image: RDMA/EFA userspace + the pinned miles fork + the
@@ -58,13 +61,17 @@ def build_trainer_image(
         .run_commands(
             f"rm -rf {MILES_ROOT}"
             f" && git clone {MILES_REPO_URL} {MILES_ROOT}"
-            f" && cd {MILES_ROOT} && git fetch origin {MILES_REPO_REF} && git checkout FETCH_HEAD"
+            f" && cd {MILES_ROOT} && git fetch origin {miles_repo_ref} && git checkout FETCH_HEAD"
             f" && python3 -m pip install --no-deps -e {MILES_ROOT}"
         )
         .add_local_file(
             str(_TORCH_DIST_WRAPPER_SRC), TORCH_DIST_CONVERT_WRAPPER, copy=True
         )
     )
+    if extra_pip_packages:
+        image = image.pip_install(*extra_pip_packages)
+    if image_run_commands:
+        image = image.run_commands(*image_run_commands)
     image = common_trainer_image.add_common_layers(
         image,
         experiment=experiment,

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -142,7 +142,6 @@ SGLANG_SERVER_ARGS = {
 @app.server(
     image=server_image,
     gpu=f"{modal_cfg.gpu}:{slime_cfg.rollout_num_gpus_per_engine}",
-    cpu=modal_cfg.rollout_cpu,
     cloud=modal_cfg.cloud,
     compute_region=modal_cfg.region,
     volumes={
@@ -198,7 +197,6 @@ _MULTINODE = slime_cfg.n_train_nodes > 1
 @app.cls(
     image=image,
     gpu=f"{modal_cfg.gpu}:{slime_cfg.actor_num_gpus_per_node}",
-    cpu=modal_cfg.trainer_cpu,
     memory=modal_cfg.trainer_memory_mib,
     cloud=modal_cfg.cloud,
     region=modal_cfg.region,


### PR DESCRIPTION
## Summary

- allow a Miles experiment to pin its own repository revision and image dependencies
- support experiment-specific Megatron runtime patches and immutable draft mounts
- attach W&B credentials only to configurations that enable W&B
- remove unused CPU decorator overrides

This is shared runtime plumbing required by specialized recipes without changing the default Miles integration.

## Validation

- `git diff --check`
- covered by the aggregate cookbook test suite in the split series