### PR TITLE
cookbook: configure GLM-5.2 NVFP4 training

### DIFF
--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -1,78 +1,171 @@
-"""GLM-5.2 GRPO on Modal, disaggregated, native-NVFP4 end to end.
-
-Deploy: EXPERIMENT_CONFIG=glm5_2_nvfp4 uv run --extra modal modal deploy --strategy recreate -m cookbook.miles_disagg.app
-"""
+"""Fully async GLM-5.2 NVFP4 GRPO on SWE-bench Pro."""
 
 from __future__ import annotations
 
 from cookbook.common.config import ModalConfig
-from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH
+from cookbook.common.constants import CHECKPOINTS_PATH, DATA_PATH, DRAFT_PATH
 from cookbook.miles_disagg.config import MilesConfig
+from cookbook.miles_disagg.swebench_pro import prepare_swebench_pro
 
 APP_NAME = "stitch-glm5-2-nvfp4"
 EXPERIMENT_VOLUME_NAME = "stitch-miles-glm5-2-nvfp4"
+# This experiment layers Stitch integration onto Miles' fully-async SWE runtime.
+# Other cookbook experiments keep the standard Miles pin in trainer_image.py.
+MILES_REPO_REF = "7cdfcf78c8f7ab3f2111dafe9881aa99b716a0c5"
 LOCAL_CHECKPOINT_PATH = None
+TRAINER_EXTRA_PIP_PACKAGES = (
+    "harbor[modal,huggingface]==0.20.0",
+    "mini-swe-agent==2.4.5",
+    "swebench==4.1.0",
+    "modal==1.5.1",
+)
+TRAINER_IMAGE_RUN_COMMANDS = (
+    "uv pip install --system --break-system-packages flashinfer-python==0.6.15.post1",
+    "uv pip install --system --break-system-packages --no-deps "
+    "--index-url https://flashinfer.ai/whl "
+    "flashinfer-cubin==0.6.15.post1",
+    "uv pip install --system --break-system-packages --no-deps "
+    "--index-url https://flashinfer.ai/whl/cu130 "
+    "flashinfer-jit-cache==0.6.15.post1+cu130",
+)
+MEGATRON_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
+]
 
-# GLM-5.2 ships BF16 training masters and an NVIDIA NVFP4 rollout checkpoint.
 SOURCE_MODEL = "zai-org/GLM-5.2"
-ROLLOUT_SOURCE_MODEL = "nvidia/GLM-5.2-NVFP4"
-ROLLOUT_SOURCE_REVISION = "aec724e8c7b8ee9db3b48c01c320f63f9cdaf8aa"
+SOURCE_REVISION = "b4734de4facf877f85769a911abafc5283eab3d9"
 BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm5-2-bf16"
 ROLLOUT_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm5-2-nvfp4"
 TORCH_DIST_CHECKPOINT_PATH = CHECKPOINTS_PATH / "glm5-2-torch-dist"
+SWEBENCH_PRO_PATH = DATA_PATH / "swebench-pro"
+DFLASH_VOLUME = "dflash-checkpoints"
+DFLASH_CHECKPOINT_PATH = DRAFT_PATH / "zai-org/GLM-5.2/dflash/draft-step-103000"
 SERVED_CHECKPOINT_FORMAT = "nvfp4"
-CHECKPOINT_PREP_REQUIRES_GPU = False
+CHECKPOINT_PREP_REQUIRES_GPU = True
+MATERIALIZE_BF16_MASTERS = False
+USE_MODAL_TORCH_DIST_WRAPPER = True
+
+TRAINER_NODES = 16
+GPUS_PER_TRAINER_NODE = 8
+ROLLOUT_GPUS_PER_ENGINE = 4
+ROLLOUT_BATCH_SIZE = 32
+N_SAMPLES_PER_PROMPT = 8
+ROLLOUT_TO_TRAINER_GPU_RATIO = 1
+ROLLOUT_INPUTS_PER_ENGINE = 24
+ROLLOUT_ENGINES = (
+    TRAINER_NODES
+    * GPUS_PER_TRAINER_NODE
+    * ROLLOUT_TO_TRAINER_GPU_RATIO
+    // ROLLOUT_GPUS_PER_ENGINE
+)
+ROLLOUT_CONCURRENT_SAMPLES = ROLLOUT_ENGINES * ROLLOUT_INPUTS_PER_ENGINE
+MAX_SEQ_LEN = 65_536
+# SGLang's request boundary needs a small physical-context margin. Miles still
+# truncates every trainable session to MAX_SEQ_LEN.
+SGLANG_CONTEXT_LENGTH = MAX_SEQ_LEN + 8
+# This metric changes exported NVFP4 bytes, so prep, training, and serving must agree.
+NVFP4_4OVER6_ERR_MODE = "MSE"
+
+NVFP4_TRAINING_ENV = {
+    "NVTE_NVFP4_DISABLE_2D_QUANTIZATION": "1",
+    "NVTE_NVFP4_DISABLE_RHT": "1",
+    "NVTE_NVFP4_DISABLE_STOCHASTIC_ROUNDING": "1",
+    "NVTE_NVFP4_ROW_SCALED_ACTIVATION": "1",
+    "NVTE_BACKWARD_OVERRIDE": "dequantized",
+    "NVTE_USE_FAST_MATH": "0",
+    "NVTE_NVFP4_4OVER6": "all",
+    "NVTE_NVFP4_4OVER6_E4M3_USE_256": "all",
+    "NVTE_NVFP4_4OVER6_ERR_MODE": NVFP4_4OVER6_ERR_MODE,
+    "NVTE_NVFP4_4OVER6_ERR_USE_FAST_MATH": "0",
+}
+NVFP4_SERVING_ENV = {
+    "FLASHINFER_NVFP4_4OVER6": "1",
+    "FLASHINFER_NVFP4_4OVER6_E4M3_USE_256": "1",
+    "FLASHINFER_NVFP4_4OVER6_ERR_MODE": NVFP4_4OVER6_ERR_MODE,
+    "FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH": "0",
+    "FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH": "1",
+    "SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION": "1",
+    "TRTLLM_DISABLE_FP4_QUANT_FAST_MATH": "1",
+}
+PREP_ENV = NVFP4_TRAINING_ENV
+SGLANG_SERVER_ENV = {
+    **NVFP4_SERVING_ENV,
+    "SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD": "0",
+    "SGLANG_SANITIZE_NAN_LOGITS": "true",
+}
 
 SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 SGLANG_DELTA_UPDATE_MODE = "cpu"
-# R3 routing-replay needs the dropless Megatron dispatch fix at startup.
-MEGATRON_RUNTIME_PATCHES = [
-    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
-]
-
 
 SGLANG_SERVER_ARGS = {
-    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
+    # loading / elastic refit
     "--load-format": "fastsafetensors",
     "--model-loader-extra-config": '{"enable_gds":false}',
     "--enable-cpu-weight-cache": "",
+    "--cpu-weight-cache-max-compile-group-gb": "8",
     "--weight-loader-drop-cache-after-load": "",
-    # The pinned SGLang has no GLM-5.2 parser; these are the closest available formats.
+    "--dist-timeout": "3600",
+    # model / quant
+    "--quantization": "modelopt_fp4",
     "--reasoning-parser": "glm45",
     "--tool-call-parser": "glm47",
-    "--trust-remote-code": "",
-    "--quantization": "modelopt_fp4",
-    "--moe-runner-backend": "flashinfer_trtllm",
-    "--dist-timeout": "3600",
-    "--kv-cache-dtype": "fp8_e4m3",
-    "--context-length": "32768",
-    "--mem-fraction-static": "0.85",
+    "--context-length": str(SGLANG_CONTEXT_LENGTH),
+    # attention — bf16 KV split
+    "--attention-backend": "dsa",
+    "--dsa-prefill-backend": "flashmla_sparse",
+    "--dsa-decode-backend": "trtllm",
+    "--dsa-topk-backend": "sgl-kernel",
+    # MoE
+    "--moe-runner-backend": "flashinfer_trtllm_routed",
+    # memory / batching
+    "--mem-fraction-static": "0.80",
     "--chunked-prefill-size": "16384",
-    "--schedule-conservativeness": "0.5",
+    "--max-running-requests": "32",
+    "--schedule-conservativeness": "1.0",
     "--schedule-policy": "lpm",
-    "--skip-server-warmup": "",
-    "--enable-return-routed-experts": "",  # routing replay (DeepSeek-V3-arch MoE)
+    "--cuda-graph-config": (
+        '{"decode":{"backend":"full","max_bs":32,'
+        '"bs":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32]}}'
+    ),
+    # speculative
+    "--speculative-algorithm": "DFLASH",
+    "--speculative-attention-mode": "decode",
+    "--speculative-dflash-block-size": "8",
+    "--speculative-num-draft-tokens": "8",
+    "--speculative-num-steps": "1",
+    "--speculative-eagle-topk": "1",
+    "--speculative-draft-attention-backend": "flashinfer",
+    "--speculative-draft-load-format": "safetensors",
+    "--speculative-draft-model-path": str(DFLASH_CHECKPOINT_PATH),
+    "--speculative-draft-model-quantization": "unquant",
+    "--speculative-draft-window-size": "4096",
+    # RL
+    "--enable-return-routed-experts": "",
 }
 
 modal = ModalConfig(
-    gpu="B200",
+    gpu="B300",
     region="us",
-    # TODO(glm5.2): size to the actual model. These are Kimi's (~1T) numbers — scale
-    # down for a smaller GLM 5.2 (memory, ephemeral disk, node count).
-    trainer_memory_mib=(1024, int(3 * 1024 * 1024)),
-    rollout_min_containers=8,  # warm floor; Flash scales above under load
-    rollout_target_inputs=32,
-    # cpu persist ≈ 862 GiB measured (canonical + TP rank images), ~995 GB observed after staging.
+    trainer_memory_mib=(1024 * 1024, 3 * 1024 * 1024),
+    # CPU mode retains both the canonical checkpoint and TP rank images.
     rollout_memory_mib=(1024 * 1024, 3 * 1024 * 1024),
+    rollout_min_containers=ROLLOUT_ENGINES,
+    rollout_max_containers=ROLLOUT_ENGINES,
+    rollout_target_inputs=ROLLOUT_INPUTS_PER_ENGINE,
+    draft_volume=DFLASH_VOLUME,
+    routing_region="us-west",
     # cpu updates stage nothing local; disk is runtime + spill only.
     rollout_ephemeral_disk_mib=524_288,
     trainer_ephemeral_disk_mib=2_097_152,
-    # TODO(glm5.2): torch_dist conversion parallelism — match the trainer EP/TP below.
     torch_dist_prep_nodes=4,
     torch_dist_prep_gpus_per_node=8,
     torch_dist_convert_extra_args=(
-        "--tensor-model-parallel-size 1 --pipeline-model-parallel-size 1 --expert-model-parallel-size 32"
+        "--tensor-model-parallel-size 1 "
+        "--pipeline-model-parallel-size 4 "
+        "--expert-model-parallel-size 8 "
+        "--decoder-first-pipeline-num-layers 18 "
+        "--decoder-last-pipeline-num-layers 20"
     ),
     torch_dist_prep_ephemeral_disk_mib=2_097_152,
 )
@@ -80,22 +173,26 @@ modal = ModalConfig(
 
 class _Miles(MilesConfig):
     miles_model_script = "scripts/models/glm5.2-744B-A40B.sh"
+    async_mode = True
 
     hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
     ref_load = str(TORCH_DIST_CHECKPOINT_PATH)
     megatron_to_hf_mode = "raw"
     model_name = "glm_moe_dsa"
+    extra_high_precision_layers_hf = [".shared_experts."]
+    extra_high_precision_layers_megatron = [
+        ".shared_experts.linear_fc1",
+        ".shared_experts.linear_fc2",
+    ]
 
-    # TODO(glm5.2): size actor_num_nodes / parallelism to the model (Kimi's 16x8=128).
-    actor_num_nodes = 16
-    actor_num_gpus_per_node = 8
-    num_gpus_per_node = 8
-    colocate = False
+    actor_num_nodes = TRAINER_NODES
+    actor_num_gpus_per_node = GPUS_PER_TRAINER_NODE
+    num_gpus_per_node = GPUS_PER_TRAINER_NODE
     rollout_num_gpus = 0
-    # TODO(glm5.2): Size B200s per rollout engine to the served checkpoint.
-    rollout_num_gpus_per_engine = 4
+    rollout_num_gpus_per_engine = ROLLOUT_GPUS_PER_ENGINE
+    # An opaque endpoint has one Miles-side semaphore for the complete fleet.
+    sglang_server_concurrency = ROLLOUT_CONCURRENT_SAMPLES
     rollout_endpoint_url = None
-    use_miles_router = True
 
     custom_rollout_request_hook_path = (
         "cookbook.common.hooks.gated_rollout_request_hook"
@@ -103,20 +200,27 @@ class _Miles(MilesConfig):
     custom_config_path = {
         "rollout_request_weight_version_mode": "min",
         "rollout_request_weight_version_lag": 1,
-        "rollout_request_retry_attempts": 1200,  # outlast a full cold pool load
+        "rollout_request_retry_attempts": 1200,
         "rollout_request_retry_sleep": 1.0,
         "rollout_session_affinity_header": "Modal-Session-ID",
         "rollout_request_timeout_secs": 300,
     }
 
-    async_mode = True
     update_weights_interval = 1
+    update_weight_transfer_mode = "disk-delta"
+    update_weight_delta_encoding = "xor"
+    update_weight_delta_checksum = "xxh3-128"
+    update_weight_buffer_size = 2 * 1024**3
+    custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
 
-    # NVFP4 QAT — miles' canonical NVFP4 RL recipe (shared with Kimi).
+    transformer_impl = "transformer_engine"
+    bf16 = True
     fp4_format = "e2m1"
     fp4_recipe = "nvfp4"
-    fp4_param_gather = False
-    # NVFP4 only on the routed expert GEMMs, everything else bf16 — matches the served base.
+    first_last_layers_bf16 = True
+    # GLM-5.2 has three dense layers; keep those and the final 15% (12/78) in BF16.
+    num_layers_at_start_in_bf16 = 3
+    num_layers_at_end_in_bf16 = 12
     te_precision_config_file = {
         "configs": {
             "nvfp4": {
@@ -149,48 +253,60 @@ class _Miles(MilesConfig):
             },
         },
     }
-    num_layers_at_start_in_bf16 = 3
-    # END must stay 0: SGLang's fused-MoE weight update allocates NVFP4 for
-    # every expert layer, so a bf16 last layer cannot be updated.
-    num_layers_at_end_in_bf16 = 0
 
-    update_weight_transfer_mode = "disk-delta"
-    update_weight_delta_encoding = "xor"
-    update_weight_delta_checksum = "xxh3-128"
-    custom_update_weight_post_write_path = "cookbook.common.hooks.commit_and_wake"
-
-    prompt_data = f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl"
+    prompt_data = f"{SWEBENCH_PRO_PATH}/test.jsonl"
     input_key = "prompt"
-    label_key = "label"
-    apply_chat_template = True
+    metadata_key = "metadata"
     rollout_shuffle = True
     balance_data = True
-    rm_type = "deepscaler"
-    eval_interval = None
 
-    num_rollout = 3  # bring-up smoke length; scale up for a real run
-    save_interval = 20
-    rollout_batch_size = 32
-    rollout_max_response_len = 4096
-    rollout_temperature = 0.8
-    n_samples_per_prompt = 8
+    fully_async = True
+    rollout_sample_completion_backfill = True
+    custom_rollout_log_function_path = "modal_swe_metrics.log_rollout_data"
+    custom_generate_function_path = (
+        "miles.rollout.generate_hub.agentic_tool_call.generate"
+    )
+    custom_agent_function_path = "modal_swe_agent_function.run"
+    custom_rm_path = "modal_swe_agent_function.reward_func"
+    tito_model = "glm47"
+    use_session_server = True
+    session_server_port = [30000, 30064]
+    session_server_startup_timeout_seconds = 180
+    tito_session_mismatch_sample_rate = 0.0625
+
+    num_rollout = 300
+    save_interval = 10
+    rollout_batch_size = ROLLOUT_BATCH_SIZE
+    n_samples_per_prompt = N_SAMPLES_PER_PROMPT
     global_batch_size = 256
+    rollout_temperature = 1.0
+    rollout_top_p = 1.0
+    rollout_max_response_len = 8192
+    max_seq_len = MAX_SEQ_LEN
     use_dynamic_global_batch_size = True
-    sglang_server_concurrency = 256
+    max_weight_staleness = 6
+    async_max_concurrent_samples = ROLLOUT_CONCURRENT_SAMPLES
 
     use_rollout_routing_replay = True
+    use_fault_tolerance = True
 
-    # TODO(glm5.2): trainer parallelism — size to the model + actor_num_nodes above
-    # (mirrors Kimi's 128-GPU layout; adjust TP/PP/CP/EP to GLM 5.2's layer/expert counts).
-    tensor_model_parallel_size = 8
+    # 128 GPUs: TP4 * PP8 * CP4, with one data-parallel replica. The uneven
+    # split keeps every DSA pipeline stage on a layer that computes its index.
+    tensor_model_parallel_size = 4
     sequence_parallel = True
     pipeline_model_parallel_size = 8
-    context_parallel_size = 2
+    decoder_first_pipeline_num_layers = 14
+    decoder_last_pipeline_num_layers = 16
+    context_parallel_size = 4
     expert_model_parallel_size = 16
     expert_tensor_parallel_size = 1
-    decoder_last_pipeline_num_layers = 5
+    allgather_cp = True
+    moe_enable_deepep = True
+    moe_token_dispatcher_type = "flex"
     use_dynamic_batch_size = True
     max_tokens_per_gpu = 16384
+    data_pad_size_multiplier = 1024
+    log_probs_chunk_size = 16384
     recompute_granularity = "full"
     recompute_method = "uniform"
     recompute_num_layers = 1
@@ -198,7 +314,8 @@ class _Miles(MilesConfig):
     hidden_dropout = 0.0
     accumulate_allreduce_grads_in_fp32 = True
     attention_softmax_in_fp32 = True
-    no_check_for_nan_in_loss_and_grad = True
+    attention_backend = "flash"
+    miles_dsa_topk_backend = "flashinfer"
 
     optimizer = "adam"
     lr = 1e-6
@@ -213,40 +330,56 @@ class _Miles(MilesConfig):
     advantage_estimator = "grpo"
     eps_clip = 0.2
     eps_clip_high = 0.28
-    use_kl_loss = True
-    kl_loss_coef = 0.0
-    kl_loss_type = "low_var_kl"
+    use_rollout_logprobs = True
+    get_mismatch_metrics = True
+    custom_tis_function_path = (
+        "examples.infra_features.train_infer_mismatch_helper.mis."
+        "compute_mis_weights_with_cp"
+    )
     entropy_coef = 0.0
-    use_tis = True
+
+    use_wandb = True
+    wandb_project = "fully-async-rl-modal"
+    wandb_group = "glm5-2-nvfp4-swebench-pro"
+    disable_wandb_random_suffix = True
+    use_prometheus = True
+    prometheus_port = 9090
+    prometheus_run_name = "glm5-2-nvfp4-swebench-pro"
 
     environment = {
+        "PYTHONPATH": (
+            "/root/Megatron-LM:/root/miles:/root/miles/examples/swe-agent:"
+            "/root/miles/examples/experimental/modal-swe"
+        ),
         "CUDA_DEVICE_MAX_CONNECTIONS": "1",
         "NCCL_NVLS_ENABLE": "1",
-        "NVSHMEM_DISABLE_NCCL": "1",
-        "NCCL_TIMEOUT_MS": "360000000",
-        # NVFP4 numerics (shared with Kimi; required for correct NVFP4 QAT).
-        "NVTE_NVFP4_DISABLE_2D_QUANTIZATION": "1",
-        "NVTE_NVFP4_DISABLE_RHT": "1",
-        "NVTE_NVFP4_DISABLE_STOCHASTIC_ROUNDING": "1",
-        "NVTE_NVFP4_ROW_SCALED_ACTIVATION": "1",
-        "NVTE_BACKWARD_OVERRIDE": "high_precision",
-        "NVTE_USE_FAST_MATH": "0",
+        # GLM-5 uses interleaved, not NeoX-style, rotary pairs in the DSA indexer.
+        "INDEXER_ROPE_NEOX_STYLE": "0",
+        "RAY_health_check_timeout_ms": "60000",
+        "MILES_EXPERIMENTAL_ROLLOUT_REFACTOR": "1",
+        "AGENT_MODEL_NAME": "model",
+        "MSWEA_SILENT_STARTUP": "1",
+        "MSWEA_MODEL_RETRY_STOP_AFTER_ATTEMPT": "1",
+        "LITELLM_LOG": "ERROR",
+        "MODAL_SWE_TASKS_DIR": f"{SWEBENCH_PRO_PATH}/tasks",
+        "MODAL_SWE_SANDBOX_APP": "glm5-2-nvfp4-swebench-pro-sandbox",
+        "MODAL_SWE_MAX_STEPS": "256",
+        "MODAL_SWE_EPISODE_TIMEOUT": "7200",
+        "MODAL_SWE_MODEL_REQUEST_TIMEOUT": "1800",
+        "MODAL_SWE_EXEC_TIMEOUT": "120",
+        "MODAL_SWE_OUTPUT_HARD_LIMIT_BYTES": str(16 * 1024 * 1024),
+        "MODAL_SWE_SETUP_TIMEOUT": "600",
+        "MODAL_SWE_VERIFY_TIMEOUT": "3600",
+        "MODAL_SWE_INJECT_PYTEST_REPORTER": "0",
+        "MODAL_SWE_CPUS": "2",
+        "MODAL_SWE_MEMORY_MIB": "16384",
+        "MODAL_SWE_AGENT_PROCESSES": "48",
+        "MODAL_SWE_AGENT_THREADS_PER_PROCESS": "16",
+        **NVFP4_TRAINING_ENV,
     }
 
     def prepare_data(self) -> None:
-        from datasets import load_dataset
+        prepare_swebench_pro(SWEBENCH_PRO_PATH)
 
-        ds = load_dataset("BytedTsinghua-SIA/DAPO-Math-17k", split="train")
-        ds = ds.shuffle(seed=42).select(range(min(50000, ds.num_rows)))
-        ds = ds.map(lambda ex: {"label": ex["reward_model"]["ground_truth"]})
-        ds = ds.select_columns(["prompt", "label"])
-        ds.to_json(f"{DATA_PATH}/dapo-math-17k/dapo-math-17k.jsonl")
-
-
-# TODO(glm5.2) — still to confirm before a real run:
-#  1. Parsers: glm45/glm47 vs a future GLM-5.2-specific parser.
-#  2. Size the trainer to 744B-A40B / 78 layers: actor_num_nodes + TP/PP/CP/EP +
-#     decoder_last_pipeline_num_layers + memory / ephemeral disk (values above are
-#     Kimi's ~1T/128-GPU layout as a starting point).
 
 miles = _Miles()

--- a/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch
+++ b/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch
@@ -1,0 +1,119 @@
+diff --git a/megatron/core/dist_checkpointing/dict_utils.py b/megatron/core/dist_checkpointing/dict_utils.py
+index 1af4ae8..9a17f52 100644
+--- a/megatron/core/dist_checkpointing/dict_utils.py
++++ b/megatron/core/dist_checkpointing/dict_utils.py
+@@ -261,6 +261,42 @@ def merge(x1: Union[dict, list], x2: Union[dict, list], key: Tuple[Union[str, in
+     return x1
+ 
+ 
++def merge_local_nonpersistent_values(
++    persistent: Union[dict, list, U], local: Union[dict, list, U]
++) -> Union[dict, list, U]:
++    """Overlay locally reconstructed values onto loaded persistent state.
++
++    ``LocalNonpersistentObject`` declares that the value supplied by the load
++    template is authoritative. This also applies when a value that is local in
++    the current schema was persisted by an older checkpoint. In that case the
++    local container shape is authoritative, while unrelated persistent values
++    in overlapping dictionaries are preserved.
++    """
++    if isinstance(persistent, dict) and isinstance(local, dict):
++        for key, local_value in local.items():
++            if key in persistent:
++                persistent[key] = merge_local_nonpersistent_values(
++                    persistent[key], local_value
++                )
++            else:
++                persistent[key] = local_value
++        return persistent
++
++    if isinstance(persistent, list) and isinstance(local, list):
++        common_length = min(len(persistent), len(local))
++        for index in range(common_length):
++            persistent[index] = merge_local_nonpersistent_values(
++                persistent[index], local[index]
++            )
++        if len(persistent) > len(local):
++            del persistent[len(local) :]
++        elif len(persistent) < len(local):
++            persistent.extend(local[len(persistent) :])
++        return persistent
++
++    return local
++
++
+ def map_reduce(
+     xs: Iterable,
+     key_fn: Callable = lambda x: x,
+diff --git a/megatron/core/dist_checkpointing/serialization.py b/megatron/core/dist_checkpointing/serialization.py
+index a8ee87d..ad2f9df 100644
+--- a/megatron/core/dist_checkpointing/serialization.py
++++ b/megatron/core/dist_checkpointing/serialization.py
+@@ -19,7 +19,11 @@ from megatron.core.utils import log_single_rank
+ 
+ from . import ShardedTensor
+ from .core import CheckpointingConfig, save_config
+-from .dict_utils import extract_matching_values, merge
++from .dict_utils import (
++    extract_matching_values,
++    merge,
++    merge_local_nonpersistent_values,
++)
+ from .mapping import (
+     CheckpointingException,
+     CommonStateDict,
+@@ -123,7 +127,7 @@ def load(
+     sharded_state_dict, nonpersistent_state_dict, sh_ten_factories = load_preprocess(
+         sharded_state_dict
+     )
+-    merge(common_state_dict, nonpersistent_state_dict)
++    merge_local_nonpersistent_values(common_state_dict, nonpersistent_state_dict)
+ 
+     # At this point we are only dealing with ShardedBase objects
+     sharded_state_dict, _ = extract_sharded_base(sharded_state_dict)
+diff --git a/megatron/core/optimizer/distrib_optimizer.py b/megatron/core/optimizer/distrib_optimizer.py
+index 058fb05..26d2cb0 100644
+--- a/megatron/core/optimizer/distrib_optimizer.py
++++ b/megatron/core/optimizer/distrib_optimizer.py
+@@ -869,7 +869,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
+             if len(steps) != 0:
+                 assert len(steps) == 1, f"steps: {steps}"
+                 step = torch.tensor(steps[0], dtype=torch.float32, device="cpu")
+-                for v in self.optimizer.state.values():
++                for v in state_dict_state.values():
+                     v["step"] = step.detach().clone()
+ 
+         # Optimizer.
+@@ -965,6 +965,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
+             sharded_model_param = self.optimizer.param_groups[group_index]["params"][group_order]
+             for k, v in tensors.items():
+                 if isinstance(self.optimizer, HybridDeviceOptimizer):
++                    if k == "step":
++                        continue
+                     if k == "param":
+                         k = "master_param"
+                     self.optimizer.state[sharded_model_param][k] = v
+@@ -980,6 +982,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
+             optim_state = self.optimizer.state[main_param]
+             dst_tensors = {"param": main_param, **optim_state}
+             for key in dst_tensors:
++                if isinstance(self.optimizer, HybridDeviceOptimizer) and key == "step":
++                    continue
+                 dst_tensors[key].copy_(tensors[key])
+ 
+     def get_parameter_state_dp_reshardable(self):
+@@ -1652,6 +1656,14 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
+                     # We add extra empty padding if necessary
+                     assert bucket_state, 'empty bucket encountered'
+ 
++                    # HybridDeviceOptimizer keeps a scalar step in every parameter state.
++                    # The canonical optimizer step is already checkpointed in param_groups,
++                    # so reconstruct per-parameter steps locally instead of treating this
++                    # DP-rank-dependent bucket structure as common checkpoint state.
++                    for tensors in bucket_state:
++                        if 'step' in tensors:
++                            tensors['step'] = LocalNonpersistentObject(tensors['step'])
++
+                     # Insert padding between parameter tensors to ensure full coverage as needed.
+                     all_pad_tensors = {}
+                     for i in range(-1, len(bucket_state)):


### PR DESCRIPTION
## Summary

- add the 16-node B300 GLM-5.2 mixed NVFP4/BF16 training recipe
- configure a 32-engine TP4 disaggregated rollout fleet with DFlash and R3
- align trainer, checkpoint export, and serving 4/6 quantization settings
- preserve HDO steps across reshardable distributed checkpoints
- connect the recipe to pinned SWE-bench Pro inputs and the fully asynchronous Miles fork

## Validation

- audited against the GLM-5.2 NVFP4 Miles reference and existing fully-async SWE configurations
- verified Tito affinity, DFlash verifier logprobs, and target-only routed-expert collection
- retained the embedded Megatron patch bytes exactly from PR #96