### PR TITLE
docs: describe GLM-5.2 training and profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,22 @@ recover without becoming part of the trainer's process lifecycle.
 ## Measured delta updates
 
 These single-update measurements use the pinned cookbook stack, 64 vCPUs, and
-element-wise deltas covering every checkpoint tensor. Remote transfer, delta
-generation, and one-time CPU destination initialization are excluded.
-Preparation runs while inference remains available; only activation pauses the
-engine.
+element-wise XOR deltas. Remote transfer, delta generation, and one-time CPU
+destination initialization are excluded. Preparation runs while inference
+remains available; only activation pauses the engine.
 
 | Model | TP | Canonical checkpoint | Preparation | Engine pause | Total update |
 | --- | ---: | --- | ---: | ---: | ---: |
 | GLM-4.5-Air FP8 | 4 | RAM | 41.2 s | 1.0 s | 42.2 s |
 | Kimi K2.6 NVFP4 | 4 | RAM | 55.6 s | 2.78 s | 58.4 s |
 | Kimi K2.6 NVFP4 | 4 | NVMe | 102.3 s | 2.76 s | 105.1 s |
-| GLM-5.2 NVFP4 | 4 | RAM | 59.3 s | 2.14 s | 61.5 s |
+| GLM-5.2 all-NVFP4 checkpoint | 4 | RAM | 59.3 s | 2.14 s | 61.5 s |
+| GLM-5.2 mixed NVFP4/BF16 | 4 | RAM | 86.2 s | 3.01 s | 89.2 s |
 | Kimi K3 MXFP4 | 8 | RAM | 122.3 s | 3.82 s | 126.1 s |
 | Kimi K3 MXFP4 | 8 | NVMe | 283.8 s | 3.79 s | 287.5 s |
+
+The mixed GLM-5.2 profile changes 0.375% of rollout-visible NVFP4 values and
+1% of BF16 values; its compressed delta is 10.06 GB.
 
 Each profiler reconstructs and checksums the complete target and validates
 generation before, during, and after activation. See

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -41,7 +41,7 @@ All persistent storage uses Modal Volume v2:
 | --- | --- | --- |
 | `huggingface-cache` | `/root/.cache/huggingface` | Pinned source-model downloads |
 | `miles-checkpoints` or `slime-checkpoints` | `/checkpoints` | Immutable prepared model layouts |
-| `miles-data` or `slime-data` | `/data` | Immutable dataset revisions |
+| `miles-data` or `slime-data` | `/data` | Pinned datasets |
 | `stitch-<framework>-<model>` | `/stitch` | Run-scoped publications, checkpoints, and logs |
 | `sglang-cache` | `/root/.cache/sglang` | Compiled SGLang kernels |
 | Configured draft Volume | `/draft` | Optional external speculative draft |
@@ -72,17 +72,15 @@ pointer. A future checkpoint resume starts a new run and reads the previous
 run's `checkpoints/` rather than appending to its update chain.
 
 Datasets are independent of models and runs. Miles mounts the shared
-`miles-data` Volume at `/data`; Slime uses `slime-data`. Each immutable dataset
-revision has its own directory:
+`miles-data` Volume at `/data`; Slime uses `slime-data`. Each dataset has a
+stable directory; `manifest.json` records its pinned source revision.
 
 ```text
 /data/
-└── datasets/
-    └── <dataset>/
-        └── <revision>/
-            ├── manifest.json
-            ├── <trainer-input>
-            └── <dataset-specific-assets>/
+└── <dataset>/
+    ├── manifest.json
+    ├── <trainer-input>
+    └── <dataset-specific-assets>/
 ```
 
 Miles:
@@ -133,7 +131,8 @@ uv run --extra modal python -m cookbook.common.smoke \
 
 ## Profile an update
 
-The model profilers support `--update-mode disk|cpu`:
+The model profilers prepare their pinned base checkpoint and synthetic delta,
+then run with `--update-mode disk|cpu`:
 
 ```bash
 uv run --extra modal modal run -d \
@@ -141,8 +140,9 @@ uv run --extra modal modal run -d \
   --update-mode cpu
 ```
 
-They generate during staging, pause the engine to activate the target, validate
-the new version, and report timing and resource use. SGLang rejects
+Prepared artifacts are reused. The profilers generate during staging, pause
+the engine to activate the target, validate the new version, and report timing
+and resource use. SGLang rejects
 logprob-returning requests when DFlash or DSPARK is enabled, so those profiles
 compare repeated deterministic text instead of token IDs and logprobs.
 

--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -135,6 +135,10 @@ CPU mode keeps rank-ready images in RAM for the shortest commit:
 Stitch starts step 1 in the background. A published delta waits for that same
 initialization task; it does not start a second cache build. An initialization
 or staging failure is reported and the GPU remains on its prior weights.
+Registering a model-sized rank image as CUDA host memory is also one-time work,
+but can delay active inference on very large models. Initialize the CPU
+destination before routing latency-sensitive traffic when warmup latency
+matters.
 
 CPU mode is delta-only. It rejects FULL publications and cannot reset a patched
 live replica to another run’s v0; the controller must use disk mode or replace
@@ -186,11 +190,12 @@ Measured component sizes are:
 | --- | ---: | ---: | ---: |
 | GLM-4.5-Air FP8 | 4 | 112.6 GB | 27.2 GB × 4 |
 | Kimi K2.6 NVFP4 | 4 | about 595 GB | about 151 GB × 4 |
+| GLM-5.2 mixed NVFP4/BF16 | 4 | 617.6 GB | 156.3 GB × 4 |
 | Kimi K3 MXFP4 | 8 | 1.561 TB | 207.5 GB × 8 |
 
 Allow additional memory for the engine process, delta decoding, and bounded
-loader staging. The supplied recipes request `(512 GiB, 2 TiB)` for GLM and
-`(1 TiB, 3 TiB)` for Kimi K2.6 and Kimi K3, expressed as
+loader staging. The supplied GLM-4.5 recipe requests `(512 GiB, 2 TiB)`;
+GLM-5.2, Kimi K2.6, and Kimi K3 request `(1 TiB, 3 TiB)`, expressed as
 `(request, limit)`.
 
 All runtime storages are prepared and committed. Element-wise sparsity only

--- a/cookbook/miles_disagg/MILES_FORK.md
+++ b/cookbook/miles_disagg/MILES_FORK.md
@@ -1,14 +1,18 @@
-# Miles fork
+# Miles forks
 
-Stitch’s Miles recipes pin a small fork for opaque rollout-fleet routing and
-canonical disk-delta publication. [`trainer_image.py`](trainer_image.py) is the
-executable source of truth:
+Stitch’s Miles recipes use a dated trainer image and an immutable Miles commit.
+[`trainer_image.py`](trainer_image.py) defines the default:
 
 ```python
-MILES_IMAGE_TAG = "radixark/miles:dev-202607260602"
+MILES_IMAGE_TAG = "radixark/miles:dev-202607290235"
 MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
 MILES_REPO_REF = "1eb7520018446cb94b7406715f66dff1a271b53b"
 ```
+
+An experiment config may override `MILES_REPO_REF` without changing other
+recipes. GLM-5.2 does this because it runs on Miles’ fully-async SWE branch.
+
+## Standard weight-sync branch
 
 The branch `stitch-weight-sync-v0516` is upstream `radixark/miles` main at
 `52403d0e3` plus six commits:
@@ -22,9 +26,25 @@ The branch `stitch-weight-sync-v0516` is upstream `radixark/miles` main at
 | `d814b87c3` | Replace the unused delta progress bar with an explicit baseline-snapshot log. |
 | `1eb752001` | Honor ModelOpt glob exclusions when exporting NVFP4 weights. |
 
-The dated base image supplies Megatron-LM, TransformerEngine, CUDA, and the
-other compiled dependencies. The fork is installed over it with `--no-deps`;
-therefore the image and the upstream Miles revision must remain compatible.
+## GLM-5.2 fully-async SWE branch
+
+`glm5_2_nvfp4.py` pins `stitch-miles-fully-async-swe` at `7cdfcf78c8f7`. The
+branch is `modal/feat/modal-swe-fully-async` at `b6c8286de` plus:
+
+| Commit | Responsibility |
+| --- | --- |
+| `32dd379cc` | Format the fully-async files touched by the integration. |
+| `78c22109d` | Route session rollouts through one external fleet endpoint with request gating and finite timeouts. |
+| `f32272102` | Publish disk deltas without Miles-managed rollout-engine handles. |
+| `c17cadee6` | Match GLM-5.2 router tensor dtypes to the canonical checkpoint. |
+| `7cdfcf78c` | Encode zero-dimensional checkpoint tensors safely. |
+
+This branch is additive and only backs the GLM-5.2 fully-async experiment. It
+does not replace the standard recipe pin.
+
+The dated image supplies Megatron-LM, TransformerEngine, CUDA, and other
+compiled dependencies. Miles is installed over it with `--no-deps`, so the
+image and Miles revision must remain compatible.
 
 ## Responsibilities
 
@@ -48,11 +68,10 @@ layouts as the base checkpoint.
 
 ## Re-porting
 
-When updating Miles:
+When updating a Miles pin:
 
-1. create a new branch from the desired `radixark/miles` main;
-2. reapply the six responsibilities separately, dropping code already
-   available upstream;
+1. start from the intended upstream branch;
+2. reapply only the responsibilities still missing upstream;
 3. keep canonical checkpoint layout changes scoped to `disk-delta`;
 4. use a dated Miles image whose Megatron and TransformerEngine match that
    upstream revision;


### PR DESCRIPTION
## Summary

- document the GLM-5.2 mixed NVFP4/BF16 measurements and memory footprint
- describe stable dataset storage and self-contained profiler behavior
- record the experiment-specific fully asynchronous Miles fork
- clarify large-model CPU-cache initialization behavior

## Validation

- documentation is the final layer of the split series
- aggregate tree is verified against PR #96 before review