### PR TITLE
cookbook: preserve HDO checkpoint state in every trainer

### DIFF
--- a/cookbook/miles_disagg/configs/glm45_air_bf16.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16.py
@@ -23,7 +23,8 @@ SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 SGLANG_DELTA_UPDATE_MODE = "cpu"
 MEGATRON_RUNTIME_PATCHES = [
-    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
 ]
 
 

--- a/cookbook/miles_disagg/configs/glm45_air_fp8.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8.py
@@ -31,7 +31,8 @@ DISABLE_HF_XET = True
 DISABLE_HF_TRANSFER = True
 
 MEGATRON_RUNTIME_PATCHES = [
-    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
 ]
 
 SGLANG_SERVER_ARGS = {

--- a/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
@@ -25,6 +25,7 @@ SGLANG_DELTA_UPDATE_MODE = "cpu"
 # R3 routing-replay needs the dropless Megatron dispatch fix at startup.
 MEGATRON_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
 ]
 
 

--- a/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
@@ -26,6 +26,7 @@ SGLANG_DELTA_UPDATE_MODE = "cpu"
 # R3 routing-replay needs the dropless Megatron dispatch fix at startup.
 MEGATRON_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
 ]
 
 

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4.py
@@ -24,6 +24,7 @@ SGLANG_DELTA_UPDATE_MODE = "cpu"
 # R3 routing-replay needs the dropless Megatron dispatch fix at startup.
 MEGATRON_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
 ]
 
 

--- a/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
+++ b/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
@@ -57,6 +57,7 @@ SGLANG_DELTA_UPDATE_MODE = "cpu"
 # R3 routing-replay needs the dropless Megatron dispatch fix at startup.
 MEGATRON_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
 ]
 
 # ── Trainer/sampler 4/6 + NVFP4 quantizer contract ────────────────────────────


### PR DESCRIPTION
## Summary

- apply the DP-reshardable HybridDeviceOptimizer checkpoint fix in every Miles training recipe
- retain the R3 dispatch patch for recipes using the default all-to-all dispatcher
- leave GLM-5.2 on only the HDO patch because it explicitly uses Flex/DeepEP
- leave the serving-only Kimi K3 configuration unchanged

## Validation

- applied the R3 and HDO patches together against `radixark/miles:dev-202607290235` in a clean container
- `uv run ruff check cookbook/miles_disagg/configs`
- `uv run ruff format --check cookbook/miles_disagg/configs`
- `uv run pytest -q cookbook/miles_disagg/swebench_pro_test.py cookbook/common/hooks_test.py` — 13 passed