### PR TITLE
cookbook: preserve HDO checkpoint state in every trainer

### DIFF
--- a/cookbook/miles_disagg/configs/glm45_air_bf16.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16.py
@@ -23,7 +23,8 @@ SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 SGLANG_DELTA_UPDATE_MODE = "cpu"
 MEGATRON_RUNTIME_PATCHES = [
-    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
 ]
 
 

--- a/cookbook/miles_disagg/configs/glm45_air_fp8.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8.py
@@ -29,7 +29,8 @@ DISABLE_HF_XET = True
 DISABLE_HF_TRANSFER = True
 
 MEGATRON_RUNTIME_PATCHES = [
-    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch"
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
 ]
 
 SGLANG_SERVER_ARGS = {

--- a/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
@@ -25,6 +25,7 @@ SGLANG_DELTA_UPDATE_MODE = "cpu"
 # R3 routing-replay needs the dropless Megatron dispatch fix at startup.
 MEGATRON_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
 ]
 
 

--- a/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
@@ -25,6 +25,7 @@ SGLANG_DELTA_UPDATE_MODE = "cpu"
 # R3 routing-replay needs the dropless Megatron dispatch fix at startup.
 MEGATRON_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
 ]
 
 

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4.py
@@ -24,6 +24,7 @@ SGLANG_DELTA_UPDATE_MODE = "cpu"
 # R3 routing-replay needs the dropless Megatron dispatch fix at startup.
 MEGATRON_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
 ]
 
 

--- a/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
+++ b/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
@@ -57,6 +57,7 @@ SGLANG_DELTA_UPDATE_MODE = "cpu"
 # R3 routing-replay needs the dropless Megatron dispatch fix at startup.
 MEGATRON_RUNTIME_PATCHES = [
     "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    "/root/cookbook/miles_disagg/patches/megatron-hdo-dp-reshardable-step.patch",
 ]
 
 # ── Trainer/sampler 4/6 + NVFP4 quantizer contract ────────────────────────────


### PR DESCRIPTION
## Summary

Apply the HDO data-parallel reshardable-step patch to every Miles training recipe while retaining the R3 dispatch patch for recipes that use all-to-all routing replay.

Targets `main` directly. Merge after the GLM-5.2 recipe PR, which adds the shared HDO patch file.

## Validation

Validated as part of the exact aggregate tree: Ruff clean and 88 tests passed. The HDO and R3 patches apply together to the pinned Miles trainer image.
