### PR TITLE
cookbook: update fully async Miles pin

### DIFF
--- a/cookbook/miles_disagg/MILES_FORK.md
+++ b/cookbook/miles_disagg/MILES_FORK.md
@@ -28,16 +28,16 @@ The branch `stitch-weight-sync-v0516` is upstream `radixark/miles` main at
 
 ## GLM-5.2 fully-async SWE branch
 
-`glm5_2_nvfp4.py` pins `stitch-miles-fully-async-swe` at `7cdfcf78c8f7`. The
-branch is `modal/feat/modal-swe-fully-async` at `b6c8286de` plus:
+`glm5_2_nvfp4.py` pins `stitch-miles-fully-async-swe` at `66bb7b767e4d`. The
+branch is `modal/feat/modal-swe-fully-async` at `be7364f9a` plus:
 
 | Commit | Responsibility |
 | --- | --- |
-| `32dd379cc` | Format the fully-async files touched by the integration. |
-| `78c22109d` | Route session rollouts through one external fleet endpoint with request gating and finite timeouts. |
-| `f32272102` | Publish disk deltas without Miles-managed rollout-engine handles. |
-| `c17cadee6` | Match GLM-5.2 router tensor dtypes to the canonical checkpoint. |
-| `7cdfcf78c` | Encode zero-dimensional checkpoint tensors safely. |
+| `54b673970` | Format the fully-async files touched by the integration. |
+| `70ff3ce73` | Route session rollouts through one external fleet endpoint with request gating and finite timeouts. |
+| `46acd47fa` | Publish disk deltas without Miles-managed rollout-engine handles. |
+| `dca03cbba` | Match GLM-5.2 router tensor dtypes to the canonical checkpoint. |
+| `66bb7b767` | Encode zero-dimensional checkpoint tensors safely. |
 
 This branch is additive and only backs the GLM-5.2 fully-async experiment. It
 does not replace the standard recipe pin.

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -11,7 +11,7 @@ APP_NAME = "stitch-glm5-2-nvfp4"
 EXPERIMENT_VOLUME_NAME = "stitch-miles-glm5-2-nvfp4"
 # This experiment layers Stitch integration onto Miles' fully-async SWE runtime.
 # Other cookbook experiments keep the standard Miles pin in trainer_image.py.
-MILES_REPO_REF = "7cdfcf78c8f7ab3f2111dafe9881aa99b716a0c5"
+MILES_REPO_REF = "66bb7b767e4dd39417b3d34a039a2be1cdc19780"
 LOCAL_CHECKPOINT_PATH = None
 TRAINER_EXTRA_PIP_PACKAGES = (
     "harbor[modal,huggingface]==0.20.0",


### PR DESCRIPTION
## Summary

- advance the GLM-5.2 fully-async recipe to the rewritten `stitch-miles-fully-async-swe` head
- refresh the Miles fork ledger with the new base and rewritten Stitch commit SHAs

## Why

The Miles branch history was rebuilt to include its updated Modal SWE sandbox setup-readiness behavior. The five Stitch integration commits remain patch-identical, but their immutable SHAs changed, so the cookbook pin and fork ledger must move together.

## Impact

Future GLM-5.2 trainer images clone the current fully-async Miles branch. Other Miles recipes retain the standard weight-sync pin.

## Validation

- `uv run ruff check cookbook/miles_disagg/configs/glm5_2_nvfp4.py`
- `uv run pytest -q` (89 passed)
- verified `modal==1.5.1` exposes `Probe.with_exec`, `Sandbox._experimental_create`, and `Sandbox.wait_until_ready`