### PR TITLE
cookbook: refresh fully async Miles pin

### DIFF
--- a/cookbook/miles_disagg/MILES_FORK.md
+++ b/cookbook/miles_disagg/MILES_FORK.md
@@ -28,16 +28,16 @@ The branch `stitch-weight-sync-v0516` is upstream `radixark/miles` main at
 
 ## GLM-5.2 fully-async SWE branch
 
-`glm5_2_nvfp4.py` pins `stitch-miles-fully-async-swe` at `66bb7b767e4d`. The
-branch is `modal/feat/modal-swe-fully-async` at `be7364f9a` plus:
+`glm5_2_nvfp4.py` pins `stitch-miles-fully-async-swe` at `2879896c0322`. The
+branch is `modal/feat/modal-swe-fully-async` at `5c71d12dd` plus:
 
 | Commit | Responsibility |
 | --- | --- |
-| `54b673970` | Format the fully-async files touched by the integration. |
-| `70ff3ce73` | Route session rollouts through one external fleet endpoint with request gating and finite timeouts. |
-| `46acd47fa` | Publish disk deltas without Miles-managed rollout-engine handles. |
-| `dca03cbba` | Match GLM-5.2 router tensor dtypes to the canonical checkpoint. |
-| `66bb7b767` | Encode zero-dimensional checkpoint tensors safely. |
+| `b4217c624` | Format the fully-async files touched by the integration. |
+| `13657f774` | Route session rollouts through one external fleet endpoint with request gating and finite timeouts. |
+| `495d65b92` | Publish disk deltas without Miles-managed rollout-engine handles. |
+| `1b5f67b81` | Match GLM-5.2 router tensor dtypes to the canonical checkpoint. |
+| `2879896c0` | Encode zero-dimensional checkpoint tensors safely. |
 
 This branch is additive and only backs the GLM-5.2 fully-async experiment. It
 does not replace the standard recipe pin.

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -11,7 +11,7 @@ APP_NAME = "stitch-glm5-2-nvfp4"
 EXPERIMENT_VOLUME_NAME = "stitch-miles-glm5-2-nvfp4"
 # This experiment layers Stitch integration onto Miles' fully-async SWE runtime.
 # Other cookbook experiments keep the standard Miles pin in trainer_image.py.
-MILES_REPO_REF = "66bb7b767e4dd39417b3d34a039a2be1cdc19780"
+MILES_REPO_REF = "2879896c0322c212be773aa8e43f88d02726b51b"
 LOCAL_CHECKPOINT_PATH = None
 TRAINER_EXTRA_PIP_PACKAGES = (
     "harbor[modal,huggingface]==0.20.0",


### PR DESCRIPTION
## Summary

- advance the GLM-5.2 fully-async recipe to the latest rewritten `stitch-miles-fully-async-swe` head
- refresh the Miles fork ledger with the new base and rewritten Stitch commit SHAs

## Why

The Miles branch was rebuilt on a newer fully-async SWE base. That base now creates the shared Sandbox app once in the rollout-manager process, has workers perform lookup-only access, uses the public `Sandbox.create` API, and makes cleanup idempotent and observable. The five Stitch integration commits remain patch-identical, but their immutable SHAs changed.

## Impact

The next GLM-5.2 trainer image will use Miles at `2879896c0322`. Other Miles recipes retain the standard weight-sync pin. The existing `modal==1.5.1` recipe dependency supports the required Sandbox and App lookup APIs.

## Validation

- `uv run ruff check cookbook/miles_disagg/configs/glm5_2_nvfp4.py`
- `uv run pytest -q` (89 passed)
- verified `modal==1.5.1` provides `Sandbox.create` and `App.lookup(..., create_if_missing=...)`