### PR TITLE
feat: route rollout traffic through a session-routing LB

### DIFF
--- a/cookbook/common/config.py
+++ b/cookbook/common/config.py
@@ -9,13 +9,18 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-GPUType = Literal["H100", "H200", "B200", "B300", "A100"]
+# ``"X+"`` is Modal's tier floor: that class or better (e.g. "B200+" = B200 or B300).
+GPUType = Literal["H100", "H200", "B200", "B200+", "B300", "A100"]
 
 
 class ModalConfig:
     """Modal infrastructure: GPU model, region, rollout-pool sizing, prep topology."""
 
     gpu: GPUType = "B200"
+    # Rollout-pool GPU; defaults to ``gpu``. Either a single type or a list of
+    # acceptable types in preference order (Modal falls back down the list) — e.g.
+    # ["B200", "B300"] schedules engines on whichever pool has capacity.
+    rollout_gpu: GPUType | list[GPUType] | None = None
     trainer_memory_mib: tuple[int, int] | None = None
     cloud: str | None = None
     region: str | None = None
@@ -27,6 +32,11 @@ class ModalConfig:
     # containers instead of packing requests until KV saturates.
     rollout_target_inputs: int | None = None
     routing_region: str = "us-east"
+    # Session-routing LB deployed alongside the pool (cookbook/common/router.py):
+    # registry replica floor, proxy replica floor, and the proxy's autoscale target.
+    router_registry_min_containers: int = 2
+    router_min_containers: int = 2
+    router_target_concurrency: int = 50
     rollout_ephemeral_disk_mib: int | None = None
     rollout_memory_mib: tuple[int, int] | None = None
     torch_dist_prep_nodes: int = 2
@@ -38,3 +48,11 @@ class ModalConfig:
     def __init__(self, **kwargs: Any) -> None:
         for k, v in kwargs.items():
             setattr(self, k, v)
+
+    def rollout_gpus(self, per_engine: int) -> str | list[str]:
+        """GPU request for one rollout engine: ``rollout_gpu`` falling back to ``gpu``,
+        with the per-engine count attached (a list when multiple types are acceptable)."""
+        spec = self.gpu if self.rollout_gpu is None else self.rollout_gpu
+        if isinstance(spec, str):
+            return f"{spec}:{per_engine}"
+        return [f"{gpu_type}:{per_engine}" for gpu_type in spec]

--- a/cookbook/common/launch.py
+++ b/cookbook/common/launch.py
@@ -61,12 +61,13 @@ def materialize_node_local_yaml(
 def deploy_pool_and_spawn(run: Any) -> None:
     """The shared body of a recipe's ``launch`` entrypoint: deploy this run's pool, block until its
     gateway is healthy, then spawn training. ``run`` is the recipe's ``app`` module (its ``app`` /
-    ``APP_NAME`` / ``spawn_train``)."""
-    from stitch.pools.modal_flash import ModalFlashPool
+    ``APP_NAME`` / ``spawn_train``). Readiness rides the session-routing LB gateway, so the
+    check validates the whole traffic path (router + pool), not just the pool."""
+    from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
     from stitch.service import await_pool_ready
 
     run.app.deploy()
-    await_pool_ready(ModalFlashPool(run.APP_NAME, "Server"))
+    await_pool_ready(ModalFlashLBPool(run.APP_NAME, "Server"))
     run.spawn_train()
     print(
         f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; stop it with: modal app stop {run.APP_NAME}"

--- a/cookbook/common/router.py
+++ b/cookbook/common/router.py
@@ -1,0 +1,614 @@
+"""Session-affinity load-balancing router for the rollout pool.
+
+A run-scoped fork of the flash-smart-router (github.com/modal-labs/flash-smart-router),
+folded into the run's own Modal app: each recipe deploys a ``RouterRegistry`` and a
+``Router`` Flash server class next to its GPU ``Server`` (thin module-level classes whose
+lifecycle delegates here, exactly like ``common.server`` does for sglang). One app, one
+deploy, one stop — the router scales and dies with the pool.
+
+Why it exists: with a per-container queue bound (sglang ``--max-queued-requests``), Flash's
+own sticky routing turns the first saturated replicas into 503 attractors — sessions stuck
+on a full replica keep retrying it while the rest of the pool starves. Here, the registry
+polls every replica's live queue depth (``/v1/loads`` + a ``/health`` zombie check); the
+router pins each ``modal-session-id`` to the least-loaded healthy replica via the
+``modal-flash-upstream`` header, and a 503 from a pinned replica evicts it from rotation and
+retries on a healthier one, so load spreads instead of sticking.
+
+Deltas from the upstream router: no proxy-auth/api-key secret plumbing (cookbook pools are
+``unauthenticated``), replica discovery reuses ``modal.experimental.flash_get_containers``
+(the same call ``ModalFlashPool`` makes), stdlib logging, and startup tolerates the sibling
+classes still cold-booting (single-app deploys have no boot ordering) instead of dying on
+the first failed poll. The legacy-tuple session-route migration is dropped — per-run route
+dicts start empty.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import math
+import random
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, AsyncGenerator, Generator
+
+import httpx
+import modal
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import StreamingResponse
+from modal._utils.async_utils import synchronize_api
+from pydantic import BaseModel, TypeAdapter
+
+logger = logging.getLogger(__name__)
+
+SESSION_ROUTE_TTL_SECONDS = 4 * 60 * 60
+SESSION_ROUTE_IMBALANCE_THRESHOLD = 0.5
+SESSION_ROUTE_OVERLOAD_FLOOR = 3
+SESSION_ROUTE_MAX_UPSTREAMS = 10
+
+CONTAINER_POLL_INTERVAL_SECONDS = 1.0
+CONTAINER_POLL_TIMEOUT_SECONDS = 3.0
+
+MAX_SESSION_RETRIES = 3
+
+_COOKBOOK_DIR = Path(__file__).resolve().parent.parent
+
+
+def build_router_image(experiment: str, run_id: str) -> modal.Image:
+    """CPU image for the router classes. Like the serving image, it bakes the run
+    coordinates and carries the cookbook + stitch sources, so a container's re-import of
+    the recipe app module rebuilds the same app name and class wiring."""
+    return (
+        modal.Image.debian_slim()
+        .pip_install("fastapi", "httpx", "pydantic", "uvicorn")
+        .env({"EXPERIMENT_CONFIG": experiment, "RUN_ID": run_id})
+        .add_local_python_source("stitch")
+        .add_local_dir(
+            str(_COOKBOOK_DIR), remote_path="/root/cookbook", ignore=["**/__pycache__"]
+        )
+    )
+
+
+def session_routes_dict(app_name: str) -> modal.Dict:
+    """The run's session→replica affinity store, namespaced to the run app."""
+    return modal.Dict.from_name(f"{app_name}-session-routes", create_if_missing=True)
+
+
+async def _list_flash_containers_rpc(app_name: str, cls_name: str) -> list[Any]:
+    from modal.client import _Client
+    from modal.config import config
+    from modal_proto import api_pb2
+
+    client = await _Client.from_env()
+    fn = await client.stub.FunctionGet(
+        api_pb2.FunctionGetRequest(
+            app_name=app_name,
+            object_tag=cls_name,
+            environment_name=config.get("environment") or "",
+        )
+    )
+    resp = await client.stub.FlashContainerList(
+        api_pb2.FlashContainerListRequest(function_id=fn.function_id)
+    )
+    return list(resp.containers)
+
+
+_list_flash_containers_synchronized = synchronize_api(_list_flash_containers_rpc)
+
+
+async def _list_flash_containers(app_name: str, cls_name: str) -> list[Any]:
+    """Live flash containers of an ``@app.server`` class.
+
+    Deliberately not ``modal.experimental.flash_get_containers``: that helper hydrates
+    the class *service-function* tag ``<Cls>.*``, which ``@app.server`` classes don't
+    register — their web function is the plain ``<Cls>`` tag (confirmed by probe:
+    ``FunctionGet('Server')`` resolves while ``'Server.*'`` 404s). Do the two-step the
+    flash-smart-router does: plain-tag FunctionGet, then FlashContainerList by id — and
+    ride the SDK's synchronicity wrapper: a raw ``client.stub`` await on the uvicorn
+    loop never gets its responses pumped (the registry's startup hung on it until
+    Modal restarted the container — a silent crash loop).
+    """
+    return await _list_flash_containers_synchronized.aio(app_name, cls_name)
+
+
+# ── routing state ────────────────────────────────────────────────────────────
+
+
+class ContainerInfo(BaseModel):
+    task_id: str
+    upstream: str  # host:port of the replica
+    load: int  # queued + running requests, last successful poll
+
+
+ContainerInfoList = TypeAdapter(list[ContainerInfo])
+
+
+class RouteEntry(BaseModel):
+    task_id: str
+    last_sent: float
+
+
+RouteEntryList = TypeAdapter(list[RouteEntry])
+
+
+def _container_addr(container: Any) -> str | None:
+    """``host:port`` for a flash container (proto or dict), tolerating a host that
+    already carries its port (the shape ``ModalFlashPool`` reads)."""
+    if isinstance(container, dict):
+        host, port = container.get("host"), container.get("port")
+    else:
+        host, port = getattr(container, "host", None), getattr(container, "port", None)
+    if not host:
+        return None
+    host = str(host).rstrip("/")
+    if ":" in host or not port:
+        return host
+    return f"{host}:{port}"
+
+
+def filter_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Drop hop-by-hop and Modal-routing headers before forwarding upstream."""
+    removed = {
+        "content-length",
+        "host",
+        "modal-flash-upstream",
+        "modal-key",
+        "modal-secret",
+        "modal-session-id",
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-port",
+        "x-forwarded-prefix",
+        "x-forwarded-proto",
+        "x-forwarded-server",
+    }
+    return {k: v for k, v in headers.items() if k.lower() not in removed}
+
+
+def select_least_loaded_container(
+    containers: dict[str, ContainerInfo],
+) -> ContainerInfo:
+    minimum = min(c.load for c in containers.values())
+    return random.choice([c for c in containers.values() if c.load == minimum])
+
+
+async def route_session(
+    session_routes: modal.Dict, session_id: str, containers: dict[str, ContainerInfo]
+) -> ContainerInfo:
+    """Pick the replica for one session: the most-recently-used of its known replicas
+    that isn't overloaded, else the pool's least-loaded. A replica is overloaded when its
+    load is ≥50% above the pool's mean (floored), so a hot replica sheds new session
+    traffic without a hard capacity number. Mutates and persists the session's routes."""
+    current_time = time.time()
+
+    routes: list[RouteEntry] = RouteEntryList.validate_python(
+        await session_routes.get.aio(session_id, [])
+    )
+    # Drop expired routes and replicas this pod hasn't discovered (they may just be
+    # new; every session lands on some pod's view, so this only trims the dead).
+    routes = [
+        entry
+        for entry in routes
+        if current_time - entry.last_sent <= SESSION_ROUTE_TTL_SECONDS
+        and entry.task_id in containers
+    ]
+    routes.sort(key=lambda entry: entry.last_sent, reverse=True)
+
+    overload_threshold = max(
+        math.ceil(
+            sum(c.load for c in containers.values())
+            / len(containers)
+            * (1 + SESSION_ROUTE_IMBALANCE_THRESHOLD)
+        ),
+        SESSION_ROUTE_OVERLOAD_FLOOR,
+    )
+
+    async def save_routes() -> None:
+        await session_routes.put.aio(
+            session_id,
+            RouteEntryList.dump_python(
+                routes[:SESSION_ROUTE_MAX_UPSTREAMS], mode="json"
+            ),
+        )
+
+    for entry in routes:
+        container = containers[entry.task_id]
+        if container.load < overload_threshold:
+            entry.last_sent = current_time
+            await save_routes()
+            return container
+
+    selected = select_least_loaded_container(containers)
+    reason = (
+        f"previous upstreams [{', '.join(entry.task_id for entry in routes)}] overloaded"
+        f" (load >= {overload_threshold})"
+        if routes
+        else "no previous upstream"
+    )
+    logger.info(
+        "session %s: %s; pinning new upstream %s (load %d)",
+        session_id,
+        reason,
+        selected.task_id,
+        selected.load,
+    )
+    routes.insert(0, RouteEntry(task_id=selected.task_id, last_sent=current_time))
+    await save_routes()
+    return selected
+
+
+# ── serving plumbing ─────────────────────────────────────────────────────────
+class _UvicornApp:
+    """Runs a FastAPI app (from ``build_app``) on a uvicorn server in a daemon thread."""
+
+    def build_app(self) -> Any:
+        raise NotImplementedError
+
+    def start(self) -> None:
+        import uvicorn
+
+        config = uvicorn.Config(
+            self.build_app(), host="0.0.0.0", port=8000, timeout_keep_alive=300
+        )
+        self.uvicorn_server = uvicorn.Server(config)
+        self.server_thread = threading.Thread(
+            target=self.uvicorn_server.run, daemon=True
+        )
+        self.server_thread.start()
+
+    def stop(self) -> None:
+        self.uvicorn_server.should_exit = True
+        self.server_thread.join()
+
+
+class _RequestCancelledMiddleware:
+    """Cancels the request handler (and so the upstream stream) on client disconnect."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> Any:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        queue: asyncio.Queue = asyncio.Queue()
+
+        async def message_poller(handler_task: asyncio.Task) -> None:
+            while True:
+                message = await receive()
+                if message["type"] == "http.disconnect":
+                    handler_task.cancel()
+                    return
+                await queue.put(message)
+
+        handler_task = asyncio.create_task(self.app(scope, queue.get, send))
+        asyncio.create_task(message_poller(handler_task))  # noqa: RUF006
+
+        try:
+            return await handler_task
+        except asyncio.CancelledError:
+            logger.info("cancelled request: client disconnected")
+            return None
+
+
+def serve_registry(replica: Any, *, app_name: str, upstream_cls: str) -> None:
+    """Start the load-registry server on a ``RouterRegistry`` container (@modal.enter)."""
+    registry = _RegistryApp(app_name=app_name, upstream_cls=upstream_cls)
+    registry.start()
+    replica._router_server = registry
+
+
+def serve_router(
+    replica: Any,
+    *,
+    registry_url: str,
+    upstream_url: str,
+    session_routes: modal.Dict,
+) -> None:
+    """Start the session-routing proxy on a ``Router`` container (@modal.enter)."""
+    router = _ProxyApp(
+        registry_url=registry_url,
+        upstream_url=upstream_url,
+        session_routes=session_routes,
+    )
+    router.start()
+    replica._router_server = router
+
+
+def stop_server(replica: Any) -> None:
+    """@modal.exit for either router class."""
+    server = getattr(replica, "_router_server", None)
+    if server is not None:
+        server.stop()
+
+
+class _RegistryApp(_UvicornApp):
+    """Polls upstream replicas for load and serves the snapshot at ``/loads``."""
+
+    def __init__(self, *, app_name: str, upstream_cls: str) -> None:
+        self.app_name = app_name
+        self.upstream_cls = upstream_cls
+        self.containers: list[ContainerInfo] = []
+
+    async def _container_load(self, upstream: str) -> int:
+        loads_response, health_response = await asyncio.gather(
+            self.client.get(f"https://{upstream}/v1/loads", params={"include": "core"}),
+            self.client.get(f"https://{upstream}/health"),
+        )
+        loads_response.raise_for_status()
+        health_response.raise_for_status()
+
+        loads = loads_response.json()["loads"]
+        queued = sum(int(load["num_waiting_reqs"]) for load in loads)
+        running = sum(int(load["num_running_reqs"]) for load in loads)
+        return queued + running
+
+    async def _poll_once(self) -> list[ContainerInfo]:
+        discovered = await _list_flash_containers(self.app_name, self.upstream_cls)
+        upstreams = {}
+        for container in discovered:
+            if isinstance(container, dict):
+                task_id = container.get("task_id")
+            else:
+                task_id = getattr(container, "task_id", None)
+            addr = _container_addr(container)
+            if task_id and addr:
+                upstreams[task_id] = addr
+        results = await asyncio.gather(
+            *(self._container_load(upstream) for upstream in upstreams.values()),
+            return_exceptions=True,
+        )
+        updated: list[ContainerInfo] = []
+        for (task_id, upstream), result in zip(upstreams.items(), results, strict=True):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "load poll failed for replica %s: %r; dropping from registry",
+                    task_id,
+                    result,
+                )
+                continue
+            updated.append(
+                ContainerInfo(task_id=task_id, upstream=upstream, load=result)
+            )
+        return updated
+
+    async def poll_containers(self) -> None:
+        await asyncio.sleep(CONTAINER_POLL_INTERVAL_SECONDS)
+        while True:
+            started_at = time.monotonic()
+            try:
+                self.containers = await self._poll_once()
+            except Exception:
+                logger.exception("failed to refresh replica loads")
+            elapsed = time.monotonic() - started_at
+            await asyncio.sleep(max(0, CONTAINER_POLL_INTERVAL_SECONDS - elapsed))
+
+    def build_app(self) -> Any:
+        fastapi_app = FastAPI()
+        self.client = httpx.AsyncClient(
+            transport=httpx.AsyncHTTPTransport(
+                retries=3,
+                limits=httpx.Limits(
+                    max_keepalive_connections=200,
+                    max_connections=200,
+                    keepalive_expiry=60,
+                ),
+            ),
+            follow_redirects=True,
+            timeout=CONTAINER_POLL_TIMEOUT_SECONDS,
+        )
+
+        @fastapi_app.on_event("startup")
+        async def startup() -> None:
+            # No network I/O in startup: bind immediately and let the poll loop fill
+            # in (~1s) — a hung startup RPC gets the container restarted by Modal
+            # before anything logs (siblings may still be cold-booting anyway).
+            self.poller_task = asyncio.create_task(self.poll_containers())
+            logger.info("registry startup complete")
+
+        @fastapi_app.on_event("shutdown")
+        async def shutdown() -> None:
+            self.poller_task.cancel()
+            await asyncio.gather(self.poller_task, return_exceptions=True)
+            await self.client.aclose()
+
+        @fastapi_app.get("/loads", response_model=list[ContainerInfo])
+        async def loads() -> list[ContainerInfo]:
+            return self.containers
+
+        return fastapi_app
+
+
+class _ProxyApp(_UvicornApp):
+    """Proxies requests to rollout replicas with session-affinity routing."""
+
+    def __init__(
+        self, *, registry_url: str, upstream_url: str, session_routes: modal.Dict
+    ) -> None:
+        self.registry_url = registry_url.rstrip("/")
+        self.upstream_url = upstream_url.rstrip("/")
+        self.session_routes = session_routes
+        self.containers: dict[str, ContainerInfo] = {}
+
+    @contextlib.contextmanager
+    def count_in_flight(self, container: ContainerInfo) -> Generator[None, None, None]:
+        container.load += 1
+        try:
+            yield
+        finally:
+            container.load = max(0, container.load - 1)
+
+    async def get_containers(self) -> dict[str, ContainerInfo]:
+        response = await self.client.get(f"{self.registry_url}/loads")
+        response.raise_for_status()
+        containers = ContainerInfoList.validate_json(response.content)
+        return {container.task_id: container for container in containers}
+
+    async def poll_containers(self) -> None:
+        await asyncio.sleep(CONTAINER_POLL_INTERVAL_SECONDS)
+        while True:
+            started_at = time.monotonic()
+            try:
+                self.containers = await self.get_containers()
+            except Exception:
+                logger.exception("failed to refresh replica loads from registry")
+            elapsed = time.monotonic() - started_at
+            await asyncio.sleep(max(0, CONTAINER_POLL_INTERVAL_SECONDS - elapsed))
+
+    async def upstream_stream(
+        self,
+        request: Any,
+        path: str,
+        headers: dict[str, str],
+        body: bytes,
+        container: ContainerInfo | None,
+        log_prefix: str,
+    ) -> AsyncGenerator[Any, None]:
+        maybe_count = (
+            self.count_in_flight(container) if container else contextlib.nullcontext()
+        )
+        async with self.client.stream(
+            url=f"{self.upstream_url}/{path}",
+            method=request.method,
+            params=request.query_params,
+            headers=headers,
+            content=body,
+            # Long read timeout: non-streaming completions send nothing until
+            # generation finishes. Connect should still fail fast.
+            timeout=httpx.Timeout(20 * 60, connect=10),
+        ) as response:
+            with maybe_count:
+                yield response  # first yield: caller inspects status/headers
+
+                start = time.perf_counter()
+                chunks = 0
+                try:
+                    async for chunk in response.aiter_raw():
+                        if chunk:
+                            yield chunk
+                            chunks += 1
+                    logger.info("%s completed request", log_prefix)
+                except asyncio.CancelledError:
+                    logger.info(
+                        "%s client disconnected after %d chunks, %.3fs",
+                        log_prefix,
+                        chunks,
+                        time.perf_counter() - start,
+                    )
+                    raise
+                except Exception as exc:
+                    logger.error(
+                        "%s error streaming response: %r after %d chunks, %.3fs",
+                        log_prefix,
+                        exc,
+                        chunks,
+                        time.perf_counter() - start,
+                    )
+                    raise  # the client must see an error, not a silent stream end
+
+    def build_app(self) -> Any:
+        self.client = httpx.AsyncClient(
+            transport=httpx.AsyncHTTPTransport(
+                retries=3,
+                limits=httpx.Limits(
+                    max_keepalive_connections=200,
+                    max_connections=200,
+                    keepalive_expiry=60,
+                ),
+            ),
+            follow_redirects=True,
+        )
+
+        fastapi_app = FastAPI()
+        fastapi_app.add_middleware(_RequestCancelledMiddleware)
+
+        @fastapi_app.on_event("startup")
+        async def startup() -> None:
+            self.poller_task = asyncio.create_task(self.poll_containers())
+            logger.info("router startup complete")
+
+        @fastapi_app.on_event("shutdown")
+        async def shutdown() -> None:
+            self.poller_task.cancel()
+            await asyncio.gather(self.poller_task, return_exceptions=True)
+            await self.client.aclose()
+
+        @fastapi_app.api_route(
+            "/{path:path}",
+            methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
+        )
+        async def forward(request: Request, path: str) -> Any:
+            # Metrics should hit the internal server.
+            if path.startswith("metrics"):
+                return Response(content=b"", status_code=200, media_type="text/plain")
+
+            body = await request.body()
+            session_id = request.headers.get("modal-session-id")
+            log_prefix = f"[request {uuid.uuid4()}, session {session_id}]"
+
+            try:
+                headers = filter_headers(dict(request.headers))
+
+                for attempt in range(MAX_SESSION_RETRIES + 1):
+                    container = None
+                    if session_id and self.containers:
+                        container = await route_session(
+                            self.session_routes, session_id, self.containers
+                        )
+                        headers["modal-flash-upstream"] = container.upstream
+
+                    logger.info(
+                        "%s proxying to replica %s (attempt=%d)",
+                        log_prefix,
+                        container.task_id if container else None,
+                        attempt,
+                    )
+
+                    stream = self.upstream_stream(
+                        request, path, headers, body, container, log_prefix
+                    )
+                    response: httpx.Response = await anext(stream)
+
+                    # Resolve stale upstream state to avoid repeated 503s: a pinned
+                    # replica that refuses the request leaves rotation, and the
+                    # session re-routes instead of retrying its saturator.
+                    if response.status_code == 503 and container is not None:
+                        logger.warning(
+                            "%s replica %s returned 503 on attempt %d/%d; evicting",
+                            log_prefix,
+                            container.task_id,
+                            attempt + 1,
+                            MAX_SESSION_RETRIES + 1,
+                        )
+                        self.containers.pop(container.task_id, None)
+                        if attempt < MAX_SESSION_RETRIES:
+                            await stream.aclose()
+                            continue
+
+                    return StreamingResponse(
+                        stream,
+                        status_code=response.status_code,
+                        headers=dict(response.headers),
+                        media_type=response.headers.get("content-type"),
+                    )
+
+            except httpx.TimeoutException as exc:
+                logger.error("%s upstream timeout: %r", log_prefix, exc)
+                return Response(
+                    content=b"Upstream Timeout",
+                    status_code=504,
+                    media_type="text/plain",
+                )
+            except Exception as exc:
+                logger.error("%s error proxying request: %r", log_prefix, exc)
+                return Response(
+                    content=b"Internal Server Error",
+                    status_code=500,
+                    media_type="text/plain",
+                )
+
+        return fastapi_app

--- a/cookbook/common/router_test.py
+++ b/cookbook/common/router_test.py
@@ -1,0 +1,142 @@
+"""Router harness: the pure routing helpers — ``route_session`` stickiness / overload
+fallback / TTL eviction, ``select_least_loaded_container``, ``filter_headers``, and
+``_container_addr`` — against a fake session-routes dict (no Modal involved)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+from cookbook.common.router import (
+    SESSION_ROUTE_TTL_SECONDS,
+    ContainerInfo,
+    RouteEntry,
+    RouteEntryList,
+    _container_addr,
+    filter_headers,
+    route_session,
+    select_least_loaded_container,
+)
+
+
+class _SyncAsync:
+    """Duck-types a Modal SDK synchronicity-wrapped method (callable, with ``.aio``)."""
+
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __call__(self, *args):
+        return self.fn(*args)
+
+    async def aio(self, *args):
+        return self.fn(*args)
+
+
+class FakeRoutes:
+    """Stands in for the session-routes ``modal.Dict``; stores the dumped JSON forms."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, list] = {}
+        self.get = _SyncAsync(lambda key, default: self.store.get(key, default))
+        self.put = _SyncAsync(lambda key, value: self.store.__setitem__(key, value))
+
+
+def _containers(*loads: int) -> dict[str, ContainerInfo]:
+    return {
+        f"ta-{i}": ContainerInfo(task_id=f"ta-{i}", upstream=f"h{i}:8000", load=load)
+        for i, load in enumerate(loads)
+    }
+
+
+def _seeded(routes: FakeRoutes, session: str, entries: list[dict]) -> None:
+    routes.store[session] = RouteEntryList.dump_python(
+        [RouteEntry(**entry) for entry in entries], mode="json"
+    )
+
+
+def test_route_session_pins_least_loaded_on_first_request() -> None:
+    routes, containers = FakeRoutes(), _containers(0, 5, 5)
+    picked = asyncio.run(route_session(routes, "s1", containers))
+    assert picked.task_id == "ta-0"
+    assert routes.store["s1"][0]["task_id"] == "ta-0"
+
+
+def test_route_session_is_sticky_for_known_healthy_replica() -> None:
+    routes, containers = FakeRoutes(), _containers(0, 5, 5)
+    first = asyncio.run(route_session(routes, "s1", containers))
+    # ta-1 becomes strictly less loaded, but stickiness holds while the pinned
+    # replica stays below the overload threshold (3 < ceil(avg × 1.5) = 4).
+    containers["ta-0"] = containers["ta-0"].model_copy(update={"load": 3})
+    containers["ta-1"] = containers["ta-1"].model_copy(update={"load": 0})
+    second = asyncio.run(route_session(routes, "s1", containers))
+    assert second.task_id == first.task_id == "ta-0"
+
+
+def test_route_session_sheds_overloaded_replica_to_least_loaded() -> None:
+    routes, containers = FakeRoutes(), _containers(0, 0, 20)
+    first = asyncio.run(route_session(routes, "s1", containers))
+    containers[first.task_id] = containers[first.task_id].model_copy(
+        update={"load": 20}
+    )
+    second = asyncio.run(route_session(routes, "s1", containers))
+    assert second.task_id != first.task_id
+    assert second.load == 0
+
+
+def test_route_session_drops_expired_and_undiscovered_routes() -> None:
+    routes, containers = FakeRoutes(), _containers(0, 5, 5)
+    _seeded(
+        routes,
+        "s1",
+        [
+            {
+                "task_id": "ta-2",
+                "last_sent": time.time() - SESSION_ROUTE_TTL_SECONDS - 1,
+            },
+            {"task_id": "ta-gone", "last_sent": time.time()},
+        ],
+    )
+    picked = asyncio.run(route_session(routes, "s1", containers))
+    assert picked.task_id == "ta-0"
+    assert [entry["task_id"] for entry in routes.store["s1"]] == ["ta-0"]
+
+
+def test_select_least_loaded_container_picks_minimum() -> None:
+    containers = _containers(7, 2, 3, 2)
+    picked = select_least_loaded_container(containers)
+    assert picked.load == 2
+
+
+def test_filter_headers_drops_routing_and_hop_by_hop() -> None:
+    headers = {
+        "Host": "example",
+        "Content-Length": "10",
+        "modal-session-id": "s1",
+        "modal-flash-upstream": "h:8000",
+        "X-Forwarded-For": "1.2.3.4",
+        "Authorization": "Bearer tok",
+        "content-type": "application/json",
+    }
+    assert filter_headers(headers) == {
+        "Authorization": "Bearer tok",
+        "content-type": "application/json",
+    }
+
+
+def test_container_addr_normalizes_host_and_port() -> None:
+    assert _container_addr({"task_id": "t", "host": "h", "port": 8000}) == "h:8000"
+    assert _container_addr({"host": "h:8000", "port": 8000}) == "h:8000"
+    assert _container_addr({"host": "h"}) == "h"
+    assert _container_addr({}) is None
+    assert (
+        _container_addr(SimpleNamespace(host="h", port=8000, task_id="t")) == "h:8000"
+    )
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"  ok  {t.__name__}")
+    print(f"router harness: {len(tests)} PASS")

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -29,7 +29,7 @@ from typing import Any
 import modal
 import modal.experimental
 
-from cookbook.common import launch, ray_cluster, server, serving_image
+from cookbook.common import launch, ray_cluster, router, server, serving_image
 from cookbook.common.constants import (
     CHECKPOINTS_PATH,
     DATA_PATH,
@@ -45,7 +45,7 @@ from cookbook.common.constants import (
 from cookbook.miles_disagg import trainer_image
 from cookbook.miles_disagg.config import YAML_CONFIG_FIELDS, MilesConfig
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
-from stitch.pools.modal_flash import ModalFlashPool
+from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
 
 EXPERIMENT = os.environ[
     "EXPERIMENT_CONFIG"
@@ -148,7 +148,7 @@ SGLANG_SERVER_ARGS = {
 # shared common.server logic: sglang plus the stitch sidecar.
 @app.server(
     image=server_image,
-    gpu=f"{modal_cfg.gpu}:{miles_cfg.rollout_num_gpus_per_engine}",
+    gpu=modal_cfg.rollout_gpus(miles_cfg.rollout_num_gpus_per_engine),
     cloud=modal_cfg.cloud,
     compute_region=modal_cfg.region,
     volumes={
@@ -197,6 +197,66 @@ class Server:
     @modal.exit()
     def stop(self) -> None:
         server.serve_stop(self)
+
+
+# ── Session-routing LB (cookbook/common/router.py) ─────────────────────────────
+# The router is two CPU Flash classes in this same app, so it deploys and dies with
+# the pool; the GPU class keeps ``Server``, rollout traffic enters through ``Router``.
+router_image = router.build_router_image(EXPERIMENT, RUN_ID)
+session_routes = router.session_routes_dict(APP_NAME)
+
+
+@app.server(
+    image=router_image,
+    cpu=2,
+    memory=1024,
+    min_containers=modal_cfg.router_registry_min_containers,
+    routing_region=modal_cfg.routing_region,
+    include_source=False,
+    port=8000,
+    unauthenticated=True,
+)
+class RouterRegistry:
+    """Polls Server replicas' live queue depth; serves the snapshot at /loads."""
+
+    @modal.enter()
+    def enter(self) -> None:
+        router.serve_registry(self, app_name=APP_NAME, upstream_cls="Server")
+
+    @modal.exit()
+    def exit(self) -> None:
+        router.stop_server(self)
+
+
+@app.server(
+    image=router_image,
+    cpu=4,
+    memory=2048,
+    min_containers=modal_cfg.router_min_containers,
+    target_concurrency=modal_cfg.router_target_concurrency,
+    routing_region=modal_cfg.routing_region,
+    include_source=False,
+    port=8000,
+    unauthenticated=True,
+    exit_grace_period=30 * MINUTES,
+)
+class Router:
+    """Front door for rollout traffic: session-affinity routing across Server replicas,
+    with 503 eviction + retry, so a saturated replica sheds sessions instead of
+    attracting them."""
+
+    @modal.enter()
+    def enter(self) -> None:
+        router.serve_router(
+            self,
+            registry_url=RouterRegistry.get_url(),
+            upstream_url=Server.get_url(),
+            session_routes=session_routes,
+        )
+
+    @modal.exit()
+    def exit(self) -> None:
+        router.stop_server(self)
 
 
 # ── Trainer (miles on Ray) ────────────────────────────────────────────────────
@@ -271,7 +331,7 @@ class Trainer:
         if self.rank != 0:
             return
 
-        cfg.rollout_endpoint_url = ModalFlashPool(APP_NAME, "Server").gateway_url()
+        cfg.rollout_endpoint_url = ModalFlashLBPool(APP_NAME, "Server").gateway_url()
         # Miles requires this CLI argument; the deployment owns its run-scoped value.
         cfg.update_weight_disk_dir = str(UPDATES_DIR)
         if getattr(cfg, "save_interval", None) is None:

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -50,14 +50,12 @@ GPUS_PER_TRAINER_NODE = 8
 ROLLOUT_GPUS_PER_ENGINE = 4
 ROLLOUT_BATCH_SIZE = 32
 N_SAMPLES_PER_PROMPT = 8
-ROLLOUT_TO_TRAINER_GPU_RATIO = 1
 ROLLOUT_INPUTS_PER_ENGINE = 24
-ROLLOUT_ENGINES = (
-    TRAINER_NODES
-    * GPUS_PER_TRAINER_NODE
-    * ROLLOUT_TO_TRAINER_GPU_RATIO
-    // ROLLOUT_GPUS_PER_ENGINE
-)
+ROLLOUT_MAX_RUNNING_REQUESTS = 32
+# Bound scheduler-poll and routing skew to the headroom above the routing target.
+# Sustained excess load gets a retryable 503 instead of an unbounded engine queue.
+ROLLOUT_MAX_QUEUED_REQUESTS = ROLLOUT_MAX_RUNNING_REQUESTS - ROLLOUT_INPUTS_PER_ENGINE
+ROLLOUT_ENGINES = 32
 ROLLOUT_CONCURRENT_SAMPLES = ROLLOUT_ENGINES * ROLLOUT_INPUTS_PER_ENGINE
 MAX_SEQ_LEN = 65_536
 # SGLang's request boundary needs a small physical-context margin. Miles still
@@ -122,7 +120,8 @@ SGLANG_SERVER_ARGS = {
     # memory / batching
     "--mem-fraction-static": "0.80",
     "--chunked-prefill-size": "16384",
-    "--max-running-requests": "32",
+    "--max-running-requests": str(ROLLOUT_MAX_RUNNING_REQUESTS),
+    "--max-queued-requests": str(ROLLOUT_MAX_QUEUED_REQUESTS),
     "--schedule-conservativeness": "1.0",
     "--schedule-policy": "lpm",
     "--cuda-graph-config": (
@@ -192,6 +191,8 @@ class _Miles(MilesConfig):
     rollout_num_gpus = 0
     rollout_num_gpus_per_engine = ROLLOUT_GPUS_PER_ENGINE
     # An opaque endpoint has one Miles-side semaphore for the complete fleet.
+    # A saturated engine's 503 retry holds its slot, feeding backpressure into
+    # session generation instead of admitting another trajectory.
     sglang_server_concurrency = ROLLOUT_CONCURRENT_SAMPLES
     rollout_endpoint_url = None
 

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -118,7 +118,7 @@ SGLANG_SERVER_ARGS = {
     # MoE
     "--moe-runner-backend": "flashinfer_trtllm_routed",
     # memory / batching
-    "--mem-fraction-static": "0.80",
+    "--mem-fraction-static": "0.85",
     "--chunked-prefill-size": "16384",
     "--max-running-requests": str(ROLLOUT_MAX_RUNNING_REQUESTS),
     "--max-queued-requests": str(ROLLOUT_MAX_QUEUED_REQUESTS),
@@ -146,12 +146,13 @@ SGLANG_SERVER_ARGS = {
 
 modal = ModalConfig(
     gpu="B300",
+    rollout_gpu="B300",
     region="us",
     trainer_memory_mib=(1024 * 1024, 3 * 1024 * 1024),
     # CPU mode retains both the canonical checkpoint and TP rank images.
     rollout_memory_mib=(1024 * 1024, 3 * 1024 * 1024),
     rollout_min_containers=ROLLOUT_ENGINES,
-    rollout_max_containers=ROLLOUT_ENGINES,
+    rollout_max_containers=None,
     rollout_target_inputs=ROLLOUT_INPUTS_PER_ENGINE,
     draft_volume=DFLASH_VOLUME,
     routing_region="us-west",

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -29,7 +29,7 @@ from typing import Any
 import modal
 import modal.experimental
 
-from cookbook.common import launch, ray_cluster, server, serving_image
+from cookbook.common import launch, ray_cluster, router, server, serving_image
 from cookbook.common.constants import (
     CHECKPOINTS_PATH,
     DATA_PATH,
@@ -45,7 +45,7 @@ from cookbook.common.constants import (
 from cookbook.slime_disagg import trainer_image
 from cookbook.slime_disagg.config import YAML_CONFIG_FIELDS, SlimeConfig
 from cookbook.slime_disagg.trainer_image import SLIME_ROOT
-from stitch.pools.modal_flash import ModalFlashPool
+from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
 
 EXPERIMENT = os.environ[
     "EXPERIMENT_CONFIG"
@@ -141,7 +141,7 @@ SGLANG_SERVER_ARGS = {
 # shared common.server logic: sglang plus the stitch sidecar.
 @app.server(
     image=server_image,
-    gpu=f"{modal_cfg.gpu}:{slime_cfg.rollout_num_gpus_per_engine}",
+    gpu=modal_cfg.rollout_gpus(slime_cfg.rollout_num_gpus_per_engine),
     cloud=modal_cfg.cloud,
     compute_region=modal_cfg.region,
     volumes={
@@ -186,6 +186,66 @@ class Server:
     @modal.exit()
     def stop(self) -> None:
         server.serve_stop(self)
+
+
+# ── Session-routing LB (cookbook/common/router.py) ─────────────────────────────
+# The router is two CPU Flash classes in this same app, so it deploys and dies with
+# the pool; the GPU class keeps ``Server``, rollout traffic enters through ``Router``.
+router_image = router.build_router_image(EXPERIMENT, RUN_ID)
+session_routes = router.session_routes_dict(APP_NAME)
+
+
+@app.server(
+    image=router_image,
+    cpu=2,
+    memory=1024,
+    min_containers=modal_cfg.router_registry_min_containers,
+    routing_region=modal_cfg.routing_region,
+    include_source=False,
+    port=8000,
+    unauthenticated=True,
+)
+class RouterRegistry:
+    """Polls Server replicas' live queue depth; serves the snapshot at /loads."""
+
+    @modal.enter()
+    def enter(self) -> None:
+        router.serve_registry(self, app_name=APP_NAME, upstream_cls="Server")
+
+    @modal.exit()
+    def exit(self) -> None:
+        router.stop_server(self)
+
+
+@app.server(
+    image=router_image,
+    cpu=4,
+    memory=2048,
+    min_containers=modal_cfg.router_min_containers,
+    target_concurrency=modal_cfg.router_target_concurrency,
+    routing_region=modal_cfg.routing_region,
+    include_source=False,
+    port=8000,
+    unauthenticated=True,
+    exit_grace_period=30 * MINUTES,
+)
+class Router:
+    """Front door for rollout traffic: session-affinity routing across Server replicas,
+    with 503 eviction + retry, so a saturated replica sheds sessions instead of
+    attracting them."""
+
+    @modal.enter()
+    def enter(self) -> None:
+        router.serve_router(
+            self,
+            registry_url=RouterRegistry.get_url(),
+            upstream_url=Server.get_url(),
+            session_routes=session_routes,
+        )
+
+    @modal.exit()
+    def exit(self) -> None:
+        router.stop_server(self)
 
 
 # ── Trainer (slime on Ray) ────────────────────────────────────────────────────
@@ -244,7 +304,7 @@ class Trainer:
             return
 
         cfg = SlimeConfig.from_payload(payload)
-        cfg.rollout_endpoint_url = ModalFlashPool(APP_NAME, "Server").gateway_url()
+        cfg.rollout_endpoint_url = ModalFlashLBPool(APP_NAME, "Server").gateway_url()
         # Slime requires this CLI argument; the deployment owns its run-scoped value.
         cfg.update_weight_disk_dir = str(UPDATES_DIR)
         hook_knobs = {

--- a/src/stitch/pools/base.py
+++ b/src/stitch/pools/base.py
@@ -1,8 +1,9 @@
 """The ``Pool`` port — a client to the running elastic replica pool.
 
-Instances subclass this base: ``pools/modal_flash.py`` (Modal Flash). Add k8s as a new
-subclass. Override ``gateway_url`` and ``discover_replicas``; ``wake`` and ``scale`` are
-optional (their no-op defaults fall back to the replicas' own polling / load-autoscale).
+Instances subclass this base: ``pools/modal_flash.py`` (Modal Flash) and its
+``modal_flash_lb_temp`` variant (the same, fronted by the session-routing LB). Add k8s as a
+new subclass. Override ``gateway_url`` and ``discover_replicas``; ``wake`` and ``scale``
+are optional (their no-op defaults fall back to the replicas' own polling / load-autoscale).
 
 The ``*_async`` variants serve callers running on an event loop (an async control plane,
 ``service.readiness``). Their defaults thread the sync implementation, so every subclass is

--- a/src/stitch/pools/modal_flash_lb_temp.py
+++ b/src/stitch/pools/modal_flash_lb_temp.py
@@ -1,0 +1,57 @@
+"""``ModalFlashLBPool`` — the ``Pool`` instance for a Modal Flash service whose traffic
+enters through the session-routing LB deployed alongside it.
+
+With a per-container queue bound (sglang ``--max-queued-requests``), Flash's own sticky
+routing turns the first saturated replicas into 503 attractors: the sessions already stuck
+on a full replica keep retrying it, so it stays full while the rest of the pool starves.
+The cookbook router (``cookbook/common/router.py``, a fork of the flash-smart-router folded
+into the run's app as the ``Router`` + ``RouterRegistry`` classes) routes sessions by *live
+container load* and retries a 503 on a healthier replica, so load spreads instead of
+sticking.
+
+Only the gateway moves: rollout traffic enters through the router's URL, while replica
+discovery, ``wake``, and ``scale`` stay on the upstream ``Server`` class (the router holds
+no weights), inherited from ``ModalFlashPool``. Like that pool, this is a client to a
+running deployment, and every Modal call is import-lazy so the module loads without Modal.
+
+This module is temporary: it exists until smart routing is productized on the Flash side
+and the router classes can be dropped from the recipes.
+"""
+
+from __future__ import annotations
+
+from stitch.pools.modal_flash import ModalFlashPool
+
+
+class ModalFlashLBPool(ModalFlashPool):
+    def __init__(
+        self,
+        app_name: str,
+        cls_name: str,
+        lb_app_name: str | None = None,
+        lb_cls_name: str = "Router",
+    ) -> None:
+        super().__init__(app_name, cls_name)
+        # The router is a class in the same app, deployed alongside the upstream.
+        self.lb_app_name = lb_app_name or app_name
+        self.lb_cls_name = lb_cls_name
+
+    def _lb_server(self):
+        import modal
+
+        return modal.Server.from_name(self.lb_app_name, self.lb_cls_name)
+
+    def gateway_url(self) -> str:
+        return self._require_gateway(self._lb_server().get_url())
+
+    async def gateway_url_async(self) -> str:
+        return self._require_gateway(await self._lb_server().get_url.aio())
+
+    def _require_gateway(self, url: str | None) -> str:
+        if not url:
+            raise RuntimeError(
+                f"no gateway URL for {self.lb_app_name}.{self.lb_cls_name} — deploy the "
+                "router classes with the pool (the cookbook recipe apps do this: see "
+                "cookbook/common/router.py)"
+            )
+        return str(url).rstrip("/")

--- a/src/stitch/pools/modal_flash_lb_temp_test.py
+++ b/src/stitch/pools/modal_flash_lb_temp_test.py
@@ -1,0 +1,123 @@
+"""ModalFlashLBPool harness: same-app gateway derivation and the gateway-vs-upstream
+split, against a stubbed ``modal`` module (the real Modal calls are validated e2e)."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
+
+
+class _SyncAsync:
+    """Mimics a Modal SDK synchronicity-wrapped method: callable, with an ``.aio``."""
+
+    def __init__(self, value):
+        self.value = value
+
+    def __call__(self):
+        return self.value
+
+    async def aio(self):
+        return self.value
+
+
+def _run_with_fake_modal(urls: dict, containers: list, fn) -> None:
+    """Patch ``sys.modules['modal']`` to resolve staged URLs/containers, then run ``fn``."""
+    lookups: list[tuple[str, str]] = []
+    modal_stub = types.ModuleType("modal")
+    modal_stub.Server = types.SimpleNamespace(
+        from_name=lambda app, cls: (
+            lookups.append((app, cls)),
+            types.SimpleNamespace(get_url=_SyncAsync(urls.get((app, cls)))),
+        )[1]
+    )
+    experimental_stub = types.ModuleType("modal.experimental")
+    experimental_stub.flash_get_containers = lambda app, cls: containers
+    modal_stub.experimental = experimental_stub
+    originals = {
+        name: sys.modules.get(name) for name in ("modal", "modal.experimental")
+    }
+    sys.modules["modal"] = modal_stub
+    sys.modules["modal.experimental"] = experimental_stub
+    try:
+        fn(lookups)
+    finally:
+        for name, original in originals.items():
+            if original is None:
+                del sys.modules[name]
+            else:
+                sys.modules[name] = original
+
+
+def test_gateway_defaults_to_router_cls_in_same_app() -> None:
+    pool = ModalFlashLBPool("pool", "Server")
+    assert (pool.lb_app_name, pool.lb_cls_name) == ("pool", "Router")
+    pool = ModalFlashLBPool(
+        "pool", "Server", lb_app_name="custom-lb", lb_cls_name="Proxy"
+    )
+    assert (pool.lb_app_name, pool.lb_cls_name) == ("custom-lb", "Proxy")
+
+
+def test_gateway_url_resolves_router_cls_not_upstream() -> None:
+    pool = ModalFlashLBPool("pool", "Server")
+
+    def check(lookups):
+        url = pool.gateway_url()
+        assert url == "https://router.example"
+        assert lookups == [("pool", "Router")]
+
+    _run_with_fake_modal({("pool", "Router"): "https://router.example/"}, [], check)
+
+
+def test_gateway_url_async_resolves_router_cls() -> None:
+    pool = ModalFlashLBPool("pool", "Server")
+
+    def check(lookups):
+        url = asyncio.run(pool.gateway_url_async())
+        assert url == "https://router.example"
+        assert lookups == [("pool", "Router")]
+
+    _run_with_fake_modal({("pool", "Router"): "https://router.example/"}, [], check)
+
+
+def test_gateway_url_requires_deployed_router() -> None:
+    pool = ModalFlashLBPool("pool", "Server")
+
+    def check(_lookups):
+        try:
+            pool.gateway_url()
+        except RuntimeError as exc:
+            message = str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
+        assert "pool.Router" in message
+        assert "router classes" in message
+
+    _run_with_fake_modal({}, [], check)
+
+
+def test_replicas_and_scale_stay_on_upstream_app() -> None:
+    pool = ModalFlashLBPool("pool", "Server")
+
+    def check(lookups):
+        assert pool.discover_replicas() == ["https://h1:8000"]
+        assert pool._server().get_url() == "https://upstream.example"
+        assert lookups == [("pool", "Server")]
+
+    # ModalFlashLBPool inherits ``discover_replicas`` and ``_server`` untouched; the
+    # stubbed lookup proves they still name the upstream app, not the LB.
+    _run_with_fake_modal(
+        {("pool", "Server"): "https://upstream.example"},
+        [{"host": "h1:8000"}],
+        check,
+    )
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"  ok  {t.__name__}")
+    print(f"modal_flash_lb_temp harness: {len(tests)} PASS")


### PR DESCRIPTION
## Problem

With a per-container queue bound on rollout replicas (sglang `--max-queued-requests`, see the commit below this one), Flash's own sticky routing turns the first saturated replicas into **503 attractors**: sessions already stuck on a full replica keep retrying it (holding their Miles-side concurrency slots), so the replica stays full while the rest of the pool starves.

## Approach

- **`cookbook/common/router.py`** — a run-scoped, purpose-fit fork of the router (~450 lines after trimming auth/env plumbing). A `RouterRegistry` Flash class polls every `Server` replica's live queue depth (`/v1/loads` + `/health` zombie check); a `Router` proxy class pins each `modal-session-id` to the least-loaded healthy replica via the `modal-flash-upstream` header and, on a 503 from a pinned replica, evicts it from rotation and retries on a healthier one. Deltas from upstream: stdlib logging, discovery via plain-tag `FunctionGet` + `FlashContainerList` RPCs, and no network I/O in the FastAPI `startup` event. Both classes deploy alongside `Server` in the same app — one deploy, one `modal app stop`, sizing from `ModalConfig` (2 registry + 2 proxy CPU replicas by default).
- **`ModalFlashLBPool`** (`src/stitch/pools/modal_flash_lb_temp.py`, temp until smart routing is productized Flash-side) — a `ModalFlashPool` whose gateway is the in-app `Router` URL; `discover_replicas`/`wake`/`scale` stay on the `Server` class (the router holds no weights). Rollout endpoints in both recipes and the launch-flow readiness check (rides `/health` through the router) now use it.

## Validation

- Unit: `router_test.py` harness (route stickiness, overload shedding, TTL eviction, header filtering, addr normalization) + pool tests; **102/102 pass**, ruff lint/format clean.
- **Modal e2e** (`stitch-router-probe`, CPU stub pool of 3 sglang-mimicking replicas + the real Router/RouterRegistry in stitch-dev): session pinning and spread across replicas, and — the defect this fixes — a forced 503 on the pinned replica: the session's next request returned **200 from a different replica**. The probe also caught two porting bugs pre-merge: a PEP 563 / FastAPI `Request` annotation resolution failure (all proxied traffic 422'd) and an unwrapped `client.stub` await hanging uvicorn startup (silent RouterRegistry crash loop at `startup_timeout`).

## Known follow-up (not in this PR)

`ModalFlashPool.discover_replicas()` rides `modal.experimental.flash_get_containers`, which resolves the class-service-function tag `<Cls>.*` — a tag `@app.server` classes don't register (their web function is the plain `<Cls>` tag). Combined with `publish._wake` swallowing exceptions, the publish-time wake fan-out has likely been silently no-op'ing. The router-side helper (`router._list_flash_containers`) has the fix; porting `modal_flash.py` over is a ~10-line follow-up.

## Not yet done

A GPU launch of a real recipe (needs a fresh deploy + run); the probe above covers routing behavior with a stub pool.
