### PR TITLE
cookbook: refresh fully async Miles pin

### DIFF
--- a/cookbook/miles_disagg/MILES_FORK.md
+++ b/cookbook/miles_disagg/MILES_FORK.md
@@ -28,16 +28,16 @@ The branch `stitch-weight-sync-v0516` is upstream `radixark/miles` main at
 
 ## GLM-5.2 fully-async SWE branch
 
-`glm5_2_nvfp4.py` pins `stitch-miles-fully-async-swe` at `2879896c0322`. The
-branch is `modal/feat/modal-swe-fully-async` at `5c71d12dd` plus:
+`glm5_2_nvfp4.py` pins `stitch-miles-fully-async-swe` at `de7135830b54`. The
+branch is `modal/feat/modal-swe-fully-async` at `13e39b5bf` plus:
 
 | Commit | Responsibility |
 | --- | --- |
-| `b4217c624` | Format the fully-async files touched by the integration. |
-| `13657f774` | Route session rollouts through one external fleet endpoint with request gating and finite timeouts. |
-| `495d65b92` | Publish disk deltas without Miles-managed rollout-engine handles. |
-| `1b5f67b81` | Match GLM-5.2 router tensor dtypes to the canonical checkpoint. |
-| `2879896c0` | Encode zero-dimensional checkpoint tensors safely. |
+| `0a781cfd5` | Format the fully-async files touched by the integration. |
+| `14b831ba2` | Route session rollouts through one external fleet endpoint with request gating and finite timeouts. |
+| `b568da274` | Publish disk deltas without Miles-managed rollout-engine handles. |
+| `274831db8` | Match GLM-5.2 router tensor dtypes to the canonical checkpoint. |
+| `de7135830` | Encode zero-dimensional checkpoint tensors safely. |
 
 This branch is additive and only backs the GLM-5.2 fully-async experiment. It
 does not replace the standard recipe pin.

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -11,7 +11,7 @@ APP_NAME = "stitch-glm5-2-nvfp4"
 EXPERIMENT_VOLUME_NAME = "stitch-miles-glm5-2-nvfp4"
 # This experiment layers Stitch integration onto Miles' fully-async SWE runtime.
 # Other cookbook experiments keep the standard Miles pin in trainer_image.py.
-MILES_REPO_REF = "2879896c0322c212be773aa8e43f88d02726b51b"
+MILES_REPO_REF = "de7135830b54b2f9c1fb8761fe567bbb493ab355"
 LOCAL_CHECKPOINT_PATH = None
 TRAINER_EXTRA_PIP_PACKAGES = (
     "harbor[modal,huggingface]==0.20.0",


### PR DESCRIPTION
## Summary

- pin the GLM-5.2 fully-async recipe to the latest Miles branch head
- refresh the documented upstream base and Stitch commit stack

## Why

The Miles fully-async branch was rebased. Pinning the immutable commit keeps the cookbook reproducible and aligned with the current branch.

The NVFP4 conversion code did not change between the prior and new heads, so the regenerated checkpoint remains valid.

## Validation

- `uv run ruff check cookbook/miles_disagg/configs/glm5_2_nvfp4.py`
- `git diff --check`
- `python -m py_compile cookbook/miles_disagg/configs/glm5_2_nvfp4.py`