### PR TITLE
cookbook: support top-p-only sampling masks

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -14,7 +14,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.16",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.16",
-    commit="1051a95a6ab16773037f8795a51aa03a1664a3b2",
+    commit="0094b725b9adbf19a7035421f295477e69b421aa",
 )
 ```
 
@@ -34,6 +34,7 @@ The branch is upstream v0.5.16 plus:
 | `1a4a4fd6b5` | Return aligned verifier logprobs for DFlash rollout tokens. |
 | `607e107b44` | Store the canonical CPU-cache checkpoint on NVMe and overlap verified persistence with bounded rank-image compilation. |
 | `1051a95a6a` | Balance CPU delta transforms across persistent worker tasks. |
+| `0094b725b9` | Support top-p-only sampling masks through the native generation and chat-completions APIs. |
 
 The image and branch must use the same SGLang release because Stitch overlays
 Python code onto the image’s existing CUDA and C++ extensions.

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -30,7 +30,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.16",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.16",
-    commit="1051a95a6ab16773037f8795a51aa03a1664a3b2",
+    commit="0094b725b9adbf19a7035421f295477e69b421aa",
 )
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent

--- a/cookbook/miles_disagg/configs/kimi_k3_mxfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k3_mxfp4.py
@@ -15,7 +15,7 @@ SGLANG_RUNTIME = SGLangRuntime(
     ),
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-kimi-k3",
-    commit="8b508a478730f73eb4419e1a2adde8425732ea95",
+    commit="977e33dd4560463d3a9a981ba3ed764de289e858",
 )
 
 SGLANG_SERVER_ARGS = {


### PR DESCRIPTION
## Summary

- advance the default Stitch SGLang runtime to include top-p-only sampling-mask support
- apply the same upstream change to the Kimi K3 runtime
- document the added fork responsibility

## Why

RL callers commonly use top-p sampling without a finite top-k. The prior SGLang admission check rejected that configuration even though top-p bounds the returned support.

## Validation

- SGLang pre-commit suite on all six touched upstream files, on both fork branches
- `uv run ruff check cookbook/common/serving_image.py cookbook/miles_disagg/configs/kimi_k3_mxfp4.py`
- Python compilation of both changed Stitch modules
- `git diff --check`

Focused SGLang unit tests could not collect locally because this host does not have PyTorch installed.