### PR TITLE
cookbook: refresh GLM-5.2 fully async recipe

### DIFF
--- a/cookbook/miles_disagg/MILES_FORK.md
+++ b/cookbook/miles_disagg/MILES_FORK.md
@@ -28,16 +28,17 @@ The branch `stitch-weight-sync-v0516` is upstream `radixark/miles` main at
 
 ## GLM-5.2 fully-async SWE branch
 
-`glm5_2_nvfp4.py` pins `stitch-miles-fully-async-swe` at `de7135830b54`. The
-branch is `modal/feat/modal-swe-fully-async` at `13e39b5bf` plus:
+`glm5_2_nvfp4.py` pins `stitch-miles-fully-async-swe` at `6280a2196ba3`. The
+branch is `modal/feat/modal-swe-fully-async` at `a999ec511` plus:
 
 | Commit | Responsibility |
 | --- | --- |
-| `0a781cfd5` | Format the fully-async files touched by the integration. |
-| `14b831ba2` | Route session rollouts through one external fleet endpoint with request gating and finite timeouts. |
-| `b568da274` | Publish disk deltas without Miles-managed rollout-engine handles. |
-| `274831db8` | Match GLM-5.2 router tensor dtypes to the canonical checkpoint. |
-| `de7135830` | Encode zero-dimensional checkpoint tensors safely. |
+| `bee4c4b61` | Format the fully-async files touched by the integration. |
+| `7529d01d0` | Route session rollouts through one external fleet endpoint with request gating and finite timeouts. |
+| `88b81a82f` | Publish disk deltas without Miles-managed rollout-engine handles. |
+| `7e91d93ad` | Match GLM-5.2 router tensor dtypes to the canonical checkpoint. |
+| `098e4dc78` | Encode zero-dimensional checkpoint tensors safely. |
+| `6280a2196` | Read scalar and version-constraint model-info responses from an external fleet. |
 
 This branch is additive and only backs the GLM-5.2 fully-async experiment. It
 does not replace the standard recipe pin.

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -17,7 +17,7 @@ TRAINER_EXTRA_PIP_PACKAGES = (
     "harbor[modal,huggingface]==0.20.0",
     "mini-swe-agent==2.4.5",
     "swebench==4.1.0",
-    "modal==1.5.1",
+    "modal==1.5.3",
 )
 TRAINER_IMAGE_RUN_COMMANDS = (
     "uv pip install --system --break-system-packages flashinfer-python==0.6.15.post1",
@@ -277,18 +277,19 @@ class _Miles(MilesConfig):
     session_server_startup_timeout_seconds = 180
     tito_session_mismatch_sample_rate = 0.0625
 
-    num_rollout = 300
+    num_rollout = 500
     save_interval = 10
     rollout_batch_size = ROLLOUT_BATCH_SIZE
     n_samples_per_prompt = N_SAMPLES_PER_PROMPT
     global_batch_size = 256
     rollout_temperature = 1.0
-    rollout_top_p = 1.0
+    rollout_top_p = 0.95
     rollout_max_response_len = 8192
     max_seq_len = MAX_SEQ_LEN
     use_dynamic_global_batch_size = True
     max_weight_staleness = 6
     async_max_concurrent_samples = ROLLOUT_CONCURRENT_SAMPLES
+    eval_interval = None
 
     use_rollout_routing_replay = True
     use_fault_tolerance = True
@@ -333,12 +334,18 @@ class _Miles(MilesConfig):
     advantage_estimator = "grpo"
     eps_clip = 0.2
     eps_clip_high = 0.28
-    use_rollout_logprobs = True
+    use_rollout_logprobs = False
+    use_tis = True
     get_mismatch_metrics = True
     custom_tis_function_path = (
-        "examples.infra_features.train_infer_mismatch_helper.mis."
-        "compute_mis_weights_with_cp"
+        "miles.backends.training_utils.loss_hub.corrections.icepop_function"
     )
+    tis_clip_low = 0.5
+    tis_clip = 5.0
+    kl_coef = 0.0
+    use_kl_loss = False
+    kl_loss_coef = None
+    kl_loss_type = None
     entropy_coef = 0.0
 
     use_wandb = True
@@ -371,13 +378,16 @@ class _Miles(MilesConfig):
         "MODAL_SWE_MODEL_REQUEST_TIMEOUT": "1800",
         "MODAL_SWE_EXEC_TIMEOUT": "120",
         "MODAL_SWE_OUTPUT_HARD_LIMIT_BYTES": str(16 * 1024 * 1024),
-        "MODAL_SWE_SETUP_TIMEOUT": "600",
+        "MODAL_SWE_SETUP_TIMEOUT": "240",
         "MODAL_SWE_VERIFY_TIMEOUT": "3600",
         "MODAL_SWE_INJECT_PYTEST_REPORTER": "0",
         "MODAL_SWE_CPUS": "2",
         "MODAL_SWE_MEMORY_MIB": "16384",
         "MODAL_SWE_AGENT_PROCESSES": "48",
         "MODAL_SWE_AGENT_THREADS_PER_PROCESS": "16",
+        # Bound concurrent schedule/setup operations near the requested 500-wide
+        # control-plane envelope: 48 controller processes * 10 boots = 480.
+        "MODAL_SWE_SANDBOX_BOOT_CONCURRENCY_PER_PROCESS": "10",
         **NVFP4_TRAINING_ENV,
     }
 

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -11,7 +11,7 @@ APP_NAME = "stitch-glm5-2-nvfp4"
 EXPERIMENT_VOLUME_NAME = "stitch-miles-glm5-2-nvfp4"
 # This experiment layers Stitch integration onto Miles' fully-async SWE runtime.
 # Other cookbook experiments keep the standard Miles pin in trainer_image.py.
-MILES_REPO_REF = "de7135830b54b2f9c1fb8761fe567bbb493ab355"
+MILES_REPO_REF = "6280a2196ba3f20dbe669b415383f9b842cae32f"
 LOCAL_CHECKPOINT_PATH = None
 TRAINER_EXTRA_PIP_PACKAGES = (
     "harbor[modal,huggingface]==0.20.0",


### PR DESCRIPTION
## Summary

- pin GLM-5.2 to the latest fully-async Miles branch at `6280a2196ba3`
- run 500 learner steps with IcePop correction and top-p `0.95`
- keep TITO, completion backfill, dynamic global batches, six-version staleness, and DFlash
- disable evaluation explicitly
- update the trainer Modal SDK to 1.5.3 and align sandbox startup limits
- bound schedule/setup concurrency at 480 across 48 controller processes

## Miles update

The latest Stitch commit accepts both scalar and version-constraint `weight_version` responses from an external fleet’s `/model_info` endpoint. This keeps fully-async staleness observations authoritative with Stitch’s constrained routing contract.

## Algorithm

The recipe uses GRPO with IcePop as the train/inference correction:

- `use_rollout_logprobs = False`
- `use_tis = True`
- IcePop bounds `[0.5, 5.0]`
- reward and loss KL remain disabled
- mismatch metrics remain enabled

## Compatibility blocker

Miles automatically requests exact per-token sampling support when `rollout_top_p < 1`. Both the pinned Stitch SGLang branch and current upstream SGLang reject `return_sampling_mask` with speculative decoding because speculative workers do not yet emit one aligned support per accepted token. The requested top-p `0.95` and DFlash settings are preserved in this draft, but the run must not launch until that SGLang limitation is resolved.

## Validation

- rebased onto current Stitch `main`
- verified `6280a2196ba3` as the latest remote Miles branch head
- Ruff check and format check
- Python compilation
- direct assertions for all requested recipe values
- `git diff --check`