### PR TITLE
cookbook: refresh Miles and SGLang pins

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -14,7 +14,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.16",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.16",
-    commit="0094b725b9adbf19a7035421f295477e69b421aa",
+    commit="7b09ce9f77c2290d5271c545d5b8b988c0479584",
 )
 ```
 
@@ -35,6 +35,7 @@ The branch is upstream v0.5.16 plus:
 | `607e107b44` | Store the canonical CPU-cache checkpoint on NVMe and overlap verified persistence with bounded rank-image compilation. |
 | `1051a95a6a` | Balance CPU delta transforms across persistent worker tasks. |
 | `0094b725b9` | Support top-p-only sampling masks through the native generation and chat-completions APIs. |
+| `7b09ce9f77` | Return aligned top-p sampling masks for tokens accepted by DFlash SpecV2. |
 
 The image and branch must use the same SGLang release because Stitch overlays
 Python code onto the image’s existing CUDA and C++ extensions.

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -30,7 +30,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.16",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.16",
-    commit="0094b725b9adbf19a7035421f295477e69b421aa",
+    commit="7b09ce9f77c2290d5271c545d5b8b988c0479584",
 )
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary

- refresh the GLM-5.2 fully-async Miles pin to f17e2c63f673668286b3517f412c9b514aa318a7
- refresh the default SGLang v0.5.16 fork pin to 7b09ce9f77c2290d5271c545d5b8b988c0479584
- update both fork maps, including the new DFlash SpecV2 sampling-mask responsibility

## Verification

- uv run pytest: 102 passed
- Ruff checks passed
- CPU-only Modal probe in stitch-dev confirmed the exact Miles checkout and import
- CPU-only Modal probe confirmed the SGLang overlay contains DFlash sampling-mask support