### PR TITLE
Retry idempotent base claims durably

### DIFF
--- a/src/stitch/publish.py
+++ b/src/stitch/publish.py
@@ -49,13 +49,20 @@ def publish_version(
 def claim_run(store: Store, pool: Pool | None, run_id: str) -> None:
     """Start a run at base before its first publish: write the base pointer and wake the
     pool, so every replica (cold or warm on a finished run) resets to base up front. A
-    reused ``run_id`` (the run's per-launch fence token) is a rewind — rejected here so a
-    restart can't leave the pool pinned to a dead incarnation's high-water mark."""
-    decide_pointer_move(
-        store.read_pointer(), VersionRef(run_id, 0)
-    )  # rewind guard (a reused run_id)
+    reused ``run_id`` above base is a rewind, while retrying an interrupted base claim is
+    idempotent."""
+    base = VersionRef(run_id, 0)
+    current = store.read_pointer()
+    if current == base:
+        # Re-write the same pointer so a retry also retries its durability
+        # boundary after an interrupted/ambiguous backend write.
+        store.claim(run_id)
+        _wake(pool, base)
+        logger.info("run %s already claimed at base", run_id)
+        return
+    decide_pointer_move(current, base)  # rewind guard (a reused run_id above base)
     store.claim(run_id)
-    _wake(pool, VersionRef(run_id, 0))
+    _wake(pool, base)
     logger.info("claimed run %s at base", run_id)
 
 

--- a/src/stitch/publish_test.py
+++ b/src/stitch/publish_test.py
@@ -16,6 +16,7 @@ class FakeStore(Store):
     def __init__(self, pointer: VersionRef | None = None) -> None:
         self._pointer = pointer
         self.published: list = []
+        self.claim_calls = 0
 
     def read_pointer(self):
         return self._pointer
@@ -27,6 +28,7 @@ class FakeStore(Store):
         self._pointer = ref
 
     def claim(self, run_id):
+        self.claim_calls += 1
         self._pointer = VersionRef(run_id, 0)
 
 
@@ -97,6 +99,15 @@ def test_claim_run() -> None:
     store, pool = FakeStore(), FakePool()
     claim_run(store, pool, "r2")
     assert store._pointer == VersionRef("r2", 0)
+    assert store.claim_calls == 1
+    assert pool.woke == [VersionRef("r2", 0)]
+
+
+def test_claim_run_at_base_is_idempotent() -> None:
+    store, pool = FakeStore(VersionRef("r2", 0)), FakePool()
+    claim_run(store, pool, "r2")
+    assert store._pointer == VersionRef("r2", 0)
+    assert store.claim_calls == 1
     assert pool.woke == [VersionRef("r2", 0)]
 
 


### PR DESCRIPTION
## What changed

- treat claiming an existing run at version 0 as an idempotent retry
- repeat the store claim so an interrupted or ambiguous backend write crosses the durability boundary again
- preserve rewind rejection once the run has advanced above version 0

## Why

Seeing version 0 locally does not prove that a previous backend commit became durable. A retry must repeat the durable write before replicas are woken.

## Validation

- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen pytest -q` — 103 passed