### PR TITLE
Publish distributed Volume shards atomically

### DIFF
--- a/cookbook/common/hooks.py
+++ b/cookbook/common/hooks.py
@@ -11,15 +11,18 @@ ModalFlashPool.
 from __future__ import annotations
 
 import asyncio
+import fcntl
+import hashlib
 import logging
 import time
+import traceback
 from pathlib import Path
 from typing import Any
 
 from stitch.pools.modal_flash import ModalFlashPool
 from stitch.publish import claim_run, constrain_request, publish_version
 from stitch.stores.modal_volume import ModalVolumeStore
-from stitch.types import PointerRewind
+from stitch.types import PointerRewind, VersionRef
 
 from . import process
 
@@ -42,27 +45,73 @@ def sample_affinity_key(sample: Any) -> str | None:
 def commit_and_wake(args: Any, published_dir: str, rollout_engines: Any = None) -> None:
     """Bridge the framework's disk-delta publish to the stitch store. The framework fires this
     at each durability boundary: a version dir (``weight_vNNNNNN``, holding the HF index) and —
-    at baseline/pointer commit — the run dir. Every rank flushes its writes, then version-dir
-    calls rendezvous before rank 0 advances the pointer. Keying on the dir name (not on reading
-    an index) keeps run-dir calls a clean no-op, not a missing-file crash."""
+    at baseline/pointer commit — the run dir. Every rank commits its mounted writes; after all
+    commits succeed, rank 0 refreshes and validates the complete checkpoint before advancing
+    the pointer. Keying on the dir name (not on reading an index) keeps run-dir calls a clean
+    no-op, not a missing-file crash."""
     del rollout_engines
     store = _store(args)
-    store.commit()
     if not Path(published_dir).name.startswith("weight_v"):
+        # Baseline cleanup is performed by rank 0 only, so a normal mounted
+        # Volume commit is authoritative here.
+        store.commit()
         return
-    # A successful Volume commit makes only this trainer rank's writes durable.
-    # Do not expose an index that names another rank's shard until every rank's
-    # commit has returned.
-    process.dist_barrier()
-    if process.dist_rank() not in (None, 0):
-        return
-    try:
-        publish_version(store, _pool(args), published_dir, run_id=_run_id(args))
-    except PointerRewind:
-        # A same-run republish (e.g. a retried step) — drop it rather than serve stale.
-        logger.warning(
-            "publish of %s would rewind latest; dropping", published_dir, exc_info=True
+
+    publication_state: tuple[bool, str | None] = (False, None)
+    if process.dist_rank() in (None, 0):
+        try:
+            target = VersionRef.parse(f"{_run_id(args)}/{Path(published_dir).name}")
+            current = store.read_pointer()
+            publication_state = (
+                current is not None
+                and current.run_id == target.run_id
+                and current.version >= target.version,
+                None,
+            )
+        except Exception:  # noqa: BLE001
+            publication_state = (False, f"rank 0:\n{traceback.format_exc()}")
+    publication_states = process.dist_all_gather_object(publication_state)
+    errors = [error for _, error in publication_states if error is not None]
+    if errors:
+        raise RuntimeError(
+            "checkpoint publication state check failed:\n" + "\n".join(errors)
         )
+    if any(already_published for already_published, _ in publication_states):
+        logger.warning("%s is already published; leaving it immutable", published_dir)
+        return
+
+    commit_error = None
+    try:
+        store.commit()
+    except Exception:  # noqa: BLE001
+        commit_error = f"rank {process.dist_rank()}:\n{traceback.format_exc()}"
+    _raise_distributed_failures("checkpoint commit", commit_error)
+
+    publish_error = None
+    if process.dist_rank() in (None, 0):
+        try:
+            store.refresh()
+            publish_version(store, _pool(args), published_dir, run_id=_run_id(args))
+        except PointerRewind:
+            # A same-run republish (e.g. a retried step) — drop it rather than serve stale.
+            logger.warning(
+                "publish of %s would rewind latest; dropping",
+                published_dir,
+                exc_info=True,
+            )
+        except Exception:  # noqa: BLE001
+            publish_error = f"rank 0:\n{traceback.format_exc()}"
+    _raise_distributed_failures("checkpoint publication", publish_error)
+
+
+def _raise_distributed_failures(phase: str, local_error: str | None) -> None:
+    errors = [
+        error
+        for error in process.dist_all_gather_object(local_error)
+        if error is not None
+    ]
+    if errors:
+        raise RuntimeError(f"{phase} failed:\n" + "\n".join(errors))
 
 
 def claim_pool(args: Any) -> None:
@@ -114,14 +163,18 @@ async def gated_rollout_request_hook(
 
 
 class _CachedPointer:
-    """TTL-cached ``latest`` version. The per-request hook gets no rollout id, so the
-    staleness floor comes from the published pointer (already advanced by the publish
-    hook), cached with a Volume reload so it isn't reloaded once per request."""
+    """TTL-cached durable ``latest`` version for request admission.
+
+    Publication runs on trainer ranks while request hooks run in rollout/session-server
+    processes, so their Volume mounts have independent visibility. Co-located request
+    processes share a file-locked refresh lease to reload at most once per TTL.
+    """
 
     def __init__(self) -> None:
         self._version = 0
         self._at = -1e9
         self._store: ModalVolumeStore | None = None
+        self._lock = asyncio.Lock()
 
     async def get(self, args: Any, ttl: float = 2.0) -> int:
         store = self._store
@@ -138,12 +191,13 @@ class _CachedPointer:
             self._version = 0
             self._at = -1e9
         now = time.monotonic()
-        if now - self._at >= ttl:
-            self._at = now
+        if now - self._at < ttl:
+            return self._version
+        async with self._lock:
+            if time.monotonic() - self._at < ttl:
+                return self._version
             try:
-                await asyncio.to_thread(
-                    store.refresh
-                )  # reload is blocking; keep the loop free
+                await asyncio.to_thread(_refresh_mount, store, ttl)
                 pointer = store.read_pointer()
                 self._version = pointer.version if pointer else 0
             except Exception:  # noqa: BLE001
@@ -152,7 +206,43 @@ class _CachedPointer:
                     self._version,
                     exc_info=True,
                 )
+            finally:
+                self._at = time.monotonic()
         return self._version
+
+
+def _refresh_mount(store: ModalVolumeStore, ttl: float) -> None:
+    """Refresh a mounted Volume at most once per container and TTL.
+
+    Miles may run many session-server processes in one container. They share the mount
+    and this local ``flock`` lease, so one process reloads while the others reuse the
+    resulting view. Separate containers get their own lease and refresh independently.
+    """
+    if not store.volume_name:
+        store.refresh()
+        return
+
+    key = hashlib.sha256(
+        f"{store.volume_name}\0{store.root}\0{store.run_id}".encode()
+    ).hexdigest()[:16]
+    lease_dir = Path("/tmp/stitch-volume-refresh")
+    lease_dir.mkdir(parents=True, exist_ok=True)
+    with (lease_dir / f"{key}.lock").open("a+", encoding="utf-8") as lease:
+        fcntl.flock(lease, fcntl.LOCK_EX)
+        lease.seek(0)
+        try:
+            refreshed_at = float(lease.read() or "-inf")
+        except ValueError:
+            refreshed_at = float("-inf")
+        if time.monotonic() - refreshed_at < ttl:
+            return
+        try:
+            store.refresh()
+        finally:
+            lease.seek(0)
+            lease.truncate()
+            lease.write(str(time.monotonic()))
+            lease.flush()
 
 
 _latest = _CachedPointer()

--- a/cookbook/common/hooks_test.py
+++ b/cookbook/common/hooks_test.py
@@ -50,6 +50,7 @@ def _write_version(root: Path, ref: VersionRef) -> str:
             }
         )
     )
+    (d / "model-00001.safetensors").write_bytes(b"weights")
     return str(d)
 
 
@@ -58,30 +59,49 @@ def test_commit_and_wake_publishes() -> None:
         root = Path(tmp)
         pool = _FakePool()
         events = []
-        original_barrier = hooks.process.dist_barrier
+        original_gather = hooks.process.dist_all_gather_object
         original_publish = hooks.publish_version
         original_commit = ModalVolumeStore.commit
+        original_refresh = ModalVolumeStore.refresh
 
-        def publish_after_barrier(*args, **kwargs):
+        def publish_after_refresh(*args, **kwargs):
             events.append("publish")
             return original_publish(*args, **kwargs)
 
-        def commit_before_barrier(store):
+        def commit_before_refresh(store):
             events.append("commit")
             return original_commit(store)
 
+        def refresh_after_commit(store):
+            events.append("refresh")
+            return original_refresh(store)
+
         hooks._pool = lambda args: pool  # rank is None in tests -> treated as writer
-        hooks.process.dist_barrier = lambda: events.append("barrier")
-        hooks.publish_version = publish_after_barrier
-        ModalVolumeStore.commit = commit_before_barrier
+
+        def gather(value):
+            events.append("gather")
+            return [value]
+
+        hooks.process.dist_all_gather_object = gather
+        hooks.publish_version = publish_after_refresh
+        ModalVolumeStore.commit = commit_before_refresh
+        ModalVolumeStore.refresh = refresh_after_commit
         try:
             vdir = _write_version(root, VersionRef("run-abc", 1))
             hooks.commit_and_wake(_args(str(root)), vdir)
         finally:
-            hooks.process.dist_barrier = original_barrier
+            hooks.process.dist_all_gather_object = original_gather
             hooks.publish_version = original_publish
             ModalVolumeStore.commit = original_commit
-        assert events == ["commit", "barrier", "publish"]
+            ModalVolumeStore.refresh = original_refresh
+        assert events == [
+            "gather",
+            "commit",
+            "gather",
+            "refresh",
+            "publish",
+            "gather",
+        ]
         assert ModalVolumeStore(root, run_id="run-abc").read_pointer() == VersionRef(
             "run-abc", 1
         )
@@ -108,6 +128,26 @@ def test_commit_and_wake_baseline_is_noop() -> None:
             hooks.process.dist_barrier = original_barrier
         assert ModalVolumeStore(root, run_id="run-abc").read_pointer() is None
         assert pool.woke == []
+
+
+def test_commit_and_wake_does_not_mutate_an_already_published_version() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        store = ModalVolumeStore(root, run_id="run-abc")
+        store.advance_pointer(VersionRef("run-abc", 1))
+        vdir = _write_version(root, VersionRef("run-abc", 1))
+        original_commit = ModalVolumeStore.commit
+
+        def unexpected_commit(_store) -> None:
+            raise AssertionError("an immutable published version must not be rewritten")
+
+        ModalVolumeStore.commit = unexpected_commit
+        try:
+            hooks.commit_and_wake(_args(str(root)), vdir)
+        finally:
+            ModalVolumeStore.commit = original_commit
+
+        assert store.read_pointer() == VersionRef("run-abc", 1)
 
 
 def test_claim_pool_resets_to_base() -> None:
@@ -158,6 +198,30 @@ def test_request_hook_min_lag() -> None:
         }
         assert request["headers"]["Modal-Session-ID"] == "group-1"
         assert request["max_retries"] == 900
+
+
+def test_request_hooks_share_one_container_refresh() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        store = ModalVolumeStore(root, run_id="run-abc")
+        store.advance_pointer(VersionRef("run-abc", 1))
+        first = hooks._CachedPointer()
+        second = hooks._CachedPointer()
+        original_refresh = ModalVolumeStore.refresh
+        refreshes = 0
+
+        def count_refresh(_store) -> None:
+            nonlocal refreshes
+            refreshes += 1
+
+        ModalVolumeStore.refresh = count_refresh
+        try:
+            args = _args(str(root), experiment_volume_name="weights")
+            assert asyncio.run(first.get(args, ttl=60)) == 1
+            assert asyncio.run(second.get(args, ttl=60)) == 1
+        finally:
+            ModalVolumeStore.refresh = original_refresh
+        assert refreshes == 1
 
 
 def test_sample_affinity_key_fallbacks() -> None:

--- a/cookbook/common/process.py
+++ b/cookbook/common/process.py
@@ -12,6 +12,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from typing import Any
 
 SIDECAR_MODULE = "cookbook.common.sidecar"
 
@@ -181,3 +182,17 @@ def dist_barrier() -> None:
 
     if dist.is_available() and dist.is_initialized():
         dist.barrier()
+
+
+def dist_all_gather_object(value: Any) -> list[Any]:
+    """Gather one small control-plane value from every distributed rank."""
+    try:
+        import torch.distributed as dist
+    except ImportError:
+        return [value]
+
+    if not (dist.is_available() and dist.is_initialized()):
+        return [value]
+    values: list[Any] = [None] * dist.get_world_size()
+    dist.all_gather_object(values, value)
+    return values

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import shutil
 import subprocess
 import tempfile
 from types import SimpleNamespace
@@ -365,18 +366,21 @@ class Trainer:
         )
         print(f"Command: {cmd}")
         log_path = str(RUN_DIR / "train.log")
-        os.makedirs(os.path.dirname(log_path), exist_ok=True)
-        teed = f"set -o pipefail; ({cmd}) 2>&1 | tee {log_path}"  # tee to a committed log; survives the app-logs buffer
-        try:
-            subprocess.run(["bash", "-lc", teed], check=True)
-        finally:
+        with tempfile.TemporaryDirectory() as local_log_dir:
+            local_log_path = os.path.join(local_log_dir, "train.log")
+            teed = f"set -o pipefail; ({cmd}) 2>&1 | tee {local_log_path}"
             try:
-                run_volume.commit()
-                print(
-                    f"Train log committed to {exp.EXPERIMENT_VOLUME_NAME} at {log_path}"
-                )
-            except Exception as exc:  # noqa: BLE001
-                print(f"WARNING: could not commit train log: {exc}")
+                subprocess.run(["bash", "-lc", teed], check=True)
+            finally:
+                try:
+                    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+                    shutil.copyfile(local_log_path, log_path)
+                    run_volume.commit()
+                    print(
+                        f"Train log committed to {exp.EXPERIMENT_VOLUME_NAME} at {log_path}"
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    print(f"WARNING: could not commit train log: {exc}")
 
 
 # ── Entrypoints (preparation lives in a separate app: cookbook.miles_disagg.prep_app) ──

--- a/src/stitch/publish.py
+++ b/src/stitch/publish.py
@@ -7,6 +7,7 @@ compose the Store and Pool ports, so they work with any backend — no Modal her
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
 from stitch.pools.base import Pool
@@ -33,6 +34,19 @@ def publish_version(
     then wake the pool. Files land before the pointer moves, so a replica never sees a
     pointer to incomplete bytes."""
     manifest = VersionManifest.from_hf_index(version_dir, run_id=run_id)
+    expected_dir = Path(manifest.ref.identity).name
+    if Path(version_dir).name != expected_dir:
+        raise ValueError(
+            f"checkpoint index identifies {expected_dir!r}, but was published from "
+            f"{Path(version_dir).name!r}"
+        )
+    missing = [
+        name for name in manifest.files if not (Path(version_dir) / name).is_file()
+    ]
+    if missing:
+        raise FileNotFoundError(
+            f"incomplete source version {version_dir}: missing " + ", ".join(missing)
+        )
     decide_pointer_move(store.read_pointer(), manifest.ref)  # rewind guard
     store.publish(manifest, version_dir)
     store.advance_pointer(manifest.ref)

--- a/src/stitch/publish_test.py
+++ b/src/stitch/publish_test.py
@@ -58,6 +58,7 @@ def _version_dir(
         )
     index = {"metadata": meta, "weight_map": {"w": "model-00001.safetensors"}}
     (d / "model.safetensors.index.json").write_text(json.dumps(index))
+    (d / "model-00001.safetensors").write_bytes(b"weights")
     return str(d)
 
 
@@ -91,6 +92,21 @@ def test_publish_rewind_rejected() -> None:
             raise AssertionError("expected PointerRewind")
         except PointerRewind:
             pass
+
+
+def test_publish_rejects_missing_payload_before_pointer_moves() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        store = FakeStore()
+        version_dir = Path(_version_dir(tmp, version=1))
+        (version_dir / "model-00001.safetensors").unlink()
+
+        try:
+            publish_version(store, None, str(version_dir), run_id="r1")
+            raise AssertionError("expected FileNotFoundError")
+        except FileNotFoundError as exc:
+            assert "missing model-00001.safetensors" in str(exc)
+
+        assert store._pointer is None
 
 
 def test_claim_run() -> None:


### PR DESCRIPTION
## What changed

- commit each trainer rank's mounted Volume v2 writes and rendezvous commit failures
- have rank 0 reload the combined durable state, validate checkpoint identity and every indexed payload, then advance `latest`
- propagate rank-0 publication failures back to every distributed rank
- refresh the durable pointer for cross-container request admission while sharing one file-locked reload lease among co-located session-server processes
- tee the live trainer log to local storage and copy it to the experiment Volume after the process exits

## Why

One checkpoint is produced by multiple trainer ranks, but rollout replicas must observe it atomically. The payload shards may become durable independently; `latest` is the commit record and moves only after every rank's commit succeeds and rank 0 verifies the complete checkpoint.

The trainer publisher and rollout request processes have independent Volume views. Request admission therefore needs a refresh, but a trainer container may run many session-server processes. A container-local lease performs at most one reload per run and TTL while each container still refreshes its own mount.

Volume v2 natively composes concurrent writes to distinct shard paths, so this uses the mounted filesystem and `commit()` directly. It does not reread and re-upload checkpoint shards through a second SDK transport.

Keeping the live log local removes the open Volume file that previously prevented rank 0 from reloading the combined state. The log is archived to the Volume in a `finally` block, including failed runs.

## Validation

- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen pytest -q` — 105 passed
- `PYTHONPATH=. uv run --frozen python cookbook/common/hooks_test.py` — 10 passed