### PR TITLE
Fix Flash replica discovery and admission accounting

### DIFF
--- a/cookbook/common/router.py
+++ b/cookbook/common/router.py
@@ -15,11 +15,10 @@ router pins each ``modal-session-id`` to the least-loaded healthy replica via th
 retries on a healthier one, so load spreads instead of sticking.
 
 Deltas from the upstream router: no proxy-auth/api-key secret plumbing (cookbook pools are
-``unauthenticated``), replica discovery reuses ``modal.experimental.flash_get_containers``
-(the same call ``ModalFlashPool`` makes), stdlib logging, and startup tolerates the sibling
-classes still cold-booting (single-app deploys have no boot ordering) instead of dying on
-the first failed poll. The legacy-tuple session-route migration is dropped — per-run route
-dicts start empty.
+``unauthenticated``), replica discovery reuses Stitch's ``ModalFlashPool`` adapter, stdlib
+logging, and startup tolerates the sibling classes still cold-booting (single-app deploys
+have no boot ordering) instead of dying on the first failed poll. The legacy-tuple
+session-route migration is dropped — per-run route dicts start empty.
 """
 
 from __future__ import annotations
@@ -39,8 +38,9 @@ import httpx
 import modal
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import StreamingResponse
-from modal._utils.async_utils import synchronize_api
 from pydantic import BaseModel, TypeAdapter
+
+from stitch.pools.modal_flash import list_flash_containers_async
 
 logger = logging.getLogger(__name__)
 
@@ -75,43 +75,6 @@ def build_router_image(experiment: str, run_id: str) -> modal.Image:
 def session_routes_dict(app_name: str) -> modal.Dict:
     """The run's session→replica affinity store, namespaced to the run app."""
     return modal.Dict.from_name(f"{app_name}-session-routes", create_if_missing=True)
-
-
-async def _list_flash_containers_rpc(app_name: str, cls_name: str) -> list[Any]:
-    from modal.client import _Client
-    from modal.config import config
-    from modal_proto import api_pb2
-
-    client = await _Client.from_env()
-    fn = await client.stub.FunctionGet(
-        api_pb2.FunctionGetRequest(
-            app_name=app_name,
-            object_tag=cls_name,
-            environment_name=config.get("environment") or "",
-        )
-    )
-    resp = await client.stub.FlashContainerList(
-        api_pb2.FlashContainerListRequest(function_id=fn.function_id)
-    )
-    return list(resp.containers)
-
-
-_list_flash_containers_synchronized = synchronize_api(_list_flash_containers_rpc)
-
-
-async def _list_flash_containers(app_name: str, cls_name: str) -> list[Any]:
-    """Live flash containers of an ``@app.server`` class.
-
-    Deliberately not ``modal.experimental.flash_get_containers``: that helper hydrates
-    the class *service-function* tag ``<Cls>.*``, which ``@app.server`` classes don't
-    register — their web function is the plain ``<Cls>`` tag (confirmed by probe:
-    ``FunctionGet('Server')`` resolves while ``'Server.*'`` 404s). Do the two-step the
-    flash-smart-router does: plain-tag FunctionGet, then FlashContainerList by id — and
-    ride the SDK's synchronicity wrapper: a raw ``client.stub`` await on the uvicorn
-    loop never gets its responses pumped (the registry's startup hung on it until
-    Modal restarted the container — a silent crash loop).
-    """
-    return await _list_flash_containers_synchronized.aio(app_name, cls_name)
 
 
 # ── routing state ────────────────────────────────────────────────────────────
@@ -348,7 +311,7 @@ class _RegistryApp(_UvicornApp):
         return queued + running
 
     async def _poll_once(self) -> list[ContainerInfo]:
-        discovered = await _list_flash_containers(self.app_name, self.upstream_cls)
+        discovered = await list_flash_containers_async(self.app_name, self.upstream_cls)
         upstreams = {}
         for container in discovered:
             if isinstance(container, dict):
@@ -471,17 +434,17 @@ class _ProxyApp(_UvicornApp):
         maybe_count = (
             self.count_in_flight(container) if container else contextlib.nullcontext()
         )
-        async with self.client.stream(
-            url=f"{self.upstream_url}/{path}",
-            method=request.method,
-            params=request.query_params,
-            headers=headers,
-            content=body,
-            # Long read timeout: non-streaming completions send nothing until
-            # generation finishes. Connect should still fail fast.
-            timeout=httpx.Timeout(20 * 60, connect=10),
-        ) as response:
-            with maybe_count:
+        with maybe_count:
+            async with self.client.stream(
+                url=f"{self.upstream_url}/{path}",
+                method=request.method,
+                params=request.query_params,
+                headers=headers,
+                content=body,
+                # Long read timeout: non-streaming completions send nothing until
+                # generation finishes. Connect should still fail fast.
+                timeout=httpx.Timeout(20 * 60, connect=10),
+            ) as response:
                 yield response  # first yield: caller inspects status/headers
 
                 start = time.perf_counter()

--- a/cookbook/common/router_test.py
+++ b/cookbook/common/router_test.py
@@ -14,6 +14,7 @@ from cookbook.common.router import (
     RouteEntry,
     RouteEntryList,
     _container_addr,
+    _ProxyApp,
     filter_headers,
     route_session,
     select_least_loaded_container,
@@ -132,6 +133,56 @@ def test_container_addr_normalizes_host_and_port() -> None:
     assert (
         _container_addr(SimpleNamespace(host="h", port=8000, task_id="t")) == "h:8000"
     )
+
+
+def test_upstream_stream_reserves_capacity_before_connecting() -> None:
+    container = _containers(0)["ta-0"]
+
+    class FakeResponse:
+        async def aiter_raw(self):
+            yield b"ok"
+
+    class FakeStream:
+        load_on_enter: int | None = None
+
+        async def __aenter__(self):
+            self.load_on_enter = container.load
+            return FakeResponse()
+
+        async def __aexit__(self, *args):
+            return None
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.stream_context = FakeStream()
+
+        def stream(self, **kwargs):
+            return self.stream_context
+
+    async def run() -> None:
+        app = _ProxyApp(
+            registry_url="https://registry",
+            upstream_url="https://upstream",
+            session_routes=FakeRoutes(),
+        )
+        client = FakeClient()
+        app.client = client
+        stream = app.upstream_stream(
+            SimpleNamespace(method="POST", query_params={}),
+            "v1/chat/completions",
+            {},
+            b"{}",
+            container,
+            "request",
+        )
+
+        await anext(stream)
+        assert client.stream_context.load_on_enter == 1
+        assert container.load == 1
+        assert [chunk async for chunk in stream] == [b"ok"]
+        assert container.load == 0
+
+    asyncio.run(run())
 
 
 if __name__ == "__main__":

--- a/src/stitch/pools/modal_flash.py
+++ b/src/stitch/pools/modal_flash.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from functools import cache
+from typing import Any
 
 from stitch.pools.base import Pool
 from stitch.types import VersionRef
@@ -45,20 +47,11 @@ class ModalFlashPool(Pool):
         return str(url).rstrip("/")
 
     def discover_replicas(self) -> list[str]:
-        import modal.experimental
-
-        return _replica_urls(
-            modal.experimental.flash_get_containers(self.app_name, self.cls_name)
-        )
+        return _replica_urls(list_flash_containers(self.app_name, self.cls_name))
 
     async def discover_replicas_async(self) -> list[str]:
-        import modal.experimental
-
         return _replica_urls(
-            await modal.experimental.flash_get_containers.aio(
-                self.app_name,
-                self.cls_name,
-            )
+            await list_flash_containers_async(self.app_name, self.cls_name)
         )
 
     def wake(self, replicas: list[str], ref: VersionRef) -> None:
@@ -105,6 +98,46 @@ class ModalFlashPool(Pool):
             kwargs["max_containers"] = max
         if kwargs:
             self._server().update_autoscaler(**kwargs)
+
+
+async def _list_flash_containers_rpc(app_name: str, cls_name: str) -> list[Any]:
+    from modal.client import _Client
+    from modal.config import config
+    from modal_proto import api_pb2
+
+    client = await _Client.from_env()
+    fn = await client.stub.FunctionGet(
+        api_pb2.FunctionGetRequest(
+            app_name=app_name,
+            object_tag=cls_name,
+            environment_name=config.get("environment") or "",
+        )
+    )
+    response = await client.stub.FlashContainerList(
+        api_pb2.FlashContainerListRequest(function_id=fn.function_id)
+    )
+    return list(response.containers)
+
+
+@cache
+def _flash_container_lister():
+    from modal._utils.async_utils import synchronize_api
+
+    return synchronize_api(_list_flash_containers_rpc)
+
+
+def list_flash_containers(app_name: str, cls_name: str) -> list[Any]:
+    """Return live containers for an ``@app.server`` function.
+
+    Modal's experimental helper resolves ``<Class>.*``, while ``@app.server``
+    registers the plain ``<Class>`` tag. Resolve that function first, then list
+    its Flash containers by function id.
+    """
+    return _flash_container_lister()(app_name, cls_name)
+
+
+async def list_flash_containers_async(app_name: str, cls_name: str) -> list[Any]:
+    return await _flash_container_lister().aio(app_name, cls_name)
 
 
 def _replica_urls(containers) -> list[str]:

--- a/src/stitch/pools/modal_flash_lb_temp_test.py
+++ b/src/stitch/pools/modal_flash_lb_temp_test.py
@@ -7,6 +7,7 @@ import asyncio
 import sys
 import types
 
+import stitch.pools.modal_flash as modal_flash
 from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
 
 
@@ -33,22 +34,18 @@ def _run_with_fake_modal(urls: dict, containers: list, fn) -> None:
             types.SimpleNamespace(get_url=_SyncAsync(urls.get((app, cls)))),
         )[1]
     )
-    experimental_stub = types.ModuleType("modal.experimental")
-    experimental_stub.flash_get_containers = lambda app, cls: containers
-    modal_stub.experimental = experimental_stub
-    originals = {
-        name: sys.modules.get(name) for name in ("modal", "modal.experimental")
-    }
+    original_modal = sys.modules.get("modal")
+    original_list = modal_flash.list_flash_containers
     sys.modules["modal"] = modal_stub
-    sys.modules["modal.experimental"] = experimental_stub
+    modal_flash.list_flash_containers = lambda app, cls: containers
     try:
         fn(lookups)
     finally:
-        for name, original in originals.items():
-            if original is None:
-                del sys.modules[name]
-            else:
-                sys.modules[name] = original
+        modal_flash.list_flash_containers = original_list
+        if original_modal is None:
+            del sys.modules["modal"]
+        else:
+            sys.modules["modal"] = original_modal
 
 
 def test_gateway_defaults_to_router_cls_in_same_app() -> None:


### PR DESCRIPTION
## What changed

- resolve `@app.server` functions by their registered plain object tag before listing Flash containers
- share one replica-discovery adapter between `ModalFlashPool` and the router
- reserve replica-local capacity before opening the upstream connection
- retain focused router and pool tests

## Why

The public experimental discovery helper resolves a service-function tag that `@app.server` does not register. Reserving capacity only after connection establishment also lets concurrent requests select the same apparently idle replica.

## Validation

- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen pytest -q` — 103 passed