### PR TITLE
Pin DFlash state capture and prefill fixes

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -14,7 +14,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.16",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.16",
-    commit="7b09ce9f77c2290d5271c545d5b8b988c0479584",
+    commit="af563ae597c62ef975821a4e410dc4ef34148bee",
 )
 ```
 
@@ -36,6 +36,9 @@ The branch is upstream v0.5.16 plus:
 | `1051a95a6a` | Balance CPU delta transforms across persistent worker tasks. |
 | `0094b725b9` | Support top-p-only sampling masks through the native generation and chat-completions APIs. |
 | `7b09ce9f77` | Return aligned top-p sampling masks for tokens accepted by DFlash SpecV2. |
+| `a50de4fe3e` | Monitor data-parallel scheduler subprocesses and fail when one exits. |
+| `e02a07c905` | Preserve routed-expert and indexer top-k state-capture outputs through DFlash. |
+| `af563ae597` | Remove attention-TP alignment rows before materializing DFlash prefill KV state. |
 
 The image and branch must use the same SGLang release because Stitch overlays
 Python code onto the image’s existing CUDA and C++ extensions.

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -30,7 +30,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.16",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.16",
-    commit="7b09ce9f77c2290d5271c545d5b8b988c0479584",
+    commit="af563ae597c62ef975821a4e410dc4ef34148bee",
 )
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## What changed

- advance the default SGLang fork pin to `af563ae597c62ef975821a4e410dc4ef34148bee`
- document the DP scheduler liveness, DFlash route/indexer propagation, and attention-TP prefill trimming fixes contained in that fork

## Why

The runtime should consume one immutable SGLang fork commit. The fix belongs in SGLang, so no Stitch image-time patch mechanism is needed.

## Validation

- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen pytest -q` — 102 passed
- SGLang pre-commit checks passed for the fork change
- the equivalent DFlash prefill fix was validated in the four-GPU GLM-5.2 probe