### PR TITLE
Keep shared cookbook code trainer-agnostic

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -47,13 +47,12 @@ Models that require another upstream SGLang line set `SGLANG_RUNTIME` in their
 configuration. The image, fork branch, and immutable commit stay together so
 the Python overlay remains ABI-compatible with the image.
 
-[`kimi_k3_mxfp4.py`](../miles_disagg/configs/kimi_k3_mxfp4.py) pins the public
-K3 image and `stitch-sglang-kimi-k3` fork. That fork ports the
-same weight-sync responsibilities onto SGLang’s public `kimi-k3` branch; other
-recipes continue to use the v0.5.16 default. Its K3-native loader narrows expert
-lookup, batches safe copies, scopes post-load work to loaded modules, and
-transforms Blackwell MXFP4 runtime layouts on GPU before caching rank-ready host
-images.
+Kimi K3 MXFP4 recipes pin the public K3 image and `stitch-sglang-kimi-k3` fork.
+That fork ports the same weight-sync responsibilities onto SGLang’s public
+`kimi-k3` branch; other recipes continue to use the v0.5.16 default. Its
+K3-native loader narrows expert lookup, batches safe copies, scopes post-load
+work to loaded modules, and transforms Blackwell MXFP4 runtime layouts on GPU
+before caching rank-ready host images.
 
 ## API
 

--- a/cookbook/common/config.py
+++ b/cookbook/common/config.py
@@ -1,8 +1,7 @@
-"""``ModalConfig`` — the Modal-infrastructure half of an experiment config, shared by
-every recipe (GPU model, region, rollout-pool sizing, prep topology).
+"""``ModalConfig`` — the shared Modal-infrastructure half of an experiment config.
 
-The framework *training* config (``MilesConfig`` / ``SlimeConfig``) is self-contained in
-each framework's subdir; only this infra grouping is common.
+Training arguments remain in each trainer integration; GPU selection, region, rollout-pool
+sizing, and preparation topology live here.
 """
 
 from __future__ import annotations

--- a/cookbook/common/hooks.py
+++ b/cookbook/common/hooks.py
@@ -1,11 +1,8 @@
-"""Shared framework-hook logic (miles and slime both write the same HF-delta layout to
-a Modal Volume and wake a Modal Flash pool, so the logic is one place).
+"""Shared trainer hooks for publishing HF weight updates and routing rollout requests.
 
-Each run config points its hook paths straight at this module (e.g.
-``custom_delta_pre_push_path = "cookbook.common.hooks.commit_and_wake"``). Each hook reads
-the run's coordinates off the trainer's ``args`` namespace (the framework ``setattr``s its
-``custom_config_path`` onto it) and calls the stitch core against a ModalVolumeStore +
-ModalFlashPool.
+Trainer integrations point their lifecycle callbacks at this module. Each hook reads the
+run coordinates from the trainer's argument namespace and composes the Stitch core with a
+``ModalVolumeStore`` and ``ModalFlashPool``.
 """
 
 from __future__ import annotations
@@ -165,9 +162,9 @@ async def gated_rollout_request_hook(
 class _CachedPointer:
     """TTL-cached durable ``latest`` version for request admission.
 
-    Publication runs on trainer ranks while request hooks run in rollout/session-server
-    processes, so their Volume mounts have independent visibility. Co-located request
-    processes share a file-locked refresh lease to reload at most once per TTL.
+    Publication runs on trainer ranks while request hooks may run in separate processes,
+    so their Volume mounts can have independent visibility. Co-located request processes
+    share a file-locked refresh lease to reload at most once per TTL.
     """
 
     def __init__(self) -> None:
@@ -214,7 +211,7 @@ class _CachedPointer:
 def _refresh_mount(store: ModalVolumeStore, ttl: float) -> None:
     """Refresh a mounted Volume at most once per container and TTL.
 
-    Miles may run many session-server processes in one container. They share the mount
+    A trainer may run many request-hook processes in one container. They share the mount
     and this local ``flock`` lease, so one process reloads while the others reuse the
     resulting view. Separate containers get their own lease and refresh independently.
     """
@@ -283,6 +280,6 @@ def _run_id(args: Any) -> str:
     run_id = getattr(args, "run_id", None)
     if not run_id:
         raise ValueError(
-            "run_id is required (pass it via custom_config_path) — it is the run's fence token"
+            "run_id is required in the trainer hook arguments — it is the run's fence token"
         )
     return str(run_id)

--- a/cookbook/common/launch.py
+++ b/cookbook/common/launch.py
@@ -1,36 +1,24 @@
-"""Trainer-launch helpers shared by every recipe: build the train command (sourcing the
-model-arch MODEL_ARGS script) and resolve/materialize a config before launch. Both are
-framework-agnostic given the framework's root + model-script attribute + YAML fields.
-"""
+"""Trainer-launch infrastructure shared by every recipe."""
 
 from __future__ import annotations
 
 import os
-import shlex
 from typing import Any
 
 
-def build_train_cmd(cfg: Any, root: str, model_script_attr: str) -> str:
-    """The train command. ``train_async.py`` / ``train.py`` live at the framework root
-    and consume the ``MODEL_ARGS`` bash array defined by the sourced model script."""
-    train_script = f"{root}/{'train_async.py' if cfg.async_mode else 'train.py'}"
-    model_script = getattr(cfg, model_script_attr, "")
-    if model_script:
-        inner = (
-            f"source {root}/{model_script} && "
-            f"python3 {train_script} ${{MODEL_ARGS[@]}} {shlex.join(cfg.cli_args())}"
-        )
-        return f"bash -c {shlex.quote(inner)}"
-    return f"python3 {train_script} {shlex.join(cfg.cli_args())}"
-
-
-def resolve_config(cfg: Any, tmpdir: str, yaml_fields: tuple[str, ...]) -> None:
+def resolve_config(
+    cfg: Any,
+    tmpdir: str,
+    *,
+    checkpoint_fields: tuple[str, ...],
+    yaml_fields: tuple[str, ...],
+) -> None:
     """Resolve HF repo-id checkpoint fields to local paths and materialize inline YAML
     config dicts to files the trainer reads. Absolute paths are left untouched."""
     import yaml
     from huggingface_hub import snapshot_download
 
-    for attr in ("hf_checkpoint", "load", "ref_load", "critic_load"):
+    for attr in checkpoint_fields:
         if (val := getattr(cfg, attr, None)) and not str(val).startswith("/"):
             setattr(cfg, attr, snapshot_download(val, local_files_only=True))
     for field in yaml_fields:
@@ -44,10 +32,10 @@ def resolve_config(cfg: Any, tmpdir: str, yaml_fields: tuple[str, ...]) -> None:
 def materialize_node_local_yaml(
     cfg: Any, field: str, dest_dir: str = "/root/.node_yaml"
 ) -> None:
-    """Write an inline-dict config field to a deterministic node-local YAML path, so every Ray
-    actor across nodes re-reads identical content at an identical path — unlike ``resolve_config``'s
-    per-launch tmpdir. Call on every node (before the rank gate). No-op unless the field is a dict;
-    mutates ``cfg`` in place. (e.g. miles' ``te_precision_config_file``.)"""
+    """Write an inline-dict config field to a deterministic node-local YAML path, so every
+    worker re-reads identical content at an identical path — unlike ``resolve_config``'s
+    per-launch tmpdir. Call on every node before the rank gate. No-op unless the field is
+    a dict; mutates ``cfg`` in place."""
     import yaml
 
     if isinstance(val := getattr(cfg, field, None), dict):

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -1,10 +1,10 @@
-"""The weight-sync sglang SERVING image — shared by every recipe.
+"""The trainer-agnostic weight-sync SGLang image shared by every recipe.
 
-Trainer-agnostic: no trainer package is installed (the delta apply lives in the engine behind
-``/stage_weight_update``), so miles and slime serve on the identical image; precision comes
-from the served checkpoint, not a ``--quantization`` flag. The fork pin carries asynchronous
-weight staging, correct quantized weight loading, and the optional CPU delta cache. See
-``SGLANG_FORK.md`` for the patch stack and how to re-port onto a newer sglang release.
+No trainer package is installed: delta application lives in the engine behind
+``/stage_weight_update``. Precision comes from the served checkpoint, not a
+``--quantization`` flag. The fork pin carries asynchronous weight staging, correct
+quantized weight loading, and the optional CPU delta cache. See ``SGLANG_FORK.md`` for
+the patch stack and how to re-port onto a newer SGLang release.
 """
 
 from __future__ import annotations

--- a/cookbook/common/trainer_image.py
+++ b/cookbook/common/trainer_image.py
@@ -22,7 +22,7 @@ def add_common_layers(
     """Append the framework-agnostic trainer layers: the trainer-side delta ENCODER's codecs
     (needed even under --no-deps), the HF-download env (``EXPERIMENT_CONFIG``/``RUN_ID`` so a
     container's re-import selects the same experiment/run as the deploy), and the stitch + cookbook
-    source so the trainer, Ray actors, and the sidecar subprocess resolve their imports.
+    source so trainer workers and the sidecar subprocess resolve their imports.
 
     ``copy_source=True`` bakes those sources into image layers.  Callers that need to append
     build steps must opt into that mode because Modal intentionally rejects build steps after a

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -348,8 +349,13 @@ class Trainer:
             "run_id": RUN_ID,
         }
         cfg.custom_config_path = custom_config
-        launch.resolve_config(cfg, tempfile.mkdtemp(), YAML_CONFIG_FIELDS)
-        cmd = launch.build_train_cmd(cfg, MILES_ROOT, "miles_model_script")
+        launch.resolve_config(
+            cfg,
+            tempfile.mkdtemp(),
+            checkpoint_fields=("hf_checkpoint", "load", "ref_load", "critic_load"),
+            yaml_fields=YAML_CONFIG_FIELDS,
+        )
+        cmd = _build_train_cmd(cfg)
 
         # Claim the pool before miles publishes: reset every replica to base for this run.
         from cookbook.common import hooks
@@ -381,6 +387,18 @@ class Trainer:
                     )
                 except Exception as exc:  # noqa: BLE001
                     print(f"WARNING: could not commit train log: {exc}")
+
+
+def _build_train_cmd(cfg: MilesConfig) -> str:
+    train_script = f"{MILES_ROOT}/{'train_async.py' if cfg.async_mode else 'train.py'}"
+    model_script = cfg.miles_model_script
+    if model_script:
+        inner = (
+            f"source {MILES_ROOT}/{model_script} && "
+            f"python3 {train_script} ${{MODEL_ARGS[@]}} {shlex.join(cfg.cli_args())}"
+        )
+        return f"bash -c {shlex.quote(inner)}"
+    return f"python3 {train_script} {shlex.join(cfg.cli_args())}"
 
 
 # ── Entrypoints (preparation lives in a separate app: cookbook.miles_disagg.prep_app) ──

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import shlex
 import subprocess
 import tempfile
 from types import SimpleNamespace
@@ -316,8 +317,13 @@ class Trainer:
         cfg.custom_config_path = (
             hook_knobs  # materialized to a YAML path below; keep the mapping for claim
         )
-        launch.resolve_config(cfg, tempfile.mkdtemp(), YAML_CONFIG_FIELDS)
-        cmd = launch.build_train_cmd(cfg, SLIME_ROOT, "slime_model_script")
+        launch.resolve_config(
+            cfg,
+            tempfile.mkdtemp(),
+            checkpoint_fields=("hf_checkpoint", "load", "ref_load", "critic_load"),
+            yaml_fields=YAML_CONFIG_FIELDS,
+        )
+        cmd = _build_train_cmd(cfg)
 
         # Claim the pool before slime publishes: reset every replica to base for this run.
         from cookbook.common import hooks
@@ -333,6 +339,18 @@ class Trainer:
         )
         print(f"Command: {cmd}")
         subprocess.run(["bash", "-lc", cmd], check=True)
+
+
+def _build_train_cmd(cfg: SlimeConfig) -> str:
+    train_script = f"{SLIME_ROOT}/{'train_async.py' if cfg.async_mode else 'train.py'}"
+    model_script = cfg.slime_model_script
+    if model_script:
+        inner = (
+            f"source {SLIME_ROOT}/{model_script} && "
+            f"python3 {train_script} ${{MODEL_ARGS[@]}} {shlex.join(cfg.cli_args())}"
+        )
+        return f"bash -c {shlex.quote(inner)}"
+    return f"python3 {train_script} {shlex.join(cfg.cli_args())}"
 
 
 # ── Entrypoints (preparation lives in a separate app: cookbook.slime_disagg.prep_app) ──

--- a/cookbook/trainer_image_integration_test.py
+++ b/cookbook/trainer_image_integration_test.py
@@ -8,6 +8,8 @@ from cookbook.miles_disagg import trainer_image as miles_trainer_image
 from cookbook.slime_disagg import trainer_image as slime_trainer_image
 
 
+# Cross-integration coverage lives at the cookbook boundary so ``cookbook.common``
+# never imports the trainer-specific packages that consume it.
 class _OrderingImage:
     """Small Modal Image ordering model: build layers may not follow runtime mounts."""
 
@@ -75,10 +77,10 @@ def test_sources_remain_fast_runtime_mounts_by_default(
 
 
 @pytest.mark.parametrize(
-    ("trainer_image", "local_source_arg", "local_source"),
+    ("trainer_image", "local_source_arg", "local_source", "trainer_root"),
     [
-        (miles_trainer_image, "miles_local", "/local/miles"),
-        (slime_trainer_image, "slime_local", "/local/slime"),
+        (miles_trainer_image, "miles_local", "/local/miles", "/root/miles"),
+        (slime_trainer_image, "slime_local", "/local/slime", "/root/slime"),
     ],
     ids=["miles", "slime"],
 )
@@ -87,6 +89,7 @@ def test_copy_source_image_can_be_extended_after_local_fork_overlay(
     trainer_image: Any,
     local_source_arg: str,
     local_source: str,
+    trainer_root: str,
 ) -> None:
     image = _build(
         monkeypatch,
@@ -99,4 +102,4 @@ def test_copy_source_image_can_be_extended_after_local_fork_overlay(
     assert not image.has_runtime_mount
     image.env({"TRAINER_GPU": "B300"})
     image.add_local_file("patch", "/root/patch", copy=True)
-    image.run_commands("cd /root/miles && git apply /root/patch")
+    image.run_commands(f"cd {trainer_root} && git apply /root/patch")


### PR DESCRIPTION
## What changed

- remove trainer-specific names and examples from shared cookbook documentation
- describe request-gate Volume refreshes through the generic trainer-hook contract
- move cross-trainer image coverage from `cookbook/common` to the cookbook integration boundary
- move trainer command construction into each trainer integration
- make checkpoint-field resolution explicit at the integration boundary instead of hardcoding trainer fields in `common`

## Why

`cookbook/common` is the shared layer consumed by trainer integrations. It should own Modal, Stitch, SGLang, and shared PyTorch-distributed infrastructure—not the command layout, field names, imports, or terminology of a particular trainer.

A trainer using the reference Modal/PyTorch stack can reuse these components through the documented hook arguments. Trainers with a different process or request contract provide an adapter rather than changing the shared layer.

Runtime behavior is unchanged.

## Validation

- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen pytest -q` — 107 passed
- verified no trainer names, trainer-package imports, trainer script names, or hardcoded checkpoint-field names remain under `cookbook/common`