### PR TITLE
Accelerate mid-run replica bootstrap from saved checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Pool gateway ──────────────────────�
 - **Continuous policy updates.** Replicas stage and verify the next full
   checkpoint or delta while serving. Weight activation briefly pauses the
   engine and gates new requests.
-- **Elastic rollout capacity.** New replicas load the base policy, catch up to
-  the current version, and enter rotation only when ready.
+- **Elastic rollout capacity.** New replicas load an eligible policy
+  checkpoint, catch up to the current version, and enter rotation only when
+  ready.
 - **Failure-safe convergence.** Version bytes become durable before the shared
   pointer advances. A replica reports a version only after its engine activates
   it successfully.

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -121,6 +121,12 @@ normally. Stop it with Ctrl-C. It is off by default and requires
 `save_interval`, `save_hf`, and optimizer/RNG checkpointing. A fresh run becomes
 resumable after its first complete Megatron/Hugging Face checkpoint pair.
 
+With the Modal Volume store, complete Hugging Face checkpoints also accelerate
+elastic rollout startup. When a Miles recipe saves checkpoints and updates
+weights every step, a new replica loads the current run's newest complete
+checkpoint no newer than `latest`, then applies only the remaining deltas.
+Before the first save, it catches up from the run's configured boot checkpoint.
+
 ### 6. Inspect or change a live run
 
 Follow logs using the app name printed by the launcher:
@@ -257,11 +263,12 @@ Each experiment Volume contains only run-scoped state:
     ├── updates/weight_vNNNNNN/
     ├── checkpoints/
     ├── hf_checkpoints/weight_vNNNNNN/
+    │   └── .complete
     └── train.log
 ```
 
-The training framework owns `updates/`; Stitch owns the `latest` commit
-pointer. A resumed checkpoint starts a new run and reads the previous run's
+The training framework owns `updates/` and the saved checkpoints; Stitch owns
+`latest`. A resumed checkpoint starts a new run and reads the previous run's
 `checkpoints/` rather than appending to its update chain.
 
 Datasets are independent of models and runs:

--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -65,8 +65,9 @@ def serve_startup(
         log_requests_level=-1,
     )
     replica.endpoint.start()
+    served_model_name = str(sglang_args.get("--served-model-name", model_name))
     warmup = {
-        "model": model_name,
+        "model": served_model_name,
         "messages": [{"role": "user", "content": "Reply with exactly OK."}],
         "max_tokens": 8,
         "temperature": 0,
@@ -123,7 +124,10 @@ def serve_startup(
         on_failure=lambda: modal.experimental.stop_fetching_inputs(),
         max_consecutive_failures=12,  # ~1 min of sustained idle-state failures
     )
-    print(f"Rollout server ready: model={model_name}, target_inputs={concurrency}")
+    print(
+        f"Rollout server ready: model={served_model_name}, "
+        f"boot_version={boot_version}, target_inputs={concurrency}"
+    )
 
 
 def serve_stop(replica: Any) -> None:

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -25,6 +25,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -49,9 +50,11 @@ from cookbook.miles_disagg.config import YAML_CONFIG_FIELDS, MilesConfig
 from cookbook.miles_disagg.resume import (
     RESUME_POINT_ENV,
     ResumePoint,
+    saved_checkpoint_version,
 )
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
 from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
+from stitch.types import VersionRef
 
 EXPERIMENT = os.environ[
     "EXPERIMENT_CONFIG"
@@ -74,11 +77,6 @@ def _resume_point() -> ResumePoint | None:
 def _rollout_boot_checkpoint() -> str:
     point = _resume_point()
     return point.rollout_checkpoint if point is not None else miles_cfg.hf_checkpoint
-
-
-def _rollout_boot_version() -> int:
-    point = _resume_point()
-    return point.version if point is not None else 0
 
 
 # Per-run id, minted fresh by cookbook.miles_disagg.launch. The same identity
@@ -220,10 +218,66 @@ class Server:
     def startup(self) -> None:
         STORE_DEPLOYMENT.bootstrap_credentials()
         store_config = STORE_DEPLOYMENT.hook_config(APP_NAME)
+        resume_point = _resume_point()
+        model_name = (
+            resume_point.rollout_checkpoint
+            if resume_point is not None
+            else miles_cfg.hf_checkpoint
+        )
+        boot_version = resume_point.version if resume_point is not None else 0
+        save_hf = getattr(miles_cfg, "save_hf", None)
+        # TODO: support larger update intervals once saved checkpoints expose the
+        # exact published weight version instead of only Miles' rollout ID.
+        update_every_step = getattr(miles_cfg, "update_weights_interval", 1) == 1
+        if (
+            STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME
+            and save_hf
+            and getattr(miles_cfg, "save_interval", None) is not None
+            and update_every_step
+        ):
+            relative_path = Path(save_hf.format(rollout_id=0))
+            if relative_path.is_absolute() or ".." in relative_path.parts:
+                raise ValueError("save_hf must be a run-relative path")
+
+            # Read complete HF exports and the published pointer from one Volume
+            # snapshot. A save ahead of latest is not eligible yet.
+            run_volume.reload()
+            store = storage.create_store(
+                store_config["stitch_store_backend"],
+                local_root=RUN_DIR,
+                run_id=RUN_ID,
+                volume_name=exp.EXPERIMENT_VOLUME_NAME,
+            )
+            latest = store.read_pointer()
+            if latest is not None:
+                if latest.run_id != RUN_ID:
+                    raise ValueError(
+                        f"latest belongs to run {latest.run_id!r}, not {RUN_ID!r}"
+                    )
+                checkpoints = []
+                for marker in (RUN_DIR / relative_path.parent).glob("*/.complete"):
+                    try:
+                        saved_rollout_id = VersionRef.parse(marker.parent.name).version
+                    except ValueError:
+                        continue
+                    if marker.parent != RUN_DIR / save_hf.format(
+                        rollout_id=saved_rollout_id
+                    ):
+                        continue
+                    saved_version = saved_checkpoint_version(
+                        saved_rollout_id,
+                        resumed=resume_point is not None,
+                    )
+                    if boot_version <= saved_version <= latest.version:
+                        checkpoints.append((saved_version, marker.parent))
+                if checkpoints:
+                    saved_version, checkpoint = max(checkpoints)
+                    model_name = str(checkpoint)
+                    boot_version = saved_version
         server.serve_startup(
             self,
-            model_name=_rollout_boot_checkpoint(),
-            boot_version=_rollout_boot_version(),
+            model_name=model_name,
+            boot_version=boot_version,
             sglang_args=SGLANG_SERVER_ARGS,
             tp=miles_cfg.rollout_num_gpus_per_engine,
             concurrency=ROLLOUT_CONCURRENCY,

--- a/cookbook/miles_disagg/configs/glm45_air_bf16.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16.py
@@ -113,6 +113,7 @@ class _Miles(MilesConfig):
 
     num_rollout = 3
     save_interval = 20
+    save_hf = "hf_checkpoints/weight_v{rollout_id:06d}"
     rollout_batch_size = 16
     rollout_max_response_len = 4096
     rollout_temperature = 0.8

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -296,6 +296,7 @@ class _Miles(MilesConfig):
 
     num_rollout = 500
     save_interval = 10
+    save_hf = "hf_checkpoints/weight_v{rollout_id:06d}"
     rollout_batch_size = ROLLOUT_BATCH_SIZE
     n_samples_per_prompt = N_SAMPLES_PER_PROMPT
     global_batch_size = 256

--- a/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
@@ -146,6 +146,7 @@ class _Miles(MilesConfig):
     # Tiny smoke: a couple of rollout/train steps to close the loop fast.
     num_rollout = 2
     save_interval = 10
+    save_hf = "hf_checkpoints/weight_v{rollout_id:06d}"
     rollout_batch_size = 16
     rollout_max_response_len = 2048
     rollout_temperature = 0.8

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4.py
@@ -111,9 +111,8 @@ class _Miles(MilesConfig):
     eval_interval = None
 
     num_rollout = 20
-    save_interval = (
-        1000  # megatron requires it; > num_rollout so the smoke skips megatron saves
-    )
+    save_interval = 1000  # The short smoke saves only its final checkpoint.
+    save_hf = "hf_checkpoints/weight_v{rollout_id:06d}"
     rollout_batch_size = 32
     rollout_max_response_len = 4096  # fits within the 8192 context (prompt + response)
     rollout_temperature = 0.8

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -40,6 +40,16 @@ class ResumePoint:
         )
 
 
+def saved_checkpoint_version(rollout_id: int, *, resumed: bool) -> int:
+    """Return the Stitch version stored by a Miles ``save_hf`` checkpoint.
+
+    A fresh trainer starts rollout 0 from Stitch v0, so save N precedes the
+    publication of vN+1. A resumed trainer starts rollout N+1 from Stitch vN,
+    so subsequent save IDs and Stitch versions are equal.
+    """
+    return rollout_id if resumed else rollout_id + 1
+
+
 def validate_auto_resume_config(cfg: Any) -> None:
     """Require an explicit, resumable checkpoint policy before automatic resume."""
     validate_resume_config(cfg)

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -5,6 +5,7 @@ import pytest
 from cookbook.miles_disagg.resume import (
     ResumePoint,
     resolve_resume_point,
+    saved_checkpoint_version,
     validate_auto_resume_config,
     validate_resume_config,
 )
@@ -25,6 +26,17 @@ class _Config:
     save_interval = 20
     save_hf = "hf_checkpoints/weight_v{rollout_id:06d}"
     no_save_optim = False
+
+
+@pytest.mark.parametrize(
+    ("rollout_id", "resumed", "version"),
+    [
+        (19, False, 20),
+        (120, True, 120),
+    ],
+)
+def test_saved_checkpoint_version(rollout_id: int, resumed: bool, version: int) -> None:
+    assert saved_checkpoint_version(rollout_id, resumed=resumed) == version
 
 
 def test_resolve_resume_point_pairs_megatron_and_hf_checkpoints() -> None:


### PR DESCRIPTION
## What

- let a new Miles rollout replica inspect the current run's existing `save_hf` directory when publications use the Modal Volume store
- load the newest complete saved checkpoint whose corresponding published version is no newer than the run's durable `latest` pointer
- initialize the existing reconciler at that published version so it applies only the remaining delta tail
- preserve both fresh-run and resumed-run checkpoint numbering
- fall back to the configured run boot checkpoint when no eligible save exists, including with the S3 publication backend
- keep a stable SGLang served-model name while the physical checkpoint path varies between replicas
- enable complete HF saves in the bundled Miles training recipes that already save trainer checkpoints

## Why

A mid-run replica currently loads the run's original boot checkpoint and replays its entire delta history. Periodic full saves already contain newer policy weights, so startup should depend on the tail after the latest complete save rather than the age of the run.

This is independent of autoresume. A mid-run replica stays in the same run and reads only that run's saves. Autoresume creates a new run ID and uses a previous run's checkpoint as the new run's initial state.

The S3 store introduced on main transports Stitch policy publications, while Miles HF saves remain framework-owned files on the experiment Volume. This PR therefore does not invent a cross-store checkpoint contract: S3 replicas retain the existing base-plus-delta catch-up path.

## Correctness

- checkpoint discovery and `latest` are read from one Modal Volume snapshot before model files are opened
- an incomplete save has no `.complete` marker and is ignored
- a complete save ahead of `latest` is ignored until its corresponding weight version is published
- with one update per step, a fresh run's save N contains Stitch vN+1, while a resumed run's save N contains Stitch vN
- the resume checkpoint and version remain the initial physical and logical boot state until the current run has an eligible complete save
- other update cadences safely use the original boot path until the save contract exposes the exact published version
- the rebased startup path preserves main's storage credential bootstrap and passes its backend-specific configuration to the common sidecar
- no new checkpoint metadata, mutable pointer, save hook, Miles patch, SGLang RPC, or checkpoint copy is introduced

## Validation

- `uv run --frozen ruff check ...`
- `uv run --frozen ruff format --check ...`
- `uv run --frozen pytest -q` — 164 passed
- focused tests cover fresh save N → vN+1 and resumed save N → vN
- live H200 canary on fresh run `a6a494fb`: selected complete `weight_v000119` as Stitch v120, folded v121-v125, and validated the reconstructed tensor checksums
- preparation: CPU cache init 51.1s; v120→v125 stage 107.5s
- engine pause: 1.11s
- final smoke returned `OK` with `weight_version_start=weight_version_end=125` and server state `applied=a6a494fb/weight_v000125`
