### PR TITLE
Bump the Stitch SGLang fork pin

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -14,7 +14,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.17",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.17",
-    commit="974035001038645296f584583b46f245513928a6",
+    commit="bc992874b335d0b6e314f9e883d9f55df185740d",
 )
 ```
 

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -30,7 +30,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.17",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.17",
-    commit="974035001038645296f584583b46f245513928a6",
+    commit="bc992874b335d0b6e314f9e883d9f55df185740d",
 )
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary

- update the cookbook serving image to the rewritten `stitch-sglang-v0.5.17` tip
- keep the documented fork pin in sync

The rewritten fork tip includes the root-group weight-image path fix.

## Validation

- `uv run --no-config pytest` (136 passed)
- `uv run --no-config pytest -q cookbook/common/serving_image_test.py`
- Ruff check and format check