### PR TITLE
Supervise sidecars for unrecoverable engine failures

### DIFF
--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from stitch.service import sync_in_progress
+from stitch.service import engine_health_may_be_stale
 
 from . import process
 from .constants import SGLANG_PORT, SIDECAR_PORT
@@ -106,14 +106,16 @@ def serve_startup(
     )
 
     def engine_health() -> str | None:
-        # Weight staging can make the engine health endpoint briefly stale.
-        # Suppress that expected blip only while the reconciler reports work.
+        # Applying staged weights pauses inference. Staging does not, so a health
+        # failure during staging must remain visible as a stalled-engine signal.
         error = replica.endpoint.health_check()
         if error is None:
             return None
         return (
             None
-            if sync_in_progress(f"http://127.0.0.1:{SIDECAR_PORT}/server_info")
+            if engine_health_may_be_stale(
+                f"http://127.0.0.1:{SIDECAR_PORT}/server_info"
+            )
             else error
         )
 

--- a/src/stitch/engines/base.py
+++ b/src/stitch/engines/base.py
@@ -7,9 +7,33 @@ shape. Subclasses override the methods they use —
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 from stitch.types import VersionManifest, VersionRef
+
+
+class EngineHealthStatus(str, Enum):
+    """How conclusively the sidecar can account for an engine health failure."""
+
+    HEALTHY = "healthy"
+    UNRESPONSIVE = "unresponsive"
+    UNREACHABLE = "unreachable"
+
+
+@dataclass(frozen=True)
+class EngineHealth:
+    """One engine-liveness probe result.
+
+    ``UNRESPONSIVE`` includes timeouts and non-200 health responses. Whether a
+    transition explains one is engine-specific; the rollout sidecar exempts only
+    its explicit paused-apply window. ``UNREACHABLE`` means the sidecar could not
+    establish a connection to its colocated engine at all.
+    """
+
+    status: EngineHealthStatus
+    detail: str = ""
 
 
 class Engine:
@@ -77,3 +101,7 @@ class Engine:
         """Engine control routes the versioned proxy must never forward: a stray external
         call would mutate engine state behind the reconciler's back. Default: none."""
         return frozenset()
+
+    async def check_health(self) -> EngineHealth:
+        """Probe whether the colocated engine can still serve requests."""
+        raise NotImplementedError

--- a/src/stitch/engines/sglang.py
+++ b/src/stitch/engines/sglang.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal
 
-from stitch.engines.base import Engine
+from stitch.engines.base import Engine, EngineHealth, EngineHealthStatus
+from stitch.errors import UnrecoverableEngineError
 from stitch.types import VersionKind, VersionManifest, VersionRef
 
 
@@ -19,6 +20,7 @@ class SGLangEngine(Engine):
         delta_update_mode: Literal["disk", "cpu"] = "disk",
         disk_load_format: str = "auto",
         control_timeout: float = 120.0,
+        health_timeout: float = 5.0,
         weight_staging_timeout: float = 3600.0,
         weight_update_timeout: float = 600.0,
     ) -> None:
@@ -35,6 +37,7 @@ class SGLangEngine(Engine):
         self.delta_update_mode = delta_update_mode
         self.disk_load_format = disk_load_format
         self._control_timeout = control_timeout
+        self._health_timeout = health_timeout
         self._weight_staging_timeout = weight_staging_timeout
         self._weight_update_timeout = weight_update_timeout
         self._boot_version = 0
@@ -55,6 +58,29 @@ class SGLangEngine(Engine):
                 "continue_generation",
                 "abort_request",
             }
+        )
+
+    async def check_health(self) -> EngineHealth:
+        """Distinguish an absent process from an engine busy doing weight work."""
+        import httpx
+
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._health_timeout, trust_env=False
+            ) as client:
+                response = await client.get(f"{self._base_url}/health")
+        except httpx.ConnectError as exc:
+            return EngineHealth(EngineHealthStatus.UNREACHABLE, str(exc))
+        except httpx.RequestError as exc:
+            return EngineHealth(
+                EngineHealthStatus.UNRESPONSIVE,
+                f"{type(exc).__name__}: {exc}",
+            )
+        if response.status_code == 200:
+            return EngineHealth(EngineHealthStatus.HEALTHY)
+        return EngineHealth(
+            EngineHealthStatus.UNRESPONSIVE,
+            f"health endpoint returned HTTP {response.status_code}",
         )
 
     async def stage(self, manifest: VersionManifest, source_dir: str) -> None:
@@ -115,7 +141,7 @@ class SGLangEngine(Engine):
 
     async def reset(self) -> None:
         if self.delta_update_mode == "cpu":
-            raise RuntimeError(
+            raise UnrecoverableEngineError(
                 "CPU delta update mode cannot restore a live engine to its boot checkpoint; "
                 "start a fresh rollout replica for a new run"
             )

--- a/src/stitch/engines/sglang_test.py
+++ b/src/stitch/engines/sglang_test.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 
+import httpx
 import pytest
 
+from stitch.engines.base import EngineHealthStatus
 from stitch.engines.sglang import SGLangEngine
 from stitch.types import VersionKind, VersionManifest, VersionRef
 
@@ -310,6 +312,52 @@ def test_staging_and_commit_have_independent_timeouts() -> None:
         ("/stage_weight_update", 3600.0),
         ("/update_weights_from_disk", 600.0),
     ]
+
+
+class _HealthClient:
+    def __init__(self, outcome) -> None:
+        self.outcome = outcome
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args) -> None:
+        pass
+
+    async def get(self, url: str) -> httpx.Response:
+        if isinstance(self.outcome, Exception):
+            raise self.outcome
+        return httpx.Response(self.outcome, request=httpx.Request("GET", url))
+
+
+@pytest.mark.parametrize(
+    "outcome,expected",
+    [
+        (200, EngineHealthStatus.HEALTHY),
+        (503, EngineHealthStatus.UNRESPONSIVE),
+        (
+            httpx.ReadTimeout("busy", request=httpx.Request("GET", "http://engine")),
+            EngineHealthStatus.UNRESPONSIVE,
+        ),
+        (
+            httpx.ConnectError(
+                "connection refused",
+                request=httpx.Request("GET", "http://engine"),
+            ),
+            EngineHealthStatus.UNREACHABLE,
+        ),
+    ],
+)
+def test_health_check_classifies_engine_failures(
+    monkeypatch, outcome, expected
+) -> None:
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **_kwargs: _HealthClient(outcome),
+    )
+    engine = SGLangEngine("http://engine", "/base", "/ckpt")
+    assert asyncio.run(engine.check_health()).status is expected
 
 
 if __name__ == "__main__":

--- a/src/stitch/errors.py
+++ b/src/stitch/errors.py
@@ -1,0 +1,9 @@
+"""Failure types whose recovery boundary is the rollout replica process."""
+
+
+class UnrecoverableSidecarError(RuntimeError):
+    """A failure which requires replacing, rather than retrying, this sidecar."""
+
+
+class UnrecoverableEngineError(UnrecoverableSidecarError):
+    """The local inference engine cannot recover inside this replica."""

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -26,6 +26,12 @@ from stitch.pools.base import Pool
 from stitch.stores.base import Store
 from stitch.sync import CommitMode, ConstraintUnmet, Reconciler
 from stitch.types import PoolState, ReplicaState, SyncState, VersionConstraint
+from stitch.watchdog import (
+    EngineWatchdog,
+    SidecarWatchdog,
+    TerminalFailureMonitor,
+    run_server_with_watchdog,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -265,6 +271,8 @@ def serve(
     port: int = 8000,
     debug_requests: bool = False,
     reconcile_interval: float = 5.0,
+    watchdog_interval: float = 5.0,
+    watchdog_failure_threshold: int = 3,
 ) -> None:
     """Run one replica's sidecar: build the Reconciler over the given store+engine
     and serve the versioned proxy. The deployment supplies the concrete instances."""
@@ -280,7 +288,19 @@ def serve(
         debug_requests=debug_requests,
         reconcile_interval=reconcile_interval,
     )
-    uvicorn.run(create_app(reconciler, engine), host=host, port=port, log_level="info")
+    watchdog = SidecarWatchdog(
+        EngineWatchdog(
+            engine,
+            engine_health_may_be_stale=reconciler.engine_health_may_be_stale,
+            interval=watchdog_interval,
+            failure_threshold=watchdog_failure_threshold,
+        ),
+        TerminalFailureMonitor(reconciler.wait_for_terminal_error),
+    )
+    config = uvicorn.Config(
+        create_app(reconciler, engine), host=host, port=port, log_level="info"
+    )
+    asyncio.run(run_server_with_watchdog(uvicorn.Server(config), watchdog))
 
 
 async def readiness(pool: Pool, *, timeout: float = 15.0) -> PoolState:
@@ -304,19 +324,12 @@ async def readiness(pool: Pool, *, timeout: float = 15.0) -> PoolState:
     return PoolState(list(states))
 
 
-# The reconciler states in which the engine is legitimately unresponsive: it is
-# staging or loading weights, so a stale health heartbeat is expected.
-_SYNCING_STATES = {
-    SyncState.STAGING.value,
-    SyncState.COMMITTING.value,
-}
+def engine_health_may_be_stale(server_info_url: str, *, timeout: float = 5.0) -> bool:
+    """Whether the engine is paused while staged weights are applied.
 
-
-def sync_in_progress(server_info_url: str, *, timeout: float = 5.0) -> bool:
-    """Whether the replica is initializing, staging, or committing weights.
-
-    A deployment's engine-health probe uses this to suppress expected health
-    blips during weight work. An unreachable sidecar returns ``False`` so the
+    Staging and destination initialization run alongside inference. Suppressing
+    their health failures would mask a stalled scheduler, so only the short
+    commit window is exempt. An unreachable sidecar returns ``False`` so the
     caller still reports an actual failure.
     """
     try:
@@ -324,10 +337,7 @@ def sync_in_progress(server_info_url: str, *, timeout: float = 5.0) -> bool:
             info = json.loads(resp.read())
     except Exception:  # noqa: BLE001
         return False
-    initializing = not info.get("update_destination_ready", True) and not info.get(
-        "update_destination_error"
-    )
-    return bool(initializing or info.get("sync_state") in _SYNCING_STATES)
+    return info.get("sync_state") == SyncState.COMMITTING.value
 
 
 def await_pool_ready(

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -1,5 +1,4 @@
-"""``sync_in_progress`` — the shared /server_info interpretation a deployment's engine-health
-probe uses to suppress health blips while the reconciler commits staged weights."""
+"""Engine-health suppression derived from the sidecar's ``/server_info`` state."""
 
 from __future__ import annotations
 
@@ -15,7 +14,7 @@ import httpx
 import pytest
 
 from stitch.engines.base import Engine
-from stitch.service import create_app, sync_in_progress
+from stitch.service import create_app, engine_health_may_be_stale
 from stitch.sync import AdmissionGate
 from stitch.types import VersionRef
 
@@ -268,14 +267,14 @@ def _server_info(payload):
     "info,expected",
     [
         ({"update_destination_ready": True, "sync_state": "COMMITTING"}, True),
-        ({"update_destination_ready": True, "sync_state": "STAGING"}, True),
+        ({"update_destination_ready": True, "sync_state": "STAGING"}, False),
         ({"update_destination_ready": True, "sync_state": "FETCHING"}, False),
         (
             {
                 "update_destination_ready": False,
                 "update_destination_error": None,
             },
-            True,
+            False,
         ),
         ({"update_destination_ready": True, "sync_state": "IDLE"}, False),
         (
@@ -287,11 +286,14 @@ def _server_info(payload):
         ),
     ],
 )
-def test_sync_in_progress(info, expected):
+def test_engine_health_may_be_stale(info, expected):
     with _server_info(info) as url:
-        assert sync_in_progress(url) is expected
+        assert engine_health_may_be_stale(url) is expected
 
 
 def test_unreachable_sidecar_reports_error():
     # Nothing listening: best-effort False so the caller surfaces the engine error.
-    assert sync_in_progress("http://127.0.0.1:1/server_info", timeout=0.2) is False
+    assert (
+        engine_health_may_be_stale("http://127.0.0.1:1/server_info", timeout=0.2)
+        is False
+    )

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -17,6 +17,7 @@ from contextlib import asynccontextmanager, contextmanager, suppress
 from typing import Any, Literal
 
 from stitch.engines.base import Engine
+from stitch.errors import UnrecoverableSidecarError
 from stitch.stores.base import Store
 from stitch.types import (
     SyncState,
@@ -203,6 +204,8 @@ class Reconciler(AdmissionGate):
         self._destination_ready = False
         self._destination_init_error: str | None = None
         self._periodic_task: asyncio.Task[None] | None = None
+        self._terminal_error: UnrecoverableSidecarError | None = None
+        self._terminal_error_event = asyncio.Event()
         self._lock = asyncio.Lock()
 
     async def startup(self) -> None:
@@ -219,7 +222,7 @@ class Reconciler(AdmissionGate):
         if not self._behind(pointer):
             self.ready = True
         await self.reconcile()
-        if self.reconcile_interval > 0:
+        if self.reconcile_interval > 0 and self._terminal_error is None:
             self._periodic_task = asyncio.create_task(self._periodic_reconcile())
 
     async def shutdown(self) -> None:
@@ -240,6 +243,12 @@ class Reconciler(AdmissionGate):
         try:
             await self.engine.initialize_update_destination(self.boot_version)
             self._destination_ready = True
+        except UnrecoverableSidecarError as exc:
+            self._destination_init_error = str(exc)
+            self._record_terminal_error(exc)
+            logger.exception(
+                "weight update destination initialization failed terminally"
+            )
         except Exception as exc:  # noqa: BLE001
             self._destination_init_error = str(exc)
             logger.exception("weight update destination initialization failed")
@@ -257,6 +266,9 @@ class Reconciler(AdmissionGate):
             "active_requests": self._active,
             "update_destination_ready": self._destination_ready,
             "update_destination_error": self._destination_init_error,
+            "terminal_error": str(self._terminal_error)
+            if self._terminal_error
+            else None,
             "metrics": self.metrics,
         }
 
@@ -274,13 +286,28 @@ class Reconciler(AdmissionGate):
         applied = self.applied.identity if self.applied else "boot"
         return f"catching up to live version (applied={applied}, state={self.sync_state.value})"
 
+    def engine_health_may_be_stale(self) -> bool:
+        """Whether the engine is paused while staged weights are applied."""
+        return self.sync_state is SyncState.COMMITTING
+
+    async def wait_for_terminal_error(self) -> None:
+        """Raise once reconciliation proves this replica must be replaced."""
+        await self._terminal_error_event.wait()
+        assert self._terminal_error is not None
+        raise self._terminal_error
+
+    def _record_terminal_error(self, error: UnrecoverableSidecarError) -> None:
+        if self._terminal_error is None:
+            self._terminal_error = error
+            self._terminal_error_event.set()
+
     def _on_reject(self, error: dict[str, Any]) -> None:
         self.wake()  # a 409 is our cue to catch up
 
     def wake(self) -> None:
         """Nudge a reconcile now (a publish wake or a 409). Non-cancelling: starts a
         task only if none is running; the running loop re-reads the authoritative pointer."""
-        if self._task is None or self._task.done():
+        if self._terminal_error is None and (self._task is None or self._task.done()):
             self._task = asyncio.get_running_loop().create_task(self.reconcile())
 
     async def reconcile(self) -> None:
@@ -295,6 +322,12 @@ class Reconciler(AdmissionGate):
                     pointer = await asyncio.to_thread(self.store.read_pointer)
                     if self._behind(pointer):
                         caught_up = False
+            except UnrecoverableSidecarError as exc:
+                self.last_error = str(exc)
+                self.sync_state = SyncState.ERROR
+                self._record_terminal_error(exc)
+                logger.exception("reconcile failed terminally")
+                return
             except Exception as exc:  # noqa: BLE001
                 self.last_error = str(exc)
                 self.sync_state = SyncState.ERROR

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -539,6 +539,7 @@ class Reconciler(AdmissionGate):
 
         async def apply() -> None:
             if was_patched:
+                self.sync_state = SyncState.COMMITTING
                 await self.engine.reset()
 
         def on_applied() -> None:

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -12,6 +12,7 @@ from functools import partial
 import pytest
 
 from stitch.engines.base import Engine
+from stitch.errors import UnrecoverableEngineError
 from stitch.stores.base import Store
 from stitch.sync import ConstraintUnmet, Reconciler
 from stitch.types import (
@@ -162,6 +163,25 @@ def test_startup_initializes_update_destination() -> None:
         assert "initialize_update_destination" in engine.calls
 
     _run(go())
+
+
+@pytest.mark.parametrize(
+    "sync_state,expected",
+    [
+        (SyncState.IDLE, False),
+        (SyncState.FETCHING, False),
+        (SyncState.STAGING, False),
+        (SyncState.COMMITTING, True),
+        (SyncState.ERROR, False),
+    ],
+)
+def test_engine_health_may_be_stale_only_during_commit(
+    sync_state: SyncState, expected: bool
+) -> None:
+    reconciler = _make_reconciler(store=FakeStore(), engine=FakeEngine())
+    reconciler.sync_state = sync_state
+
+    assert reconciler.engine_health_may_be_stale() is expected
 
 
 def test_catch_up() -> None:
@@ -638,11 +658,38 @@ def test_update_fails_after_update_destination_initialization_fails() -> None:
             reconcile_interval=0.0,
         )
         r.applied = VersionRef("r1", 0)
+        terminal = asyncio.create_task(r.wait_for_terminal_error())
         await r.startup()
         assert r.sync_state is SyncState.ERROR
         assert r.last_error is not None
         assert "broken destination" in r.last_error
         assert "stage:2" not in engine.calls
+        assert not terminal.done()
+        terminal.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await terminal
+        await r.shutdown()
+
+    _run(go())
+
+
+def test_unrecoverable_reconcile_error_reaches_terminal_monitor() -> None:
+    async def go() -> None:
+        engine = FakeEngine()
+
+        async def fail_stage(_manifest, _source_dir) -> None:
+            raise UnrecoverableEngineError("engine process is gone")
+
+        engine.stage = fail_stage  # type: ignore[method-assign]
+        r = _make_reconciler(
+            store=FakeStore(VersionRef("r1", 2), _full("r1", 2)),
+            engine=engine,
+            reconcile_interval=0,
+        )
+        await r.startup()
+        with pytest.raises(UnrecoverableEngineError, match="process is gone"):
+            await r.wait_for_terminal_error()
+        assert r.server_info()["terminal_error"] == "engine process is gone"
         await r.shutdown()
 
     _run(go())

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -347,6 +347,37 @@ def test_run_switch_resets_in_place() -> None:
     _run(go())
 
 
+def test_run_switch_exposes_paused_reset_to_engine_watchdog() -> None:
+    async def go() -> None:
+        engine = FakeEngine()
+        reset_started = asyncio.Event()
+        finish_reset = asyncio.Event()
+
+        async def slow_reset() -> None:
+            engine.calls.append("reset")
+            reset_started.set()
+            await finish_reset.wait()
+
+        engine.reset = slow_reset  # type: ignore[method-assign]
+        r = _make_reconciler(
+            store=FakeStore(),
+            engine=engine,
+            commit_mode="in_place",
+        )
+        r.applied = VersionRef("r0", 5)
+
+        switch = asyncio.create_task(r._switch_run("r1"))
+        await reset_started.wait()
+        assert engine.calls == ["pause", "reset"]
+        assert r.sync_state is SyncState.COMMITTING
+        assert r.engine_health_may_be_stale()
+
+        finish_reset.set()
+        await switch
+
+    _run(go())
+
+
 def test_run_switch_drains_rolling_requests() -> None:
     # Base reset is incompatible: even in in_place, no rolling request crosses the wipe (drain_all; stitch#32).
     async def go() -> None:

--- a/src/stitch/watchdog.py
+++ b/src/stitch/watchdog.py
@@ -1,0 +1,175 @@
+"""Supervise a sidecar's colocated engine and propagate terminal failures.
+
+The reconciler owns weight-sync retries; this module owns process liveness. Keeping
+those policies separate lets a transient store or engine-control error remain
+retryable while a persistently dead local engine tears down the sidecar process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from typing import Protocol
+
+from stitch.engines.base import Engine, EngineHealthStatus
+from stitch.errors import UnrecoverableEngineError
+
+logger = logging.getLogger(__name__)
+
+
+class _Server(Protocol):
+    should_exit: bool
+
+    async def serve(self) -> None: ...
+
+
+class _Watchdog(Protocol):
+    async def run(self) -> None: ...
+
+
+class TerminalFailureMonitor:
+    """Adapt a component's terminal-failure signal into the watchdog interface."""
+
+    def __init__(self, wait_for_failure: Callable[[], Awaitable[None]]) -> None:
+        self._wait_for_failure = wait_for_failure
+
+    async def run(self) -> None:
+        await self._wait_for_failure()
+
+
+class SidecarWatchdog:
+    """Fail when any independently supervised sidecar component fails."""
+
+    def __init__(self, *components: _Watchdog) -> None:
+        if not components:
+            raise ValueError("sidecar watchdog requires at least one component")
+        self._components = components
+
+    async def run(self) -> None:
+        tasks = {
+            asyncio.create_task(component.run(), name=f"watchdog-{index}")
+            for index, component in enumerate(self._components)
+        }
+        try:
+            done, _pending = await asyncio.wait(
+                tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+            await next(iter(done))
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+
+class EngineWatchdog:
+    """Turn repeated engine-health failures into one terminal sidecar error.
+
+    An unresponsive health endpoint is ignored while the engine is paused to apply
+    staged weights. Staging itself runs alongside inference and is not exempt: a
+    health failure then is evidence of scheduler starvation or failure. A connection
+    failure is never expected, but still receives the consecutive-failure budget so
+    a one-off socket race does not recycle an otherwise healthy replica.
+    """
+
+    def __init__(
+        self,
+        engine: Engine,
+        *,
+        engine_health_may_be_stale: Callable[[], bool],
+        interval: float = 5.0,
+        failure_threshold: int = 3,
+    ) -> None:
+        if interval <= 0:
+            raise ValueError("watchdog interval must be positive")
+        if failure_threshold < 1:
+            raise ValueError("watchdog failure threshold must be positive")
+        self._engine = engine
+        self._engine_health_may_be_stale = engine_health_may_be_stale
+        self._interval = interval
+        self._failure_threshold = failure_threshold
+        self._consecutive_failures = 0
+
+    async def run(self) -> None:
+        """Run until cancelled or the engine is conclusively unrecoverable."""
+        while True:
+            health = await self._engine.check_health()
+            if health.status is EngineHealthStatus.HEALTHY:
+                self._consecutive_failures = 0
+            elif (
+                health.status is EngineHealthStatus.UNRESPONSIVE
+                and self._engine_health_may_be_stale()
+            ):
+                self._consecutive_failures = 0
+                logger.debug(
+                    "ignoring engine health failure while applying weights: %s",
+                    health.detail,
+                )
+            else:
+                self._consecutive_failures += 1
+                logger.warning(
+                    "engine watchdog failure %d/%d status=%s detail=%s",
+                    self._consecutive_failures,
+                    self._failure_threshold,
+                    health.status.value,
+                    health.detail,
+                )
+                if self._consecutive_failures >= self._failure_threshold:
+                    raise UnrecoverableEngineError(
+                        "local engine is persistently "
+                        f"{health.status.value} after {self._consecutive_failures} checks: "
+                        f"{health.detail}"
+                    )
+            await asyncio.sleep(self._interval)
+
+
+async def run_server_with_watchdog(
+    server: _Server,
+    watchdog: _Watchdog,
+    *,
+    shutdown_timeout: float = 10.0,
+) -> None:
+    """Run uvicorn and make a terminal watchdog error reach the process boundary."""
+    server_task = asyncio.create_task(server.serve(), name="sidecar-server")
+    watchdog_task = asyncio.create_task(watchdog.run(), name="engine-watchdog")
+    try:
+        done, _pending = await asyncio.wait(
+            {server_task, watchdog_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+    except BaseException:
+        server_task.cancel()
+        watchdog_task.cancel()
+        await asyncio.gather(server_task, watchdog_task, return_exceptions=True)
+        raise
+
+    if watchdog_task in done:
+        try:
+            await watchdog_task
+        except BaseException:
+            logger.critical("engine watchdog terminated the sidecar", exc_info=True)
+            await _stop_server(server, server_task, timeout=shutdown_timeout)
+            raise
+        await _stop_server(server, server_task, timeout=shutdown_timeout)
+        raise UnrecoverableEngineError("engine watchdog exited unexpectedly")
+
+    watchdog_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await watchdog_task
+    await server_task
+
+
+async def _stop_server(
+    server: _Server, server_task: asyncio.Task[None], *, timeout: float
+) -> None:
+    server.should_exit = True
+    try:
+        await asyncio.wait_for(asyncio.shield(server_task), timeout=timeout)
+    except TimeoutError:
+        logger.error("sidecar server did not stop within %.1fs; cancelling it", timeout)
+        server_task.cancel()
+        with suppress(BaseException):
+            await server_task
+    except BaseException:
+        logger.exception("sidecar server failed while handling watchdog shutdown")

--- a/src/stitch/watchdog_test.py
+++ b/src/stitch/watchdog_test.py
@@ -1,0 +1,135 @@
+"""Sidecar engine-watchdog policy and process-propagation tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+
+from stitch.engines.base import EngineHealth, EngineHealthStatus
+from stitch.watchdog import (
+    EngineWatchdog,
+    SidecarWatchdog,
+    TerminalFailureMonitor,
+    UnrecoverableEngineError,
+    run_server_with_watchdog,
+)
+
+
+class _HealthSequence:
+    def __init__(self, *statuses: EngineHealthStatus) -> None:
+        self._statuses = iter(statuses)
+        self.checked = asyncio.Event()
+
+    async def check_health(self) -> EngineHealth:
+        try:
+            status = next(self._statuses)
+        except StopIteration:
+            self.checked.set()
+            status = EngineHealthStatus.HEALTHY
+        return EngineHealth(status, status.value)
+
+
+class _FakeServer:
+    def __init__(self) -> None:
+        self.should_exit = False
+        self.stopped = asyncio.Event()
+
+    async def serve(self) -> None:
+        try:
+            while not self.should_exit:
+                await asyncio.sleep(0)
+        finally:
+            self.stopped.set()
+
+
+def _watchdog(
+    engine: _HealthSequence,
+    *,
+    engine_health_may_be_stale: Callable[[], bool] = lambda: False,
+    failure_threshold: int = 2,
+) -> EngineWatchdog:
+    return EngineWatchdog(
+        engine,  # type: ignore[arg-type]
+        engine_health_may_be_stale=engine_health_may_be_stale,
+        interval=0.001,
+        failure_threshold=failure_threshold,
+    )
+
+
+def test_expected_unresponsiveness_during_weight_apply_is_recoverable() -> None:
+    async def go() -> None:
+        engine = _HealthSequence(
+            EngineHealthStatus.UNRESPONSIVE,
+            EngineHealthStatus.UNRESPONSIVE,
+        )
+        task = asyncio.create_task(
+            _watchdog(engine, engine_health_may_be_stale=lambda: True).run()
+        )
+        await asyncio.wait_for(engine.checked.wait(), timeout=1)
+        assert not task.done()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(go())
+
+
+def test_transient_idle_failure_does_not_trip_watchdog() -> None:
+    async def go() -> None:
+        engine = _HealthSequence(
+            EngineHealthStatus.UNRESPONSIVE,
+            EngineHealthStatus.HEALTHY,
+            EngineHealthStatus.UNRESPONSIVE,
+        )
+        task = asyncio.create_task(_watchdog(engine).run())
+        await asyncio.wait_for(engine.checked.wait(), timeout=1)
+        assert not task.done()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(go())
+
+
+def test_unreachable_engine_is_terminal_even_during_weight_apply() -> None:
+    async def go() -> None:
+        engine = _HealthSequence(
+            EngineHealthStatus.UNREACHABLE,
+            EngineHealthStatus.UNREACHABLE,
+        )
+        with pytest.raises(UnrecoverableEngineError, match="unreachable"):
+            await _watchdog(engine, engine_health_may_be_stale=lambda: True).run()
+
+    asyncio.run(go())
+
+
+def test_watchdog_failure_stops_server_and_reaches_process_boundary() -> None:
+    async def go() -> None:
+        server = _FakeServer()
+        engine = _HealthSequence(
+            EngineHealthStatus.UNREACHABLE,
+            EngineHealthStatus.UNREACHABLE,
+        )
+        with pytest.raises(UnrecoverableEngineError):
+            await run_server_with_watchdog(server, _watchdog(engine))
+        assert server.stopped.is_set()
+
+    asyncio.run(go())
+
+
+def test_sidecar_watchdog_propagates_component_terminal_error() -> None:
+    async def go() -> None:
+        async def terminal_failure() -> None:
+            raise UnrecoverableEngineError("cannot restore boot weights")
+
+        engine = _HealthSequence(EngineHealthStatus.HEALTHY)
+        watchdog = SidecarWatchdog(
+            _watchdog(engine),
+            TerminalFailureMonitor(terminal_failure),
+        )
+        with pytest.raises(UnrecoverableEngineError, match="restore boot weights"):
+            await watchdog.run()
+
+    asyncio.run(go())


### PR DESCRIPTION
## Summary

- supervise the colocated inference engine and reconciler terminal-error signal from the sidecar process
- classify SGLang health failures as unresponsive or unreachable and terminate only after a consecutive-failure budget
- propagate unrecoverable CPU-weight reset and destination-initialization failures so Modal can replace the replica
- suppress an unresponsive health probe only during the paused weight-apply window; initialization and staging remain observable

## Motivation

A terminal engine failure could previously leave a rollout sidecar alive and returning errors until the one-hour reconciliation timeout. Successful CPU-weight stages continue serving inference: two observed stages lasting 1,584s and 2,600s produced no SGLang health failure. The failed replica instead stopped scheduler/detokenizer progress before SGLang began returning real health failures.

This also corrects a misleading distinction in the old comments. The frequent 503s while a joining replica catches up are the Stitch sidecar readiness gate, not SGLang liveness failures caused by staging.

## Verification

- `uv run pytest` — 151 passed
- `uv run ruff check src cookbook`
- `uv run ruff format --check src cookbook`
- CPU-only Modal process-boundary probe in `stitch-dev`: staging remained healthy, one transient SGLang 503 recovered, and sustained SGLang 503s terminated the sidecar with a nonzero exit
