### PR TITLE
Fix auto-resume cleanup after trainer failure

### DIFF
--- a/cookbook/miles_disagg/launch.py
+++ b/cookbook/miles_disagg/launch.py
@@ -196,7 +196,7 @@ def _run_attempt(*, supervise: bool) -> None:
         trainer_call.get()
     finally:
         subprocess.run(
-            [sys.executable, "-m", "modal", "app", "stop", run.APP_NAME],
+            [sys.executable, "-m", "modal", "app", "stop", "--yes", run.APP_NAME],
             check=False,
         )
 

--- a/cookbook/miles_disagg/launch_test.py
+++ b/cookbook/miles_disagg/launch_test.py
@@ -150,7 +150,7 @@ def test_supervised_attempt_stops_pool_when_launch_fails(monkeypatch) -> None:
     with pytest.raises(RuntimeError, match="not ready"):
         launch._run_attempt(supervise=True)
 
-    assert stopped["command"][-3:] == ["app", "stop", "app"]
+    assert stopped["command"][-4:] == ["app", "stop", "--yes", "app"]
     assert stopped["check"] is False
 
 


### PR DESCRIPTION
## Summary

- stop supervisor-owned rollout apps without an interactive confirmation
- cover the cleanup command with a regression test

## Root cause

After a trainer failure, the supervised attempt called `modal app stop` without `--yes`. When launched from an interactive terminal, cleanup waited indefinitely for confirmation, so the outer auto-resume loop never resolved the latest checkpoint or started its next attempt.

## Validation

- `uv run pytest -q` (164 passed)
- `uv run ruff check .`