### PR TITLE
Pin uv resolution to public PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ dev = [
     "httpx",
 ]
 
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary

- declare public PyPI as Stitch's project-level package index
- keep the restored `uv.lock` reproducible even when a developer has a private user-level default index

## Why

PR #144 restored the tracked lockfile. The original leak occurred because this machine's user-level uv configuration selects a private CodeArtifact mirror as its default index. uv merges project and user configuration, with project indexes taking priority.

Declaring PyPI at the project level makes it the first source for Stitch's public dependencies. The private user default remains available only as a fallback and no longer rewrites `uv.lock` with internal registry URLs.

## Validation

- generated a fresh lock while the active user-level uv config points at CodeArtifact; its only hosts were `pypi.org` and `files.pythonhosted.org`
- `uv lock --check`
- `uv lock --check --no-config`
- `uv run --locked pytest` (164 passed)
- `uv run --locked ruff check .`
- `uv run --locked ruff format --check .`