### PR TITLE
Update Miles for resilient agent sessions

### DIFF
--- a/cookbook/miles_disagg/MILES_FORK.md
+++ b/cookbook/miles_disagg/MILES_FORK.md
@@ -6,7 +6,7 @@ image. [`trainer_image.py`](trainer_image.py) defines the shared default:
 ```python
 MILES_IMAGE_TAG = "radixark/miles:dev-202607290235"
 MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
-MILES_REPO_REF = "b21dc7df8dcb0d4fd3fc07f6a6be1ee9fa35d369"
+MILES_REPO_REF = "60f7be88af1956111d18351d20413cfd53e0a607"
 ```
 
 The pin is `modal-projects/miles:stitch-miles-fully-async-swe`. It contains a
@@ -37,14 +37,15 @@ These commits are useful independently of Stitch:
 | `719e2844d` | Suppress per-request session access logs. |
 | `45a2c5b25` | Reject aborted generations at the session protocol boundary. |
 | `55b69d37a` | Continue disk-delta versions from a loaded checkpoint. |
+| `a5e2999fa` | Keep transient session-transport failures local to their trajectories. |
 
 ## Stitch integration
 
 | Commit | Responsibility |
 | --- | --- |
-| `b82540407` | Route fully-async generation through an external fleet with version constraints and finite timeouts. |
-| `3b51b9894` | Publish disk deltas without Miles-managed rollout-engine handles. |
-| `b21dc7df8` | Overlap external weight updates with active rollout. |
+| `dfbed689a` | Route fully-async generation through an external fleet with version constraints and finite timeouts. |
+| `57b27a8f6` | Publish disk deltas without Miles-managed rollout-engine handles. |
+| `60f7be88a` | Overlap external weight updates with active rollout. |
 
 The dated image supplies Megatron-LM, TransformerEngine, CUDA, and other
 compiled dependencies. Miles is installed over it with `--no-deps`, so the

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -21,7 +21,7 @@ from cookbook.common import trainer_image as common_trainer_image
 # a moved mutable tag, so `latest` silently serves whatever was first pulled.
 MILES_IMAGE_TAG = "radixark/miles:dev-202607290235"
 MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
-MILES_REPO_REF = "b21dc7df8dcb0d4fd3fc07f6a6be1ee9fa35d369"
+MILES_REPO_REF = "60f7be88af1956111d18351d20413cfd53e0a607"
 
 MILES_ROOT = "/root/miles"
 # Source-only megatron.training must be on PYTHONPATH.


### PR DESCRIPTION
## What changed

- pin the restacked Miles external-fleet branch
- contain transient session transport failures within one trajectory
- preserve fatal behavior for HTTP, malformed-response, and protocol errors
- retain the three Stitch-only commits above the updated general fully-async branch

## Root cause

A session-creation timeout escaped the agentic generate boundary and terminated the persistent fully-async rollout producer. Cancelling its sibling samples also retired sessions still used by shielded remote agent episodes.

## Failure semantics

Only timeout and HTTP transport failures produce an aborted trajectory. Deterministic session-server and protocol failures still fail loudly. A cancelled local waiter does not retire a session while its remote episode may still be running.

## Validation

- focused Miles agent collection tests: 4 passed
- Miles pre-commit hooks passed
- Stitch trainer image integration tests: 4 passed
- Stitch Ruff check and format check passed