### PR TITLE
Resume a run within its existing Stitch lineage

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -266,12 +266,13 @@ Each experiment Volume contains only run-scoped state:
     ├── checkpoints/
     ├── hf_checkpoints/weight_vNNNNNN/
     │   └── .complete
-    └── train.log
+    └── logs/train-from-vNNNNNN-<UTC>-<id>.log
 ```
 
 The training framework owns `updates/` and the saved checkpoints; Stitch owns
 `latest`. Resume keeps the same run ID, restores `latest` to the checkpoint,
-and replaces the abandoned update suffix as training continues.
+and replaces the abandoned update suffix as training continues. Each finished
+trainer attempt writes a separate log; use Modal app logs while it is running.
 
 Datasets are independent of models and runs:
 

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -100,24 +100,26 @@ export EXPERIMENT_CONFIG=your_config_name
 export MODAL_ENVIRONMENT=your_environment
 
 uv run --extra modal python -m cookbook.miles_disagg.launch \
-  --resume-from source_run_id
+  --resume-from existing_run_id
 ```
 
-The launcher creates a new run ID; do not reuse or pass the source run ID as
-`RUN_ID`. If the source checkpoint is v120, the new run boots at v120 and
-publishes v121 next.
+The launcher keeps the existing run ID, recreates its rollout deployment, and
+resets `latest` before replacement engines load the saved checkpoint. If the
+checkpoint is v120, the run resumes at v120 and publishes a replacement v121
+next. Resume currently requires the Modal Volume store and
+`update_weights_interval = 1`.
 
 Add automatic resume to a fresh or resumed launch with:
 
 ```bash
 uv run --extra modal python -m cookbook.miles_disagg.launch \
-  --resume-from source_run_id \
+  --resume-from existing_run_id \
   --auto-resume
 ```
 
-`--auto-resume` stays attached to the trainer. An unexpected exit starts a new
-run from the newest complete checkpoint and retries until the trainer returns
-normally. Stop it with Ctrl-C. It is off by default and requires
+`--auto-resume` stays attached to the trainer. An unexpected exit recreates the
+same run from its newest complete checkpoint and retries until the trainer
+returns normally. Stop it with Ctrl-C. It is off by default and requires
 `save_interval`, `save_hf`, and optimizer/RNG checkpointing. A fresh run becomes
 resumable after its first complete Megatron/Hugging Face checkpoint pair.
 
@@ -268,8 +270,8 @@ Each experiment Volume contains only run-scoped state:
 ```
 
 The training framework owns `updates/` and the saved checkpoints; Stitch owns
-`latest`. A resumed checkpoint starts a new run and reads the previous run's
-`checkpoints/` rather than appending to its update chain.
+`latest`. Resume keeps the same run ID, restores `latest` to the checkpoint,
+and replaces the abandoned update suffix as training continues.
 
 Datasets are independent of models and runs:
 

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -26,9 +26,11 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from uuid import uuid4
 
 import modal
 import modal.experimental
@@ -487,11 +489,12 @@ class Trainer:
         # Claim the version already served by the pool before Miles publishes.
         from cookbook.common import hooks
 
+        boot_version = resume_point.version if resume_point is not None else 0
         hooks.claim_pool(
             SimpleNamespace(
                 update_weight_disk_dir=cfg.update_weight_disk_dir, **custom_config
             ),
-            boot_version=resume_point.version if resume_point is not None else 0,
+            boot_version=boot_version,
         )
 
         resume_log = (
@@ -506,7 +509,12 @@ class Trainer:
             f"nodes={miles_cfg.n_train_nodes}, rollout_endpoint={cfg.rollout_endpoint_url}"
         )
         print(f"Command: {cmd}")
-        log_path = str(RUN_DIR / "train.log")
+        started_at = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        log_path = (
+            RUN_DIR
+            / "logs"
+            / f"train-from-v{boot_version:06d}-{started_at}-{uuid4().hex[:8]}.log"
+        )
         with tempfile.TemporaryDirectory() as local_log_dir:
             local_log_path = os.path.join(local_log_dir, "train.log")
             teed = f"set -o pipefail; ({cmd}) 2>&1 | tee {local_log_path}"
@@ -514,7 +522,7 @@ class Trainer:
                 subprocess.run(["bash", "-lc", teed], check=True)
             finally:
                 try:
-                    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+                    log_path.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copyfile(local_log_path, log_path)
                     run_volume.commit()
                     print(

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -6,8 +6,9 @@ and publishes XOR deltas through the configured checkpoint store.
 
 Prepare the checkpoints once first (a separate app, so prep never spins up the rollout Server
 floor — see ``cookbook.miles_disagg.prep_app``), then launch a run with one command — it mints a
-unique run id, stands up that run's pool, and starts training. Each launch is its own run,
-isolated even from an identical-config relaunch (see ``cookbook.miles_disagg.launch``):
+unique run id, stands up that run's pool, and starts training. A fresh launch is isolated even
+from an identical-config launch; resume retains the existing run id (see
+``cookbook.miles_disagg.launch``):
 
     EXPERIMENT_CONFIG=glm45_air_fp8 uv run --extra modal python -m cookbook.miles_disagg.launch
 
@@ -51,6 +52,7 @@ from cookbook.miles_disagg.resume import (
     RESUME_POINT_ENV,
     ResumePoint,
     saved_checkpoint_version,
+    wait_for_restored_pointer,
 )
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
 from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
@@ -79,8 +81,8 @@ def _rollout_boot_checkpoint() -> str:
     return point.rollout_checkpoint if point is not None else miles_cfg.hf_checkpoint
 
 
-# Per-run id, minted fresh by cookbook.miles_disagg.launch. The same identity
-# scopes the pool, Stitch pointer, publications, checkpoints, and logs.
+# Minted once for a run and retained across resume. The same identity scopes the
+# pool, Stitch pointer, publications, checkpoints, and logs.
 RUN_ID = os.environ["RUN_ID"]
 APP_NAME = f"{exp.APP_NAME}-{RUN_ID}"
 RUN_DIR = STITCH_PATH / RUN_ID
@@ -219,6 +221,12 @@ class Server:
         STORE_DEPLOYMENT.bootstrap_credentials()
         store_config = STORE_DEPLOYMENT.hook_config(APP_NAME)
         resume_point = _resume_point()
+        if resume_point is not None:
+            wait_for_restored_pointer(
+                run_volume,
+                resume_point,
+                timeout=SERVER_STARTUP_TIMEOUT,
+            )
         model_name = (
             resume_point.rollout_checkpoint
             if resume_point is not None
@@ -489,7 +497,6 @@ class Trainer:
         resume_log = (
             f", checkpoint_version={resume_point.version}, "
             f"next_version={resume_point.version + 1}, "
-            f"source_run_id={resume_point.source_run_id}, "
             f"stitch_boot={RUN_ID}/weight_v{resume_point.version:06d}"
             if resume_point is not None
             else ""

--- a/cookbook/miles_disagg/launch.py
+++ b/cookbook/miles_disagg/launch.py
@@ -1,10 +1,10 @@
-"""Launch isolated Miles/Stitch attempts, optionally resuming saved checkpoints.
+"""Launch an isolated Miles/Stitch run, optionally resuming its saved checkpoint.
 
 A run's pool is a deployed Flash app the trainer reaches by name, so the run id has to be in the
 app name before either half runs — which is why deploy and launch can't be one CLI call. This
 closes that: mint the id, deploy ``app.py``'s pool under it, wait for it to be ready, then spawn
-the trainer. Each launch is its own run — two launches of an identical config are two isolated
-runs (distinct ids), like commits.
+the trainer. A resume keeps that identity and recreates the rollout deployment
+from its latest complete trainer/rollout checkpoint.
 
     EXPERIMENT_CONFIG=glm45_air_fp8 uv run --extra modal python -m cookbook.miles_disagg.launch
 
@@ -31,6 +31,7 @@ from cookbook.miles_disagg.resume import (
     ResumePoint,
     ResumePointNotFound,
     resolve_resume_point,
+    restore_resume_point,
     validate_auto_resume_config,
     validate_resume_config,
 )
@@ -41,7 +42,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--resume-from",
         metavar="RUN_ID",
-        help="start a new run from RUN_ID's latest saved Megatron/HF checkpoint",
+        help="resume RUN_ID from its latest complete Megatron/HF checkpoint pair",
     )
     parser.add_argument(
         "--auto-resume",
@@ -71,11 +72,13 @@ def main() -> None:
     if args.resume_from is not None:
         validate_resume_config(exp.miles)
         resume_point = _resume_point_for_run(exp, args.resume_from)
+        run_id = args.resume_from
     else:
         resume_point = None
+        run_id = uuid.uuid4().hex[:8]
     _set_attempt_env(
         os.environ,
-        run_id=uuid.uuid4().hex[:8],
+        run_id=run_id,
         resume_point=resume_point,
     )
     _run_attempt(supervise=False)
@@ -83,11 +86,11 @@ def main() -> None:
 
 def _run_auto_resume(exp: Any, resume_from: str | None) -> None:
     validate_auto_resume_config(exp.miles)
+    run_id = resume_from or uuid.uuid4().hex[:8]
     resume_point = (
         _resume_point_for_run(exp, resume_from) if resume_from is not None else None
     )
     while True:
-        run_id = uuid.uuid4().hex[:8]
         result = _run_supervised_attempt(
             run_id=run_id,
             resume_point=resume_point,
@@ -97,21 +100,25 @@ def _run_auto_resume(exp: Any, resume_from: str | None) -> None:
 
         resume_point = _resume_point_after_failure(exp, run_id, resume_point)
         print(
-            f"Trainer stopped unexpectedly; resuming from checkpoint v"
-            f"{resume_point.version} of run {resume_point.source_run_id}",
+            f"Trainer stopped unexpectedly; resuming run {run_id} from "
+            f"checkpoint v{resume_point.version}",
             flush=True,
         )
 
 
-def _resume_point_for_run(exp: Any, source_run_id: str) -> ResumePoint:
+def _resume_point_for_run(exp: Any, run_id: str) -> ResumePoint:
+    from cookbook.common import storage
+
+    if storage.StoreDeployment.from_environment().backend != storage.MODAL_VOLUME:
+        raise ValueError("Miles resume currently requires the Modal Volume store")
     volume = modal.Volume.from_name(exp.EXPERIMENT_VOLUME_NAME, version=2)
     resume_point = resolve_resume_point(
         volume,
-        source_run_id=source_run_id,
+        source_run_id=run_id,
         save_hf=exp.miles.save_hf,
     )
     print(
-        f"Resolved resume checkpoint: source_run_id={resume_point.source_run_id}, "
+        f"Resolved resume checkpoint: run_id={resume_point.source_run_id}, "
         f"version={resume_point.version}, "
         f"trainer={resume_point.trainer_checkpoint}, "
         f"rollout={resume_point.rollout_checkpoint}",
@@ -130,8 +137,7 @@ def _resume_point_after_failure(
             raise
         print(
             f"Run {failed_run_id} produced no newer complete checkpoint; "
-            f"retrying checkpoint v{previous.version} from run "
-            f"{previous.source_run_id}",
+            f"retrying checkpoint v{previous.version}",
             flush=True,
         )
         return previous
@@ -148,11 +154,15 @@ def _set_attempt_env(
         env.pop(RESUME_POINT_ENV, None)
         print(f"Launching fresh run {run_id}", flush=True)
         return
+    if resume_point.source_run_id != run_id:
+        raise ValueError(
+            f"resume checkpoint belongs to run {resume_point.source_run_id!r}, "
+            f"not {run_id!r}"
+        )
     env[RESUME_POINT_ENV] = resume_point.to_json()
     print(
-        f"Launching run {run_id} from checkpoint v{resume_point.version} "
-        f"of run {resume_point.source_run_id}; "
-        f"new Stitch boot={run_id}/weight_v{resume_point.version:06d}",
+        f"Resuming run {run_id} from checkpoint v{resume_point.version}; "
+        f"Stitch boot={run_id}/weight_v{resume_point.version:06d}",
         flush=True,
     )
 
@@ -177,28 +187,38 @@ def _run_supervised_attempt(
 
 def _run_attempt(*, supervise: bool) -> None:
     from cookbook.common import launch
+    from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
+    from stitch.service import await_pool_ready
 
     run = importlib.import_module("cookbook.miles_disagg.app")
+    resume_point = (
+        ResumePoint.from_json(payload)
+        if (payload := os.environ.get(RESUME_POINT_ENV))
+        else None
+    )
+    if resume_point is None:
+        trainer_call = launch.deploy_pool_and_spawn(run)
+    else:
+        # Replacement servers block before engine startup until this pointer is
+        # restored, so none can reconcile against the abandoned suffix.
+        run.app.deploy(strategy="recreate")
+        volume = modal.Volume.from_name(run.exp.EXPERIMENT_VOLUME_NAME, version=2)
+        target = restore_resume_point(volume, resume_point)
+        print(f"Restored {target.identity}; waiting for the recreated pool", flush=True)
+        await_pool_ready(ModalFlashLBPool(run.APP_NAME, "Server"))
+        trainer_call = run.spawn_train()
 
     if not supervise:
-        launch.deploy_pool_and_spawn(run)
         print(
             f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; "
             f"stop it with: modal app stop {run.APP_NAME}"
         )
         return
-    try:
-        trainer_call = launch.deploy_pool_and_spawn(run)
-        print(
-            f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; "
-            "the auto-resume launcher owns this rollout pool"
-        )
-        trainer_call.get()
-    finally:
-        subprocess.run(
-            [sys.executable, "-m", "modal", "app", "stop", "--yes", run.APP_NAME],
-            check=False,
-        )
+    print(
+        f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; "
+        "the auto-resume launcher is supervising its trainer"
+    )
+    trainer_call.get()
 
 
 if __name__ == "__main__":

--- a/cookbook/miles_disagg/launch_test.py
+++ b/cookbook/miles_disagg/launch_test.py
@@ -14,7 +14,7 @@ from cookbook.miles_disagg.resume import (
 )
 
 
-def test_supervised_attempt_passes_resume_point_to_fresh_process(monkeypatch) -> None:
+def test_supervised_attempt_preserves_run_id(monkeypatch) -> None:
     captured = {}
 
     def run(command, *, env, check):
@@ -24,19 +24,18 @@ def test_supervised_attempt_passes_resume_point_to_fresh_process(monkeypatch) ->
     monkeypatch.setattr(launch.subprocess, "run", run)
     point = ResumePoint(9, "old", "/trainer", "/rollout")
 
-    launch._run_supervised_attempt(run_id="new", resume_point=point)
+    launch._run_supervised_attempt(run_id="old", resume_point=point)
 
-    assert captured["env"]["RUN_ID"] == "new"
+    assert captured["env"]["RUN_ID"] == "old"
     assert ResumePoint.from_json(captured["env"][RESUME_POINT_ENV]) == point
     assert captured["command"][-1] == "--run-attempt"
     assert captured["check"] is False
 
 
 def test_auto_resume_uses_checkpoint_from_failed_attempt(monkeypatch) -> None:
-    run_ids = iter((SimpleNamespace(hex="first"), SimpleNamespace(hex="second")))
     launches = []
-    point = ResumePoint(19, "first", "/trainer", "/rollout")
-    monkeypatch.setattr(launch.uuid, "uuid4", lambda: next(run_ids))
+    point = ResumePoint(19, "first-re", "/trainer", "/rollout")
+    monkeypatch.setattr(launch.uuid, "uuid4", lambda: SimpleNamespace(hex="first-rest"))
     monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
     monkeypatch.setattr(launch, "_resume_point_for_run", lambda _exp, run_id: point)
 
@@ -49,8 +48,8 @@ def test_auto_resume_uses_checkpoint_from_failed_attempt(monkeypatch) -> None:
     launch._run_auto_resume(SimpleNamespace(miles=object()), None)
 
     assert launches == [
-        {"run_id": "first", "resume_point": None},
-        {"run_id": "second", "resume_point": point},
+        {"run_id": "first-re", "resume_point": None},
+        {"run_id": "first-re", "resume_point": point},
     ]
 
 
@@ -69,18 +68,18 @@ def test_auto_resume_starts_from_requested_checkpoint(monkeypatch) -> None:
 
     launch._run_auto_resume(SimpleNamespace(miles=object()), "old")
 
-    assert launches == [{"run_id": "new", "resume_point": point}]
+    assert launches == [{"run_id": "old", "resume_point": point}]
 
 
 def test_set_attempt_env_uses_one_resume_payload() -> None:
     env = {"STITCH_UNUSED": "value"}
     point = ResumePoint(9, "old", "/trainer", "/rollout")
 
-    launch._set_attempt_env(env, run_id="new", resume_point=point)
+    launch._set_attempt_env(env, run_id="old", resume_point=point)
 
     assert env == {
         "STITCH_UNUSED": "value",
-        "RUN_ID": "new",
+        "RUN_ID": "old",
         RESUME_POINT_ENV: point.to_json(),
     }
 
@@ -91,6 +90,13 @@ def test_set_attempt_env_clears_a_stale_resume_point() -> None:
     launch._set_attempt_env(env, run_id="fresh", resume_point=None)
 
     assert env == {"RUN_ID": "fresh"}
+
+
+def test_set_attempt_env_rejects_cross_run_resume() -> None:
+    point = ResumePoint(9, "old", "/trainer", "/rollout")
+
+    with pytest.raises(ValueError, match="belongs to run"):
+        launch._set_attempt_env({}, run_id="new", resume_point=point)
 
 
 def test_manual_launch_runs_directly_without_attempt_subprocess(monkeypatch) -> None:
@@ -127,34 +133,72 @@ def test_manual_launch_runs_directly_without_attempt_subprocess(monkeypatch) -> 
 
     launch.main()
 
-    assert configured == {"run_id": "newrunid", "resume_point": point}
+    assert configured == {"run_id": "old", "resume_point": point}
     assert ran == [False]
 
 
-def test_supervised_attempt_stops_pool_when_launch_fails(monkeypatch) -> None:
+def test_supervised_attempt_leaves_pool_deployed_when_trainer_fails(
+    monkeypatch,
+) -> None:
     run = SimpleNamespace(APP_NAME="app")
-    stopped = {}
     monkeypatch.setattr(launch.importlib, "import_module", lambda _name: run)
+    monkeypatch.delenv(RESUME_POINT_ENV, raising=False)
 
     def fail(_run):
         raise RuntimeError("not ready")
 
     monkeypatch.setattr(common_launch, "deploy_pool_and_spawn", fail)
 
-    def stop(command, *, check):
-        stopped.update(command=command, check=check)
-        return subprocess.CompletedProcess(command, 0)
-
-    monkeypatch.setattr(launch.subprocess, "run", stop)
-
     with pytest.raises(RuntimeError, match="not ready"):
         launch._run_attempt(supervise=True)
 
-    assert stopped["command"][-4:] == ["app", "stop", "--yes", "app"]
-    assert stopped["check"] is False
+
+def test_resume_restores_pointer_before_pool_readiness(monkeypatch) -> None:
+    events = []
+    point = ResumePoint(9, "run", "/trainer", "/rollout")
+    volume = object()
+    run = SimpleNamespace(
+        APP_NAME="app-run",
+        exp=SimpleNamespace(EXPERIMENT_VOLUME_NAME="runs"),
+        app=SimpleNamespace(
+            deploy=lambda *, strategy: events.append(("deploy", strategy))
+        ),
+        spawn_train=lambda: events.append(("spawn",)) or object(),
+    )
+    monkeypatch.setenv("RUN_ID", "run")
+    monkeypatch.setenv(RESUME_POINT_ENV, point.to_json())
+    monkeypatch.setattr(launch.importlib, "import_module", lambda _name: run)
+    monkeypatch.setattr(
+        launch.modal.Volume, "from_name", lambda *_args, **_kwargs: volume
+    )
+    monkeypatch.setattr(
+        launch,
+        "restore_resume_point",
+        lambda actual_volume, actual_point: (
+            events.append(("restore", actual_volume, actual_point))
+            or SimpleNamespace(identity="run/weight_v000009")
+        ),
+    )
+
+    import stitch.service
+
+    monkeypatch.setattr(
+        stitch.service,
+        "await_pool_ready",
+        lambda _pool: events.append(("ready",)),
+    )
+
+    launch._run_attempt(supervise=False)
+
+    assert events == [
+        ("deploy", "recreate"),
+        ("restore", volume, point),
+        ("ready",),
+        ("spawn",),
+    ]
 
 
-def test_auto_resume_reuses_source_when_attempt_has_no_new_checkpoint(
+def test_auto_resume_reuses_previous_checkpoint_when_attempt_has_no_new_checkpoint(
     monkeypatch,
 ) -> None:
     previous = ResumePoint(9, "old", "/trainer", "/rollout")

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -1,14 +1,17 @@
-"""Resolve a saved Miles checkpoint into a fresh Stitch run."""
+"""Resolve and restore a saved Miles checkpoint for one Stitch run."""
 
 from __future__ import annotations
 
 import json
 import re
+import time
 from dataclasses import asdict, dataclass
+from io import BytesIO
 from pathlib import PurePosixPath
 from typing import Any
 
 from cookbook.common.constants import STITCH_PATH
+from stitch.types import VersionRef
 
 RESUME_POINT_ENV = "STITCH_RESUME_POINT"
 
@@ -19,7 +22,7 @@ class ResumePointNotFound(ValueError):
 
 @dataclass(frozen=True)
 class ResumePoint:
-    """One paired trainer/rollout checkpoint produced by a previous run."""
+    """One paired trainer/rollout checkpoint produced by a run."""
 
     version: int
     source_run_id: str
@@ -64,6 +67,9 @@ def validate_auto_resume_config(cfg: Any) -> None:
 def validate_resume_config(cfg: Any) -> None:
     """Require a complete saved trainer state and matching rollout checkpoint."""
     _validate_save_hf_template(getattr(cfg, "save_hf", None))
+    # TODO: define the checkpoint-to-weight-version mapping for larger intervals.
+    if int(getattr(cfg, "update_weights_interval", 1)) != 1:
+        raise ValueError("resume currently requires update_weights_interval == 1")
     if getattr(cfg, "no_load_optim", False):
         raise ValueError("resume requires loading optimizer state")
     if getattr(cfg, "no_load_rng", False):
@@ -76,7 +82,7 @@ def resolve_resume_point(
     source_run_id: str,
     save_hf: str | None,
 ) -> ResumePoint:
-    """Resolve Miles' latest Megatron tracker and matching complete HF export."""
+    """Resolve the newest complete Megatron/HF checkpoint pair for a run."""
     if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", source_run_id) is None:
         raise ValueError(f"invalid resume run id: {source_run_id!r}")
 
@@ -90,29 +96,105 @@ def resolve_resume_point(
             f"run {source_run_id!r} has no saved Megatron checkpoint"
         ) from exc
     try:
-        version = int(tracker_value)
+        tracked_version = int(tracker_value)
     except ValueError as exc:
         raise ValueError(
             f"invalid checkpoint tracker {tracker}: {tracker_value!r}"
         ) from exc
-    if version < 0:
-        raise ValueError(f"invalid checkpoint version {version} in {tracker}")
+    if tracked_version < 0:
+        raise ValueError(f"invalid checkpoint version {tracked_version} in {tracker}")
 
-    relative_hf = _validate_save_hf_template(save_hf).format(rollout_id=version)
-    hf_root = run_root / relative_hf
-    complete_marker = hf_root / ".complete"
-    try:
-        _read_volume_file(volume, str(complete_marker))
-    except FileNotFoundError as exc:
+    checkpoint_versions = []
+    for entry in volume.iterdir(str(checkpoint_root), recursive=False):
+        if match := re.fullmatch(r"iter_(\d+)", PurePosixPath(entry.path).name):
+            version = int(match.group(1))
+            if version <= tracked_version:
+                checkpoint_versions.append(version)
+
+    save_hf = _validate_save_hf_template(save_hf)
+    for version in sorted(checkpoint_versions, reverse=True):
+        relative_hf = save_hf.format(rollout_id=version)
+        hf_root = run_root / relative_hf
+        try:
+            _read_volume_file(volume, str(hf_root / ".complete"))
+        except FileNotFoundError:
+            continue
+        break
+    else:
         raise ResumePointNotFound(
-            f"run {source_run_id!r} checkpoint v{version} has no complete HF export"
-        ) from exc
+            f"run {source_run_id!r} has no complete Megatron/HF checkpoint pair at or "
+            f"before v{tracked_version}"
+        )
 
     return ResumePoint(
         version=version,
         source_run_id=source_run_id,
         trainer_checkpoint=str(STITCH_PATH / checkpoint_root),
         rollout_checkpoint=str(STITCH_PATH / hf_root),
+    )
+
+
+def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:
+    """Restore the trainer tracker and Stitch pointer to one checkpoint pair."""
+    target = VersionRef(point.source_run_id, point.version)
+    pointer_path = f"{point.source_run_id}/latest"
+    try:
+        current = VersionRef.parse(
+            _read_volume_file(volume, pointer_path).decode().strip()
+        )
+    except FileNotFoundError as exc:
+        raise ResumePointNotFound(
+            f"run {point.source_run_id!r} has no Stitch latest pointer"
+        ) from exc
+    if current.run_id != target.run_id:
+        raise ValueError(
+            f"cannot restore {target.identity!r} from {current.identity!r}"
+        )
+    if target.version > current.version:
+        raise ValueError(
+            f"resume checkpoint v{target.version} is newer than latest v{current.version}"
+        )
+
+    with volume.batch_upload(force=True) as upload:
+        upload.put_file(BytesIO(target.identity.encode()), pointer_path)
+        upload.put_file(
+            BytesIO(str(point.version).encode()),
+            f"{point.source_run_id}/checkpoints/latest_checkpointed_iteration.txt",
+        )
+    return target
+
+
+def wait_for_restored_pointer(
+    volume: Any,
+    point: ResumePoint,
+    *,
+    timeout: float,
+) -> VersionRef:
+    """Block engine startup until the launcher has restored this run's pointer."""
+    target = VersionRef(point.source_run_id, point.version)
+    pointer_path = f"{point.source_run_id}/latest"
+    deadline = time.monotonic() + timeout
+    current = None
+    while time.monotonic() < deadline:
+        volume.reload()
+        try:
+            current = VersionRef.parse(
+                _read_volume_file(volume, pointer_path).decode().strip()
+            )
+        except FileNotFoundError:
+            current = None
+        if current == target:
+            return target
+        if current is not None and (
+            current.run_id != target.run_id or current.version < target.version
+        ):
+            raise ValueError(
+                f"cannot boot {target.identity!r} from {current.identity!r}"
+            )
+        time.sleep(1)
+    actual = current.identity if current is not None else "<unset>"
+    raise TimeoutError(
+        f"latest was not restored to {target.identity}; observed {actual}"
     )
 
 

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from cookbook.miles_disagg.resume import (
     ResumePoint,
     resolve_resume_point,
+    restore_resume_point,
     saved_checkpoint_version,
     validate_auto_resume_config,
     validate_resume_config,
+    wait_for_restored_pointer,
 )
 
 
@@ -20,6 +24,36 @@ class _Volume:
             yield self.files[path]
         except KeyError as exc:
             raise FileNotFoundError(path) from exc
+
+    def reload(self) -> None:
+        pass
+
+    def iterdir(self, path: str, *, recursive: bool):
+        assert recursive is False
+        prefix = path.rstrip("/") + "/"
+        entries = {
+            name.split("/", 1)[0]
+            for key in self.files
+            if key.startswith(prefix)
+            for name in [key.removeprefix(prefix)]
+        }
+        return [SimpleNamespace(path=f"{path}/{name}") for name in sorted(entries)]
+
+    def batch_upload(self, *, force: bool):
+        volume = self
+
+        class _Upload:
+            def __enter__(self):
+                assert force is True
+                return self
+
+            def put_file(self, source, path: str) -> None:
+                volume.files[path] = source.read()
+
+            def __exit__(self, *_args) -> None:
+                return None
+
+        return _Upload()
 
 
 class _Config:
@@ -43,6 +77,7 @@ def test_resolve_resume_point_pairs_megatron_and_hf_checkpoints() -> None:
     volume = _Volume(
         {
             "old/checkpoints/latest_checkpointed_iteration.txt": b"119\n",
+            "old/checkpoints/iter_0000119/state": b"checkpoint",
             "old/hf_checkpoints/weight_v000119/.complete": b"",
         }
     )
@@ -57,10 +92,35 @@ def test_resolve_resume_point_pairs_megatron_and_hf_checkpoints() -> None:
     )
 
 
-def test_resolve_resume_point_requires_matching_complete_hf_export() -> None:
-    volume = _Volume({"old/checkpoints/latest_checkpointed_iteration.txt": b"119\n"})
+def test_resolve_resume_point_falls_back_to_previous_complete_pair() -> None:
+    volume = _Volume(
+        {
+            "old/checkpoints/latest_checkpointed_iteration.txt": b"119\n",
+            "old/checkpoints/iter_0000099/state": b"checkpoint",
+            "old/checkpoints/iter_0000119/state": b"checkpoint",
+            "old/hf_checkpoints/weight_v000099/.complete": b"",
+        }
+    )
 
-    with pytest.raises(ValueError, match="no complete HF export"):
+    assert resolve_resume_point(
+        volume, source_run_id="old", save_hf=_Config.save_hf
+    ) == ResumePoint(
+        version=99,
+        source_run_id="old",
+        trainer_checkpoint="/stitch/old/checkpoints",
+        rollout_checkpoint="/stitch/old/hf_checkpoints/weight_v000099",
+    )
+
+
+def test_resolve_resume_point_requires_a_complete_checkpoint_pair() -> None:
+    volume = _Volume(
+        {
+            "old/checkpoints/latest_checkpointed_iteration.txt": b"119\n",
+            "old/checkpoints/iter_0000119/state": b"checkpoint",
+        }
+    )
+
+    with pytest.raises(ValueError, match="no complete Megatron/HF checkpoint pair"):
         resolve_resume_point(volume, source_run_id="old", save_hf=_Config.save_hf)
 
 
@@ -104,7 +164,70 @@ def test_validate_resume_config(field: str, message: str) -> None:
         validate_resume_config(cfg)
 
 
+def test_validate_resume_requires_per_step_weight_updates() -> None:
+    cfg = _Config()
+    cfg.update_weights_interval = 2
+
+    with pytest.raises(ValueError, match="update_weights_interval == 1"):
+        validate_resume_config(cfg)
+
+
 def test_resume_point_json_round_trip() -> None:
     point = ResumePoint(7, "run", "/trainer", "/rollout")
 
     assert ResumePoint.from_json(point.to_json()) == point
+
+
+def test_restore_resume_point_overwrites_trackers_but_preserves_updates() -> None:
+    volume = _Volume(
+        {
+            "run/latest": b"run/weight_v000012",
+            "run/checkpoints/latest_checkpointed_iteration.txt": b"12",
+            "run/updates/weight_v000009/old": b"preserved",
+        }
+    )
+    point = ResumePoint(8, "run", "/trainer", "/rollout")
+
+    restored = restore_resume_point(volume, point)
+
+    assert restored.identity == "run/weight_v000008"
+    assert volume.files["run/latest"] == b"run/weight_v000008"
+    assert volume.files["run/checkpoints/latest_checkpointed_iteration.txt"] == b"8"
+    assert volume.files["run/updates/weight_v000009/old"] == b"preserved"
+
+
+def test_restore_resume_point_rejects_a_checkpoint_ahead_of_latest() -> None:
+    volume = _Volume({"run/latest": b"run/weight_v000007"})
+    point = ResumePoint(8, "run", "/trainer", "/rollout")
+
+    with pytest.raises(ValueError, match="newer than latest"):
+        restore_resume_point(volume, point)
+
+
+def test_engine_startup_waits_for_exact_restored_pointer() -> None:
+    volume = _Volume({"run/latest": b"run/weight_v000008"})
+    point = ResumePoint(8, "run", "/trainer", "/rollout")
+
+    restored = wait_for_restored_pointer(volume, point, timeout=1)
+
+    assert restored.identity == "run/weight_v000008"
+
+
+def test_engine_startup_does_not_accept_abandoned_suffix(monkeypatch) -> None:
+    volume = _Volume({"run/latest": b"run/weight_v000012"})
+    point = ResumePoint(8, "run", "/trainer", "/rollout")
+    reloads = 0
+
+    def reload() -> None:
+        nonlocal reloads
+        reloads += 1
+        if reloads == 2:
+            volume.files["run/latest"] = b"run/weight_v000008"
+
+    volume.reload = reload
+    monkeypatch.setattr("cookbook.miles_disagg.resume.time.sleep", lambda _delay: None)
+
+    restored = wait_for_restored_pointer(volume, point, timeout=1)
+
+    assert restored.identity == "run/weight_v000008"
+    assert reloads == 2


### PR DESCRIPTION
## Summary

- keep the same Stitch run ID when resuming a Miles checkpoint
- recreate rollout replicas and restore both the Stitch pointer and trainer checkpoint tracker before replacement engines start
- select the newest checkpoint that is complete in both Megatron and Hugging Face formats
- reject `update_weights_interval != 1` until the checkpoint-to-weight-version mapping supports larger intervals
- let Miles rebuild its baseline and replace the abandoned update suffix
- archive each finished trainer attempt under the run-scoped `logs/` directory

## Why

A checkpoint resume continues one logical run. Replacement replicas must not reconcile against an abandoned newer suffix, and the trainer and rollout fleet must boot the same checkpoint. The startup barrier keeps replicas blocked while one batched Volume update restores both control points. If a failure lands between the Megatron save and Hugging Face export, resume falls back to the newest earlier complete pair.

The implementation stays in the Stitch cookbook and uses existing Modal deployment, Volume, Miles checkpoint, and Stitch publication primitives. It does not change Miles, SGLang, or the Stitch core.

## Validation

- `uv run pytest -q` — 188 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check origin/main...HEAD`
- real Modal Volume integration: selected a prior complete checkpoint pair, restored both trackers in one batch, and preserved the abandoned suffix
- live same-run resume from v239 through v269: 30 contiguous training steps and 30 contiguous publications
- live precision checks across those steps: rollout log-prob absolute difference 0.0209–0.0243; train-rollout ESS 0.9938–0.9947; finite gradient norms throughout
- trainer-only failure test: the same deployment restored v259, recreated all 48 rollout replicas at v259, resumed training, republished v260, and served an exact-v260 smoke request successfully
