### PR TITLE
Preserve reconcile wakeups during active passes

### DIFF
--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -200,6 +200,7 @@ class Reconciler(AdmissionGate):
         self._boot_monotonic = time.monotonic()
         self._catchup_passes = 0
         self._task: asyncio.Task[None] | None = None
+        self._wake_pending = False
         self._destination_init_task: asyncio.Task[None] | None = None
         self._destination_ready = False
         self._destination_init_error: str | None = None
@@ -305,23 +306,25 @@ class Reconciler(AdmissionGate):
         self.wake()  # a 409 is our cue to catch up
 
     def wake(self) -> None:
-        """Nudge a reconcile now (a publish wake or a 409). Non-cancelling: starts a
-        task only if none is running; the running loop re-reads the authoritative pointer."""
-        if self._terminal_error is None and (self._task is None or self._task.done()):
-            self._task = asyncio.get_running_loop().create_task(self.reconcile())
+        """Nudge reconciliation now (a publish wake or a 409).
+
+        Multiple wakes coalesce because each pass reads the authoritative pointer. A
+        wake during an active pass requests one more pass instead of being dropped.
+        """
+        if self._terminal_error is not None:
+            return
+        if self._task is not None and not self._task.done():
+            self._wake_pending = True
+            return
+        self._task = asyncio.get_running_loop().create_task(self.reconcile())
 
     async def reconcile(self) -> None:
         """Loop until caught up to the store's (run, latest); on error, record it and
         stop — a later wake or poll retries."""
         while True:
+            self._wake_pending = False
             try:
                 caught_up = await self._reconcile_once()
-                if caught_up:
-                    # A publish can land mid-commit; re-check before idling.
-                    await asyncio.to_thread(self.store.refresh)
-                    pointer = await asyncio.to_thread(self.store.read_pointer)
-                    if self._behind(pointer):
-                        caught_up = False
             except UnrecoverableSidecarError as exc:
                 self.last_error = str(exc)
                 self.sync_state = SyncState.ERROR
@@ -332,8 +335,12 @@ class Reconciler(AdmissionGate):
                 self.last_error = str(exc)
                 self.sync_state = SyncState.ERROR
                 logger.exception("reconcile failed")
+                if self._wake_pending:
+                    continue
                 return
             if caught_up:
+                if self._wake_pending:
+                    continue
                 self.sync_state = SyncState.IDLE
                 if not self.ready:
                     logger.info(

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -669,7 +669,7 @@ def test_store_refresh_waits_for_update_destination() -> None:
 
         release.set()
         await startup
-        assert store.refreshed > 0
+        assert store.refreshed == 1
         await r.shutdown()
 
     _run(go())
@@ -727,7 +727,7 @@ def test_unrecoverable_reconcile_error_reaches_terminal_monitor() -> None:
 
 
 # ── convergence liveness ─────────────────────────────────────────────────────
-# Backstop self-heals what wake-only cannot (stitch#45): each converges with it, never with interval=0.
+# The periodic backstop heals a wake that never arrives. A delivered wake is sufficient.
 
 
 async def _converged(r: Reconciler, target: VersionRef, timeout: float = 1.0) -> bool:
@@ -797,33 +797,26 @@ class HostViewStore(FakeStore):
         self.remote_pointer = ref
 
 
-async def _heals_dropped_wake(interval: float) -> bool:
-    """A wake IS delivered, but mid-pass: wake() no-ops against the running task, whose
-    caught-up recheck already snapshotted pre-publish state — the wake is lost."""
+async def _preserves_concurrent_wake(interval: float) -> bool:
+    """A publish wake delivered during a pass schedules another authoritative read."""
     store = HostViewStore(VersionRef("r1", 1), _full("r1", 1), _full("r1", 2))
     r = _make_reconciler(store=store, engine=FakeEngine(), reconcile_interval=interval)
     await r.startup()  # converges to v1, ungated
 
     gate = store.refresh_gate = queue.Queue()
     r.wake()  # start an idle pass
-    (
-        await asyncio.to_thread(gate.get, True, 10)
-    ).set()  # release its pass-start refresh
-    recheck = await asyncio.to_thread(
-        gate.get, True, 10
-    )  # its recheck: snapshotted v1, held
+    refresh = await asyncio.to_thread(gate.get, True, 10)  # snapshotted v1, held
     store.advance_pointer(VersionRef("r1", 2))
-    r.wake()  # v2's wake: delivered mid-pass -> dropped; the pass idles on its v1 snapshot
-    recheck.set()
+    r.wake()  # delivered mid-pass: request another pass
     store.refresh_gate = None
+    refresh.set()
     ok = await _converged(r, VersionRef("r1", 2))
     await r.shutdown()
     return ok
 
 
-def test_dropped_wake_recovery_needs_backstop() -> None:
-    assert asyncio.run(_heals_dropped_wake(0.05))
-    assert not asyncio.run(_heals_dropped_wake(0))
+def test_wake_during_reconcile_is_preserved_without_backstop() -> None:
+    assert asyncio.run(_preserves_concurrent_wake(0))
 
 
 def test_constrained_409_recovers_without_backstop() -> None:


### PR DESCRIPTION
## Summary

- retain a reconcile wake delivered while a pass is already running
- remove the unconditional second store refresh before idling
- keep periodic reconciliation as the backstop for notifications that never arrive

## Why

The old wake path dropped notifications delivered during an active pass, then compensated with an unconditional second refresh. On Modal Volumes, that redundant reload could race a checkpoint loader closing its last file and fail with `there are open files preventing the operation`.

Each pass already reads the authoritative pointer. Coalescing concurrent wakes into one additional pass preserves convergence without an unnecessary reload.

## Validation

- `uv run pytest -q` (180 passed)
- `uv run ruff check src/stitch/sync.py src/stitch/sync_test.py`
- `uv run ruff format --check src/stitch/sync.py src/stitch/sync_test.py`
- Modal isolation probe reproduced the open-file reload rule in 3/3 attempts