### PR TITLE
Compose the AdmissionGate inside the Reconciler

### DIFF
--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -159,7 +159,7 @@ def create_app(
             async with (
                 contextlib.nullcontext()
                 if request.method == "GET" and route == "metrics"
-                else reconciler.admit(constraint if is_versioned else None)
+                else reconciler.gate.admit(constraint if is_versioned else None)
             ) as served:
                 if is_versioned and payload is not None and served is not None:
                     engine.stamp_request(payload, served)

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -19,12 +19,12 @@ import urllib.request
 import uuid
 from collections.abc import Iterable
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, Protocol
 
 from stitch.engines.base import Engine
 from stitch.pools.base import Pool
 from stitch.stores.base import Store
-from stitch.sync import CommitMode, ConstraintUnmet, Reconciler
+from stitch.sync import AdmissionGate, CommitMode, ConstraintUnmet, Reconciler
 from stitch.types import PoolState, ReplicaState, SyncState, VersionConstraint
 from stitch.watchdog import (
     EngineWatchdog,
@@ -41,8 +41,31 @@ VERSIONED_ROUTES = ("generate", "v1/chat/completions", "v1/completions")
 _DROP_HEADERS = {"host", "content-length", "connection"}
 
 
+class SidecarStatus(Protocol):
+    """The status/control surface the proxy consumes besides admission — the reconciler
+    implements it; tests stand it in with a stub. Admission flows through the
+    ``AdmissionGate`` separately, so the data plane never needs the control loop."""
+
+    @property
+    def ready(self) -> bool: ...
+
+    @property
+    def applied(self) -> Any: ...
+
+    def readiness_reason(self) -> str: ...
+
+    def server_info(self) -> dict[str, Any]: ...
+
+    def wake(self) -> None: ...
+
+    async def startup(self) -> None: ...
+
+    async def shutdown(self) -> None: ...
+
+
 def create_app(
-    reconciler: Reconciler,
+    gate: AdmissionGate,
+    status: SidecarStatus,
     engine: Engine,
     *,
     versioned_routes: Iterable[str] = VERSIONED_ROUTES,
@@ -73,14 +96,14 @@ def create_app(
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
         # Background reconcile so uvicorn answers /health (503 until the first catch-up) while it runs.
-        syncing = asyncio.create_task(reconciler.startup())
+        syncing = asyncio.create_task(status.startup())
         try:
             yield
         finally:
             syncing.cancel()
             with contextlib.suppress(BaseException):
                 await syncing
-            await reconciler.shutdown()
+            await status.shutdown()
             c = pooled.pop("client", None)
             if c is not None:
                 await c.aclose()
@@ -93,21 +116,21 @@ def create_app(
         # keeps a not-yet-synced replica out of rotation (else it's routed to and 409s the whole
         # catch-up). A fresh boot clears at once; a mid-run joiner waits until it has applied the
         # live version. Liveness/boot checks use /server_info instead.
-        if not reconciler.ready:
+        if not status.ready:
             return JSONResponse(
-                {"ready": False, "reason": reconciler.readiness_reason()},
+                {"ready": False, "reason": status.readiness_reason()},
                 status_code=503,
             )
         return JSONResponse({"ready": True})
 
     @app.get("/server_info")
     async def server_info() -> dict[str, Any]:
-        return reconciler.server_info()
+        return status.server_info()
 
     @app.post("/wake")
     async def wake() -> dict[str, Any]:
-        reconciler.wake()
-        return reconciler.server_info()
+        status.wake()
+        return status.server_info()
 
     async def _watch_disconnect(request: Request) -> None:
         while True:
@@ -159,7 +182,7 @@ def create_app(
             async with (
                 contextlib.nullcontext()
                 if request.method == "GET" and route == "metrics"
-                else reconciler.gate.admit(constraint if is_versioned else None)
+                else gate.admit(constraint if is_versioned else None)
             ) as served:
                 if is_versioned and payload is not None and served is not None:
                     engine.stamp_request(payload, served)
@@ -228,7 +251,7 @@ def create_app(
                     )
                 data = resp.json()
                 current = (
-                    reconciler.applied
+                    status.applied
                 )  # capture while still pinned, before a commit advances it
         except ConstraintUnmet as exc:
             return JSONResponse(exc.error, status_code=409)
@@ -298,7 +321,7 @@ def serve(
         TerminalFailureMonitor(reconciler.wait_for_terminal_error),
     )
     config = uvicorn.Config(
-        create_app(reconciler, engine), host=host, port=port, log_level="info"
+        create_app(reconciler.gate, reconciler, engine), host=host, port=port, log_level="info"
     )
     asyncio.run(run_server_with_watchdog(uvicorn.Server(config), watchdog))
 

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -35,6 +35,15 @@ class _ProxyEngine(Engine):
         response["served_version"] = served.version
 
 
+class _GateSidecar:
+    """create_app admits through ``reconciler.gate``; these tests exercise only
+    the gate slice, so stand in just that (no store, engine, or reconcile loop)."""
+
+    def __init__(self, applied: VersionRef | None = None) -> None:
+        self.applied = applied
+        self.gate = AdmissionGate(served_version=lambda: self.applied)
+
+
 class _FailingUpstream:
     """Let a test observe admission, then fail the engine request at a controlled point."""
 
@@ -145,18 +154,17 @@ def test_upstream_transport_failure_is_retryable_and_releases_admission(
 ):
     async def go():
         upstream = _FailingUpstream()
-        gate = AdmissionGate()
-        gate.applied = VersionRef("run", 3)
+        gate_sidecar = _GateSidecar(VersionRef("run", 3))
         monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: upstream)
-        app = create_app(gate, _ProxyEngine())  # type: ignore[arg-type]
+        app = create_app(gate_sidecar, _ProxyEngine())  # type: ignore[arg-type]
 
         request = asyncio.create_task(_asgi_post(app, {"rid": "rollout-1"}))
         await upstream.started.wait()
-        assert gate.active_requests == 1
+        assert gate_sidecar.gate.active_requests == 1
         upstream.fail.set()
         status, headers, body = await request
 
-        assert gate.active_requests == 0
+        assert gate_sidecar.gate.active_requests == 0
         assert upstream.abort_rids == ["rollout-1"]
         return status, headers, json.loads(body)
 
@@ -183,22 +191,21 @@ def test_client_disconnect_cancels_aborts_and_releases_admission(monkeypatch):
     async def go():
         upstream = _HangingUpstream()
         allow_disconnect = asyncio.Event()
-        gate = AdmissionGate()
-        gate.applied = VersionRef("run", 3)
+        gate_sidecar = _GateSidecar(VersionRef("run", 3))
         monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: upstream)
-        app = create_app(gate, _ProxyEngine())  # type: ignore[arg-type]
+        app = create_app(gate_sidecar, _ProxyEngine())  # type: ignore[arg-type]
 
         request = asyncio.create_task(
             _asgi_post(app, {"rid": "rollout-2"}, disconnect_on=allow_disconnect)
         )
         await upstream.started.wait()
-        assert gate.active_requests == 1
+        assert gate_sidecar.gate.active_requests == 1
         allow_disconnect.set()
         status, _headers, _body = await request
 
         assert upstream.cancelled.is_set()
         assert upstream.abort_rids == ["rollout-2"]
-        assert gate.active_requests == 0
+        assert gate_sidecar.gate.active_requests == 0
         assert status == 499
 
     asyncio.run(go())
@@ -207,8 +214,8 @@ def test_client_disconnect_cancels_aborts_and_releases_admission(monkeypatch):
 def test_metrics_bypasses_weight_admission_before_first_pointer(monkeypatch):
     async def go():
         upstream = _MetricsUpstream()
-        gate = AdmissionGate()
-        app = create_app(gate, _ProxyEngine())  # type: ignore[arg-type]
+        gate_sidecar = _GateSidecar()
+        app = create_app(gate_sidecar, _ProxyEngine())  # type: ignore[arg-type]
         sidecar = httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app), base_url="http://sidecar"
         )
@@ -222,9 +229,11 @@ def test_metrics_bypasses_weight_admission_before_first_pointer(monkeypatch):
             async def apply() -> None:
                 pass
 
-            assert gate.active_requests == 0
+            assert gate_sidecar.gate.active_requests == 0
             await asyncio.wait_for(
-                gate.commit(apply=apply, on_applied=lambda: None, drain_all=True),
+                gate_sidecar.gate.commit(
+                    apply=apply, on_applied=lambda: None, drain_all=True
+                ),
                 timeout=1.0,
             )
             assert not request.done()
@@ -237,7 +246,7 @@ def test_metrics_bypasses_weight_admission_before_first_pointer(monkeypatch):
         assert response.headers["content-type"].startswith("text/plain; version=0.0.4")
         assert response.content.startswith(b"# TYPE sglang:num_running_reqs gauge")
         assert upstream.requests == [("GET", "http://local-engine:8001/metrics")]
-        assert gate.active_requests == 0
+        assert gate_sidecar.gate.active_requests == 0
 
     asyncio.run(go())
 

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -36,12 +36,29 @@ class _ProxyEngine(Engine):
 
 
 class _GateSidecar:
-    """create_app admits through ``reconciler.gate``; these tests exercise only
-    the gate slice, so stand in just that (no store, engine, or reconcile loop)."""
+    """The status surface create_app consumes beside the gate; these tests exercise
+    only the admission slice, so stand in the rest (no store, engine, or reconcile
+    loop). The stubs are type-level only — lifespan never runs under ASGITransport."""
 
     def __init__(self, applied: VersionRef | None = None) -> None:
         self.applied = applied
+        self.ready = True
         self.gate = AdmissionGate(served_version=lambda: self.applied)
+
+    def readiness_reason(self) -> str:
+        return ""
+
+    def server_info(self) -> dict[str, Any]:
+        return {"ready": self.ready}
+
+    def wake(self) -> None:
+        pass
+
+    async def startup(self) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
 
 
 class _FailingUpstream:
@@ -156,7 +173,7 @@ def test_upstream_transport_failure_is_retryable_and_releases_admission(
         upstream = _FailingUpstream()
         gate_sidecar = _GateSidecar(VersionRef("run", 3))
         monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: upstream)
-        app = create_app(gate_sidecar, _ProxyEngine())  # type: ignore[arg-type]
+        app = create_app(gate_sidecar.gate, gate_sidecar, _ProxyEngine())
 
         request = asyncio.create_task(_asgi_post(app, {"rid": "rollout-1"}))
         await upstream.started.wait()
@@ -193,7 +210,7 @@ def test_client_disconnect_cancels_aborts_and_releases_admission(monkeypatch):
         allow_disconnect = asyncio.Event()
         gate_sidecar = _GateSidecar(VersionRef("run", 3))
         monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: upstream)
-        app = create_app(gate_sidecar, _ProxyEngine())  # type: ignore[arg-type]
+        app = create_app(gate_sidecar.gate, gate_sidecar, _ProxyEngine())
 
         request = asyncio.create_task(
             _asgi_post(app, {"rid": "rollout-2"}, disconnect_on=allow_disconnect)
@@ -215,7 +232,7 @@ def test_metrics_bypasses_weight_admission_before_first_pointer(monkeypatch):
     async def go():
         upstream = _MetricsUpstream()
         gate_sidecar = _GateSidecar()
-        app = create_app(gate_sidecar, _ProxyEngine())  # type: ignore[arg-type]
+        app = create_app(gate_sidecar.gate, gate_sidecar, _ProxyEngine())
         sidecar = httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app), base_url="http://sidecar"
         )

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -93,8 +93,9 @@ class AdmissionGate:
     def _rejection(self, c: VersionConstraint) -> dict[str, Any] | None:
         served = self._served_version()
         applied = served.version if served else None
-        # Until the first sync lands (applied is None) there is no served version to stamp, so
-        # reject as retryable rather than serve unversioned; the background reconcile sets it shortly.
+        # A gate without a reader serves nothing versioned, so reject as retryable rather
+        # than serve unversioned. A reconciler always attaches one whose version starts at
+        # the boot ref, so None here only occurs in standalone gate use.
         if applied is None or not c.satisfied_by(applied):
             target = c.exact_version if c.exact_version is not None else c.min_version
             return {

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -1,9 +1,12 @@
-"""The per-replica sync brain: an ``AdmissionGate`` (gate rollout requests on the
-served version) and a ``Reconciler`` (converge the replica to the store's pointer).
+"""The per-replica sync brain: a ``Reconciler`` that converges the replica to the
+store's pointer, with rollout requests admitted through a composed ``AdmissionGate``.
 
-They share one lock and one ``applied`` version so that reporting stays correct:
-a request's constraint is checked and its serving version captured under the same
-lock the committer holds across the weight apply *and* the version flip.
+Like the watchdogs, the gate is a standalone component wired by injection: the
+reconciler supplies a ``served_version`` reader and an ``on_reject`` hook, and drives
+weight commits through ``gate.commit``. The reader runs under the gate's condition
+lock, so a request's constraint is checked and its serving version captured with the
+same coherence the committer holds across the weight apply *and* the version flip —
+with no inheritance between the two policies.
 """
 
 from __future__ import annotations
@@ -59,11 +62,24 @@ class AdmissionGate:
     newly arriving request is attributed to the version it will actually run on. An
     incompatible transition (a run switch's boot reset) commits with ``drain_all=True``,
     which also drains all in-flight requests. The version flips before admission reopens.
+
+    The gate does not own the served version: it reads it through the injected
+    ``served_version`` reader, always under its condition lock, and reports every
+    rejection to the ``on_reject`` hook (so the owner can treat a 409 as a catch-up
+    trigger). A gate constructed without a reader has no served version: every
+    constrained request is rejected as retryable until a source is attached.
     """
 
-    def __init__(self, *, commit_mode: CommitMode = "in_place") -> None:
+    def __init__(
+        self,
+        *,
+        commit_mode: CommitMode = "in_place",
+        served_version: Callable[[], VersionRef | None] | None = None,
+        on_reject: Callable[[dict[str, Any]], None] | None = None,
+    ) -> None:
         self.commit_mode = commit_mode
-        self.applied: VersionRef | None = None
+        self._served_version = served_version or (lambda: None)
+        self._on_reject = on_reject or (lambda error: None)
         self._cond = asyncio.Condition()
         self._active = 0
         self._committing = False
@@ -75,7 +91,8 @@ class AdmissionGate:
         return self._active
 
     def _rejection(self, c: VersionConstraint) -> dict[str, Any] | None:
-        applied = self.applied.version if self.applied else None
+        served = self._served_version()
+        applied = served.version if served else None
         # Until the first sync lands (applied is None) there is no served version to stamp, so
         # reject as retryable rather than serve unversioned; the background reconcile sets it shortly.
         if applied is None or not c.satisfied_by(applied):
@@ -87,9 +104,6 @@ class AdmissionGate:
                 "message": f"served version {applied} does not satisfy {c}",
             }
         return None
-
-    def _on_reject(self, error: dict[str, Any]) -> None:
-        """Hook, run under the lock, when a request is rejected."""
 
     def _commit_ready(self) -> bool:
         if self.commit_mode == "in_place" and not self._drain_all:
@@ -107,7 +121,7 @@ class AdmissionGate:
             if error is not None:
                 self._on_reject(error)
                 raise ConstraintUnmet(error)
-            served = self.applied
+            served = self._served_version()
             self._active += 1
             if c.exact_version is not None:
                 self._exact_inflight[c.exact_version] += 1
@@ -163,10 +177,13 @@ class AdmissionGate:
                 self._cond.notify_all()
 
 
-class Reconciler(AdmissionGate):
+class Reconciler:
     """Converges one replica to the store's ``latest`` pointer: stage the chain,
-    commit once, flip the served version. A run change restores the immutable boot
-    checkpoint, so one run's chain is never mistaken for another's."""
+    commit once, flip the served version. Admission is delegated to the composed
+    :class:`AdmissionGate` (``self.gate``), which reads ``self.applied`` under its
+    own lock while commits flip that same attribute through ``gate.commit``. A run
+    change restores the immutable boot checkpoint, so one run's chain is never
+    mistaken for another's."""
 
     def __init__(
         self,
@@ -180,7 +197,6 @@ class Reconciler(AdmissionGate):
         debug_requests: bool = False,
         reconcile_interval: float = 5.0,
     ) -> None:
-        super().__init__(commit_mode=commit_mode)
         if not run_id:
             raise ValueError("run_id is required")
         if boot_version < 0:
@@ -191,6 +207,12 @@ class Reconciler(AdmissionGate):
         self.run_id = run_id
         self.boot_version = boot_version
         self.applied = VersionRef(run_id, boot_version)
+        # The gate consults the served version only as a reader; a 409 wakes us.
+        self.gate = AdmissionGate(
+            commit_mode=commit_mode,
+            served_version=lambda: self.applied,
+            on_reject=self._on_reject,
+        )
         self.debug_requests = debug_requests
         self.reconcile_interval = reconcile_interval
         self.sync_state = SyncState.IDLE
@@ -262,8 +284,8 @@ class Reconciler(AdmissionGate):
             "sync_state": self.sync_state.value,
             "reason": self.last_error,
             "run_id": self.run_id,
-            "commit_mode": self.commit_mode,
-            "active_requests": self._active,
+            "commit_mode": self.gate.commit_mode,
+            "active_requests": self.gate.active_requests,
             "update_destination_ready": self._destination_ready,
             "update_destination_error": self._destination_init_error,
             "terminal_error": str(self._terminal_error)
@@ -448,7 +470,7 @@ class Reconciler(AdmissionGate):
         if not has_weight_changes:
             # Nothing changed across the applied→target range: advance the
             # version without preparing or loading byte-identical weights.
-            await self.commit(apply=self._commit_noop, on_applied=on_applied)
+            await self.gate.commit(apply=self._commit_noop, on_applied=on_applied)
             m["skipped_weight_update"] = True
         else:
             # Preparation runs while serving. Re-read the head once before the
@@ -508,7 +530,7 @@ class Reconciler(AdmissionGate):
                         flush_cache=self.flush_cache_on_commit,
                     )
 
-            await self.commit(
+            await self.gate.commit(
                 apply=apply,
                 on_applied=on_applied,
                 pause=self.engine.pause,
@@ -546,7 +568,7 @@ class Reconciler(AdmissionGate):
             self.applied = VersionRef(new_run, self.boot_version)
             self.last_error = None
 
-        await self.commit(
+        await self.gate.commit(
             apply=apply,
             on_applied=on_applied,
             pause=self.engine.pause if was_patched else None,

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -392,11 +392,11 @@ def test_run_switch_drains_rolling_requests() -> None:
         late_served: list[VersionRef | None] = []
 
         async def rolling() -> None:
-            async with r.admit(None):
+            async with r.gate.admit(None):
                 await release.wait()
 
         async def late() -> None:
-            async with r.admit(None) as served:
+            async with r.gate.admit(None) as served:
                 late_served.append(served)
 
         req = asyncio.create_task(rolling())
@@ -405,7 +405,7 @@ def test_run_switch_drains_rolling_requests() -> None:
         for _ in range(
             1000
         ):  # bounded: without drain_all the switch completes without draining
-            if r._committing:
+            if r.gate._committing:
                 break
             await asyncio.sleep(0.001)
         late_task = asyncio.create_task(late())
@@ -435,7 +435,7 @@ def test_rolling_requests_cross_in_place_commit() -> None:
         release = asyncio.Event()
 
         async def rolling() -> None:
-            async with r.admit(None):
+            async with r.gate.admit(None):
                 await release.wait()
 
         req = asyncio.create_task(rolling())
@@ -475,11 +475,11 @@ def test_new_request_waits_for_in_place_commit() -> None:
         late_served: list[VersionRef | None] = []
 
         async def rolling() -> None:
-            async with r.admit():
+            async with r.gate.admit():
                 await rolling_release.wait()
 
         async def late() -> None:
-            async with r.admit() as served:
+            async with r.gate.admit() as served:
                 late_served.append(served)
 
         rolling_task = asyncio.create_task(rolling())
@@ -760,7 +760,7 @@ async def _heals_transient_error(interval: float) -> bool:
     await (
         r.startup()
     )  # the pass hits the error -> ERROR; the store is healed from here on
-    async with r.admit(None):
+    async with r.gate.admit(None):
         pass  # unconstrained traffic never 409s, so it nudges nothing
     ok = await _converged(r, VersionRef("r1", 1))
     await r.shutdown()
@@ -838,7 +838,7 @@ def test_constrained_409_recovers_without_backstop() -> None:
         await r.startup()
         assert r.sync_state is SyncState.ERROR
         try:
-            async with r.admit(VersionConstraint(min_version=1)):
+            async with r.gate.admit(VersionConstraint(min_version=1)):
                 raise AssertionError("should have rejected")
         except ConstraintUnmet:
             pass
@@ -852,7 +852,7 @@ def test_admit_satisfied() -> None:
     async def go() -> None:
         r = _make_reconciler(store=FakeStore(), engine=FakeEngine())
         r.applied = VersionRef("r1", 5)
-        async with r.admit(VersionConstraint(min_version=3)) as served:
+        async with r.gate.admit(VersionConstraint(min_version=3)) as served:
             assert served == VersionRef("r1", 5)
 
     _run(go())
@@ -865,7 +865,7 @@ def test_admit_rejected_triggers_wake() -> None:
         )
         r.applied = VersionRef("r1", 2)
         try:
-            async with r.admit(VersionConstraint(min_version=5)):
+            async with r.gate.admit(VersionConstraint(min_version=5)):
                 raise AssertionError("should have rejected")
         except ConstraintUnmet as e:
             assert e.error["type"] == "WeightVersionNotReady"
@@ -887,7 +887,7 @@ def test_run_scoped_replica_serves_boot_checkpoint_as_version_zero() -> None:
         try:
             assert r.applied == VersionRef("r1", 0)
             assert r.ready
-            async with r.admit(VersionConstraint(exact_version=0)) as served:
+            async with r.gate.admit(VersionConstraint(exact_version=0)) as served:
                 assert served == VersionRef("r1", 0)
         finally:
             await r.shutdown()
@@ -910,7 +910,7 @@ def test_resumed_replica_serves_boot_checkpoint_at_saved_version() -> None:
             assert r.ready
             assert not engine.staged
             assert engine.initialized_versions == [119]
-            async with r.admit(VersionConstraint(exact_version=119)) as served:
+            async with r.gate.admit(VersionConstraint(exact_version=119)) as served:
                 assert served == VersionRef("resumed", 119)
         finally:
             await r.shutdown()


### PR DESCRIPTION
## What

`Reconciler` no longer inherits from `AdmissionGate`. The sync brain coupled two orthogonal policies by inheritance — when to admit a rollout request vs. when to converge the replica to the store pointer — sharing `applied`, `commit_mode`, the condition lock, and an `_on_reject` override. Now the gate is composed and wired by injection, matching how the watchdogs (`EngineWatchdog`, `TerminalFailureMonitor`) are wired.

- **`AdmissionGate` is standalone**: the served version arrives as an injected `served_version` reader, consulted only under the gate's condition lock, so a request's constraint check and served-version capture stay atomic with commits (the committer holds admission closed across the weight apply *and* the version flip). Rejections surface through an injected `on_reject` hook. A bare gate has no served version, so constrained requests keep getting retryable 409s until a source is attached.
- **`Reconciler` owns `applied`**, composes `self.gate`, and drives weight commits through `gate.commit`; `on_reject` stays the 409→wake cue. `server_info` reports `commit_mode`/`active_requests` from the gate — payload keys unchanged.
- **`create_app`** admits through `reconciler.gate.admit(...)` instead of the flattened-from-inheritance `reconciler.admit(...)`.
- Tests: `sync_test` goes through `r.gate.admit(...)`; `service_test`'s raw-gate shortcut becomes a small `_GateSidecar` stand-in that composes the gate the same way the reconciler does.

## Test plan

- `uv run pytest` — 180 passed (full suite, including the gate-commit/drain/in-place ordering tests and the 409→wake recovery tests)

🤖 Generated with Codex