### PR TITLE
Extract the distributed publish protocol into stitch core

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -486,32 +486,42 @@ publish_version(
 Passing `None` for the pool is sufficient when replicas poll the store; a
 custom `Pool` can be passed to provide an immediate wake-up hint.
 
-For a distributed trainer, snapshot `latest` before upload, have one leader per
-host upload only that host's local files, gather the receipts through the
-trainer's communicator, and let rank 0 commit the pointer last:
+For a distributed trainer, `stitch.publisher.Publisher` runs the same protocol
+the cookbook's trainers use — rank 0 snapshots `latest`, one leader per host
+uploads only that host's local files, rank 0 verifies the gathered receipts and
+commits the pointer last. Provide your trainer's communicator as a
+`TrainerComms` (rank identity, an object gather, and one host leader election);
+the defaults are the single-process case:
 
 ```python
-from stitch.types import VersionRef, decide_pointer_move
+from stitch.publisher import Publisher, TrainerComms
 
-target = VersionRef(run_id, 1)
 
-if global_rank == 0:
-    expected = store.read_pointer()
-    decide_pointer_move(expected, target)
-else:
-    expected = None
-expected = broadcast_object(expected, src=0)  # your trainer's communicator
+class TorchComms(TrainerComms):
+    def rank(self):
+        import torch.distributed as dist
 
-receipt = None
-if is_host_leader:
-    receipt = store.upload_version_files(target, local_version_dir)
-receipts = gather_objects(receipt, dst=0)  # your trainer's communicator
+        return dist.get_rank() if dist.is_initialized() else None
 
-if global_rank == 0:
-    receipts = [receipt for receipt in receipts if receipt is not None]
-    store.verify_version(target, receipts)
-    store.compare_and_advance_pointer(expected, target)
+    def all_gather_object(self, value):
+        import torch.distributed as dist
+
+        values = [None] * dist.get_world_size()
+        dist.all_gather_object(values, value)
+        return values
+
+    def is_host_leader(self):
+        return torch.distributed.get_rank() % ranks_per_host == 0
+
+
+publisher = Publisher(store, None, run_id=run_id, comms=TorchComms())
+publisher.claim(boot_version=0)  # once, when establishing the run's base
+publisher.publish("/local/updates/weight_v000001")
 ```
+
+`Publisher.publish` also dispatches on the backend: a shared mounted store is
+committed by each host leader before rank 0 publishes from the refreshed view,
+which is the flow the cookbook's Miles/Slime hooks use with Modal Volumes.
 
 All ranks should treat an upload, verification, or pointer conflict as a
 failed publication and synchronize before continuing. The version prefix is

--- a/cookbook/common/hooks.py
+++ b/cookbook/common/hooks.py
@@ -1,28 +1,44 @@
 """Shared trainer hooks for publishing HF weight updates and routing rollout requests.
 
 Trainer integrations point their lifecycle callbacks at this module. Each hook reads the
-run coordinates from the trainer's argument namespace and composes the Stitch core with a
-configured Store and ``ModalFlashPool``.
+run coordinates from the trainer's argument namespace and wires the configured Store and
+``ModalFlashPool`` into :class:`stitch.publisher.Publisher`, the modal-agnostic core
+that owns the distributed publish protocol.
 """
 
 from __future__ import annotations
 
 import logging
 import time
-import traceback
 from pathlib import Path
 from typing import Any
 
 from stitch.pools.modal_flash import ModalFlashPool
-from stitch.publish import claim_run, constrain_request, publish_version, wake_pool
+from stitch.publish import constrain_request
+from stitch.publisher import Publisher, TrainerComms
 from stitch.stores.base import Store
-from stitch.stores.s3 import S3Store, UploadReceipt
-from stitch.types import VersionRef, decide_pointer_move
 
 from . import process, storage
 from .constants import MODAL_SESSION_ID_HEADER
 
 logger = logging.getLogger(__name__)
+
+
+class _TorchComms(TrainerComms):
+    """The trainer's torch.distributed comms, via ``common.process`` helpers.
+
+    Off the distributed path (no initialized process group) each helper degrades
+    to the single-process default, so a single-host dev run needs no wiring.
+    """
+
+    def rank(self) -> int | None:
+        return process.dist_rank()
+
+    def all_gather_object(self, value: Any) -> list[Any]:
+        return process.dist_all_gather_object(value)
+
+    def is_host_leader(self) -> bool:
+        return process.dist_is_container_leader()
 
 
 def sample_affinity_key(sample: Any) -> str | None:
@@ -48,152 +64,21 @@ def commit_and_wake(args: Any, published_dir: str, rollout_engines: Any = None) 
     that is a Volume durability boundary and an S3 no-op.
     """
     del rollout_engines
-    store = _store(args)
-    if not Path(published_dir).name.startswith("weight_v"):
-        if not isinstance(store, S3Store):
-            store.commit()
-        return
-
-    target = VersionRef.parse(f"{_run_id(args)}/{Path(published_dir).name}")
-    checked = process.dist_rank() in (None, 0)
-    publication_state: tuple[bool, bool, VersionRef | None, str | None] = (
-        checked,
-        False,
-        None,
-        None,
-    )
-    if process.dist_rank() in (None, 0):
-        try:
-            current = store.read_pointer()
-            publication_state = (
-                True,
-                current is not None
-                and current.run_id == target.run_id
-                and current.version >= target.version,
-                current,
-                None,
-            )
-        except Exception:  # noqa: BLE001
-            publication_state = (
-                True,
-                False,
-                None,
-                f"rank 0:\n{traceback.format_exc()}",
-            )
-    publication_states = process.dist_all_gather_object(publication_state)
-    errors = [error for _, _, _, error in publication_states if error is not None]
-    if errors:
-        raise RuntimeError(
-            "checkpoint publication state check failed:\n" + "\n".join(errors)
-        )
-    rank_zero_states = [state for state in publication_states if state[0]]
-    if len(rank_zero_states) != 1:
-        raise RuntimeError(
-            "checkpoint publication state check did not identify exactly one rank 0"
-        )
-    _, already_published, expected_pointer, _ = rank_zero_states[0]
-    if already_published:
-        logger.warning("%s is already published; leaving it immutable", published_dir)
-        return
-    decide_pointer_move(expected_pointer, target)
-
-    if isinstance(store, S3Store):
-        _publish_s3_version(
-            store,
-            args,
-            target,
-            published_dir,
-            expected_pointer=expected_pointer,
-        )
-        return
-
-    _publish_mounted_version(store, args, published_dir)
-
-
-def _publish_mounted_version(store: Store, args: Any, published_dir: str) -> None:
-    """Commit every trainer host, then publish from rank 0's refreshed mount."""
-
-    commit_error = None
-    if process.dist_is_container_leader():
-        try:
-            store.commit()
-        except Exception:  # noqa: BLE001
-            commit_error = f"rank {process.dist_rank()}:\n{traceback.format_exc()}"
-    _raise_distributed_failures("checkpoint commit", commit_error)
-
-    publish_error = None
-    if process.dist_rank() in (None, 0):
-        try:
-            store.refresh()
-            publish_version(store, _pool(args), published_dir, run_id=_run_id(args))
-        except Exception:  # noqa: BLE001
-            publish_error = f"rank 0:\n{traceback.format_exc()}"
-    _raise_distributed_failures("checkpoint publication", publish_error)
-
-
-def _publish_s3_version(
-    store: S3Store,
-    args: Any,
-    target: VersionRef,
-    published_dir: str,
-    *,
-    expected_pointer: VersionRef | None,
-) -> None:
-    """Upload once per host, verify gathered receipts, and commit ``latest`` last."""
-    receipt: UploadReceipt | None = None
-    upload_error = None
-    if process.dist_is_container_leader():
-        try:
-            receipt = store.upload_version_files(target, published_dir)
-        except Exception:  # noqa: BLE001
-            upload_error = f"rank {process.dist_rank()}:\n{traceback.format_exc()}"
-
-    upload_results = process.dist_all_gather_object((receipt, upload_error))
-    upload_errors = [error for _, error in upload_results if error is not None]
-    if upload_errors:
-        raise RuntimeError("checkpoint upload failed:\n" + "\n".join(upload_errors))
-    receipts = [receipt for receipt, _ in upload_results if receipt is not None]
-    if not receipts:
-        raise RuntimeError("checkpoint upload produced no host receipts")
-
-    publish_error = None
-    if process.dist_rank() in (None, 0):
-        try:
-            manifest = store.verify_version(target, receipts)
-            store.compare_and_advance_pointer(expected_pointer, target)
-            wake_pool(_pool(args), target)
-            logger.info(
-                "published %s: kind=%s files=%d hosts=%d",
-                target.identity,
-                manifest.kind.value,
-                len(manifest.files),
-                len(receipts),
-            )
-        except Exception:  # noqa: BLE001
-            publish_error = f"rank 0:\n{traceback.format_exc()}"
-    _raise_distributed_failures("checkpoint publication", publish_error)
-
-
-def _raise_distributed_failures(phase: str, local_error: str | None) -> None:
-    errors = [
-        error
-        for error in process.dist_all_gather_object(local_error)
-        if error is not None
-    ]
-    if errors:
-        raise RuntimeError(f"{phase} failed:\n" + "\n".join(errors))
+    _publisher(args).publish(published_dir)
 
 
 def claim_pool(args: Any, *, boot_version: int = 0) -> None:
     """Launch hook (rank 0): identify the checkpoint already served by every replica
     before the first publish."""
-    if process.dist_rank() not in (None, 0):
-        return
-    claim_run(
+    _publisher(args).claim(boot_version=boot_version)
+
+
+def _publisher(args: Any) -> Publisher:
+    return Publisher(
         _store(args),
         _pool(args),
-        _run_id(args),
-        boot_version=boot_version,
+        run_id=_run_id(args),
+        comms=_TorchComms(),
     )
 
 

--- a/cookbook/common/hooks_test.py
+++ b/cookbook/common/hooks_test.py
@@ -1,7 +1,9 @@
 """Harness for the shared hook shims.
 
 Runs without Modal/torch: the real ``_store`` builds a local dir (volume_name=None from
-the temp root) and only ``_pool`` is faked. Run directly:
+the temp root) and only ``_pool`` is faked. The distributed publish protocol itself
+is covered by ``src/stitch/publisher_test.py``; here is the cookbook's wiring of
+trainer args to the core Store/Pool/comms, plus the request-hook gate. Run directly:
   PYTHONPATH=src:. python cookbook/common/hooks_test.py
 """
 
@@ -20,7 +22,7 @@ import pytest
 
 from cookbook.common import hooks
 from stitch.stores.modal_volume import ModalVolumeStore
-from stitch.stores.s3 import S3Store, UploadReceipt
+from stitch.stores.s3 import S3Store
 from stitch.types import VersionRef
 
 
@@ -148,53 +150,23 @@ def test_commit_and_wake_publishes() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         pool = _FakePool()
-        events = []
-        original_gather = hooks.process.dist_all_gather_object
-        original_container_leader = hooks.process.dist_is_container_leader
-        original_publish = hooks.publish_version
         original_commit = ModalVolumeStore.commit
-        original_refresh = ModalVolumeStore.refresh
-
-        def publish_after_refresh(*args, **kwargs):
-            events.append("publish")
-            return original_publish(*args, **kwargs)
-
-        def commit_before_refresh(store):
-            events.append("commit")
-            return original_commit(store)
-
-        def refresh_after_commit(store):
-            events.append("refresh")
-            return original_refresh(store)
 
         hooks._pool = lambda args: pool  # rank is None in tests -> treated as writer
+        commits = 0
 
-        def gather(value):
-            events.append("gather")
-            return [value]
+        def count_commit(store):
+            nonlocal commits
+            commits += 1
+            return original_commit(store)
 
-        hooks.process.dist_all_gather_object = gather
-        hooks.process.dist_is_container_leader = lambda: True
-        hooks.publish_version = publish_after_refresh
-        ModalVolumeStore.commit = commit_before_refresh
-        ModalVolumeStore.refresh = refresh_after_commit
+        ModalVolumeStore.commit = count_commit
         try:
             vdir = _write_version(root, VersionRef("run-abc", 1))
             hooks.commit_and_wake(_args(str(root)), vdir)
         finally:
-            hooks.process.dist_all_gather_object = original_gather
-            hooks.process.dist_is_container_leader = original_container_leader
-            hooks.publish_version = original_publish
             ModalVolumeStore.commit = original_commit
-            ModalVolumeStore.refresh = original_refresh
-        assert events == [
-            "gather",
-            "commit",
-            "gather",
-            "refresh",
-            "publish",
-            "gather",
-        ]
+        assert commits == 1  # this host's mount was committed before rank 0 published
         assert ModalVolumeStore(root, run_id="run-abc").read_pointer() == VersionRef(
             "run-abc", 1
         )
@@ -270,69 +242,6 @@ def test_commit_and_wake_publishes_directly_to_s3(
         "bucket",
         "experiments/run-abc/updates/weight_v000001/model-00001.safetensors",
     ) in client.objects
-
-
-def test_commit_and_wake_verifies_receipts_from_multiple_hosts(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    client = _FakeS3()
-    ref = VersionRef("run-abc", 1)
-    local_dir = tmp_path / "updates" / "weight_v000001"
-    remote_dir = tmp_path / "remote" / "weight_v000001"
-    local_dir.mkdir(parents=True)
-    remote_dir.mkdir(parents=True)
-    (local_dir / "model.safetensors.index.json").write_text(
-        json.dumps(
-            {
-                "metadata": {"version": 1},
-                "weight_map": {
-                    "a": "model-00001-of-00002.safetensors",
-                    "b": "model-00002-of-00002.safetensors",
-                },
-            }
-        )
-    )
-    (local_dir / "model-00001-of-00002.safetensors").write_bytes(b"local")
-    (remote_dir / "model-00002-of-00002.safetensors").write_bytes(b"remote")
-    remote_store = S3Store(
-        "s3://bucket/experiments/run-abc",
-        cache_dir=tmp_path,
-        run_id="run-abc",
-    )
-    remote_store._client = client
-    remote_receipt = remote_store.upload_version_files(ref, remote_dir)
-    create_store = hooks.storage.create_store
-
-    def create_store_with_client(*args, **kwargs):
-        store = create_store(*args, **kwargs)
-        if isinstance(store, S3Store):
-            store._client = client
-        return store
-
-    def gather_with_remote_receipt(value):
-        if (
-            isinstance(value, tuple)
-            and len(value) == 2
-            and isinstance(value[0], UploadReceipt)
-        ):
-            return [value, (remote_receipt, None)]
-        return [value]
-
-    monkeypatch.setattr(hooks.storage, "create_store", create_store_with_client)
-    monkeypatch.setattr(
-        hooks.process, "dist_all_gather_object", gather_with_remote_receipt
-    )
-    monkeypatch.setattr(hooks.process, "dist_is_container_leader", lambda: True)
-    monkeypatch.setattr(hooks, "_pool", lambda _args: _FakePool())
-    args = _args(
-        str(tmp_path),
-        stitch_store_backend="s3",
-        stitch_s3_root="s3://bucket/experiments/run-abc",
-    )
-
-    hooks.commit_and_wake(args, str(local_dir))
-
-    assert hooks._store(args).read_pointer() == ref
 
 
 def test_commit_and_wake_s3_baseline_does_not_touch_a_volume(

--- a/src/stitch/publisher.py
+++ b/src/stitch/publisher.py
@@ -1,0 +1,217 @@
+"""The distributed publication protocol — how a trainer's ranks converge on one
+published version.
+
+This is the modal- and framework-agnostic core each integration's publish hook
+delegates to (the cookbook's is ``cookbook.common.hooks.commit_and_wake``).
+``TrainerComms`` abstracts how ranks rendezvous, the Store abstracts where bytes
+live, and the Pool wake stays best-effort. A single-process trainer gets the
+default comms for free; a distributed one subclasses them over its runtime
+(torch.distributed, MPI, ...) and hands them in with its Store.
+
+The protocol composes ``publish.py``'s single-writer helpers rather than
+replacing them: rank 0 runs the same ``publish_version`` / ``claim_run`` a
+one-host trainer calls directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import traceback
+from pathlib import Path
+from typing import Any
+
+from stitch.pools.base import Pool
+from stitch.publish import claim_run, publish_version, wake_pool
+from stitch.stores.base import Store
+from stitch.stores.s3 import S3Store
+from stitch.types import WEIGHT_PREFIX, VersionRef, decide_pointer_move
+
+logger = logging.getLogger(__name__)
+
+
+class TrainerComms:
+    """The trainer's communicator — how distributed ranks rendezvous during a publish.
+
+    Each method's default is the single-process case: one writer, singleton
+    gathers. A distributed trainer subclasses all three over its runtime. Every
+    method must be callable on every rank with the same published_dir — the
+    protocol gathers results across ranks so all of them fail or succeed together.
+    """
+
+    def rank(self) -> int | None:
+        """This process's global rank, or None off the distributed path (single
+        process: treated as rank 0)."""
+        return None
+
+    def all_gather_object(self, value: Any) -> list[Any]:
+        """Gather one small control-plane value from every rank."""
+        return [value]
+
+    def is_host_leader(self) -> bool:
+        """Whether this rank performs the once-per-host-or-mount store side effects
+        (its host's shard commit/upload), for runtimes where several ranks share one
+        host's files."""
+        return True
+
+
+class Publisher:
+    """One run's publication actor: claim the run's boot checkpoint, then publish
+    each framework-written weight update across the trainer's ranks."""
+
+    def __init__(
+        self,
+        store: Store,
+        pool: Pool | None = None,
+        *,
+        run_id: str,
+        comms: TrainerComms | None = None,
+    ) -> None:
+        self._store = store
+        self._pool = pool
+        self._run_id = run_id
+        self._comms = comms if comms is not None else TrainerComms()
+
+    def claim(self, *, boot_version: int = 0) -> None:
+        """Start the run at the checkpoint every replica already serves (rank 0's
+        job; the single-writer ``claim_run`` does the move)."""
+        if self._comms.rank() not in (None, 0):
+            return
+        claim_run(self._store, self._pool, self._run_id, boot_version=boot_version)
+
+    def publish(self, published_dir: str) -> None:
+        """Publish one framework-written disk update as the run's next served version.
+
+        A ``weight_vNNNNNN`` directory is a version publish; any other directory is
+        the framework's run directory — a durability boundary for a mounted store
+        (every rank commits) and a no-op for an upload store. The version publish
+        splits by backend: with a shared mount every host leader commits its mount
+        and rank 0 publishes from the refreshed view; with per-host uploads each
+        leader uploads its node-local files and rank 0 commits ``latest`` only after
+        the gathered receipts verify, so a replica never follows ``latest`` to
+        incomplete bytes."""
+        name = Path(published_dir).name
+        if not name.startswith(WEIGHT_PREFIX):
+            if not isinstance(self._store, S3Store):
+                self._store.commit()
+            return
+
+        target = VersionRef.parse(f"{self._run_id}/{name}")
+        already_published, expected = self._pointer_snapshot(target)
+        if already_published:
+            logger.warning(
+                "%s is already published; leaving it immutable", published_dir
+            )
+            return
+        decide_pointer_move(expected, target)  # every rank rejects a rewind identically
+
+        if isinstance(self._store, S3Store):
+            self._publish_uploaded(target, published_dir, expected)
+        else:
+            self._publish_mounted(published_dir)
+
+    def _pointer_snapshot(self, target: VersionRef) -> tuple[bool, VersionRef | None]:
+        """Rank 0 reads ``latest`` and every rank agrees on the gathered result.
+
+        Returns whether ``target`` was already published and the pointer rank 0 saw
+        — the expected predecessor of rank 0's later conditional advance."""
+        checked = self._comms.rank() in (None, 0)
+        current = None
+        already_published = False
+        error = None
+        if checked:
+            try:
+                current = self._store.read_pointer()
+                already_published = (
+                    current is not None
+                    and current.run_id == target.run_id
+                    and current.version >= target.version
+                )
+            except Exception:  # noqa: BLE001
+                error = f"rank 0:\n{traceback.format_exc()}"
+        states = self._comms.all_gather_object(
+            (checked, already_published, current, error)
+        )
+        errors = [state[3] for state in states if state[3] is not None]
+        if errors:
+            raise RuntimeError(
+                "checkpoint publication state check failed:\n" + "\n".join(errors)
+            )
+        rank_zero = [state for state in states if state[0]]
+        if len(rank_zero) != 1:
+            raise RuntimeError(
+                "checkpoint publication state check did not identify exactly one rank 0"
+            )
+        _, already, expected, _ = rank_zero[0]
+        return already, expected
+
+    def _publish_mounted(self, published_dir: str) -> None:
+        """Commit every host's mount, then publish from rank 0's refreshed view."""
+        commit_error = None
+        if self._comms.is_host_leader():
+            try:
+                self._store.commit()
+            except Exception:  # noqa: BLE001
+                commit_error = f"rank {self._comms.rank()}:\n{traceback.format_exc()}"
+        self._raise_gathered_failures("checkpoint commit", commit_error)
+
+        publish_error = None
+        if self._comms.rank() in (None, 0):
+            try:
+                self._store.refresh()
+                publish_version(
+                    self._store, self._pool, published_dir, run_id=self._run_id
+                )
+            except Exception:  # noqa: BLE001
+                publish_error = f"rank 0:\n{traceback.format_exc()}"
+        self._raise_gathered_failures("checkpoint publication", publish_error)
+
+    def _publish_uploaded(
+        self,
+        target: VersionRef,
+        published_dir: str,
+        expected: VersionRef | None,
+    ) -> None:
+        """Upload once per host, verify the gathered receipts, and commit ``latest`` last."""
+        receipt = None
+        upload_error = None
+        if self._comms.is_host_leader():
+            try:
+                receipt = self._store.upload_version_files(target, published_dir)
+            except Exception:  # noqa: BLE001
+                upload_error = f"rank {self._comms.rank()}:\n{traceback.format_exc()}"
+
+        results = self._comms.all_gather_object((receipt, upload_error))
+        upload_errors = [error for _, error in results if error is not None]
+        if upload_errors:
+            raise RuntimeError(
+                "checkpoint upload failed:\n" + "\n".join(upload_errors)
+            )
+        receipts = [receipt for receipt, _ in results if receipt is not None]
+        if not receipts:
+            raise RuntimeError("checkpoint upload produced no host receipts")
+
+        publish_error = None
+        if self._comms.rank() in (None, 0):
+            try:
+                manifest = self._store.verify_version(target, receipts)
+                self._store.compare_and_advance_pointer(expected, target)
+                wake_pool(self._pool, target)
+                logger.info(
+                    "published %s: kind=%s files=%d hosts=%d",
+                    target.identity,
+                    manifest.kind.value,
+                    len(manifest.files),
+                    len(receipts),
+                )
+            except Exception:  # noqa: BLE001
+                publish_error = f"rank 0:\n{traceback.format_exc()}"
+        self._raise_gathered_failures("checkpoint publication", publish_error)
+
+    def _raise_gathered_failures(self, phase: str, local_error: str | None) -> None:
+        errors = [
+            error
+            for error in self._comms.all_gather_object(local_error)
+            if error is not None
+        ]
+        if errors:
+            raise RuntimeError(f"{phase} failed:\n" + "\n".join(errors))

--- a/src/stitch/publisher_test.py
+++ b/src/stitch/publisher_test.py
@@ -1,0 +1,418 @@
+"""Publisher harness: the distributed publication protocol against fake comms/stores.
+
+Runs without Modal/torch: ranks are scripted in-process, mounted stores are local
+dirs (volume_name=None), and S3 is a fake client. The multi-rank scripts emulate
+what a real collective would return — every rank sees every gathered value.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tempfile
+from base64 import b64encode
+from pathlib import Path
+
+import pytest
+
+from stitch import publisher
+from stitch.publisher import Publisher, TrainerComms
+from stitch.stores.modal_volume import ModalVolumeStore
+from stitch.stores.s3 import S3Store, UploadReceipt
+from stitch.types import PointerRewind, VersionRef
+
+
+class _FakePool:
+    def __init__(self) -> None:
+        self.woke: list = []
+
+    def discover_replicas(self):
+        return ["http://r1"]
+
+    def wake(self, replicas, ref):
+        self.woke.append(ref)
+
+
+class _RecordingComms(TrainerComms):
+    """Scriptable in-process comms: ``gather`` emulates the collective's result."""
+
+    def __init__(
+        self,
+        events: list[str] | None = None,
+        rank: int | None = None,
+        is_host_leader: bool = True,
+        gather=None,
+    ) -> None:
+        self._events = events
+        self._rank = rank
+        self._leader = is_host_leader
+        self._gather = gather or (lambda value: [value])
+
+    def rank(self):
+        return self._rank
+
+    def all_gather_object(self, value):
+        if self._events is not None:
+            self._events.append("gather")
+        return self._gather(value)
+
+    def is_host_leader(self):
+        return self._leader
+
+
+class _RecordingVolumeStore(ModalVolumeStore):
+    def __init__(self, events: list[str], *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._events = events
+
+    def commit(self) -> None:
+        self._events.append("commit")
+        super().commit()
+
+    def refresh(self) -> None:
+        self._events.append("refresh")
+        super().refresh()
+
+
+class _FakeS3:
+    """Dict-backed subset of the boto3 S3 client used by ``S3Store``."""
+
+    class exceptions:  # noqa: N801 - mirrors boto3's client.exceptions namespace
+        class NoSuchKey(Exception):
+            pass
+
+    class ConditionalWriteFailed(Exception):
+        def __init__(self) -> None:
+            self.response = {
+                "Error": {"Code": "PreconditionFailed"},
+                "ResponseMetadata": {"HTTPStatusCode": 412},
+            }
+
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], bytes] = {}
+        self.metadata: dict[tuple[str, str], dict[str, str]] = {}
+        self.checksums: dict[tuple[str, str], str] = {}
+        self.etags: dict[tuple[str, str], str] = {}
+
+    def put_object(
+        self,
+        *,
+        Bucket: str,
+        Key: str,
+        Body: bytes,
+        IfMatch: str | None = None,
+        IfNoneMatch: str | None = None,
+    ) -> None:
+        object_id = (Bucket, Key)
+        if IfNoneMatch == "*" and object_id in self.objects:
+            raise self.ConditionalWriteFailed
+        if IfMatch is not None and self.etags.get(object_id) != IfMatch:
+            raise self.ConditionalWriteFailed
+        self._write_object(object_id, Body)
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict[str, io.BytesIO]:
+        try:
+            value = self.objects[(Bucket, Key)]
+        except KeyError:
+            raise self.exceptions.NoSuchKey from None
+        return {"Body": io.BytesIO(value), "ETag": self.etags[(Bucket, Key)]}
+
+    def upload_file(
+        self,
+        filename: str,
+        bucket: str,
+        key: str,
+        ExtraArgs: dict[str, object] | None = None,
+    ) -> None:
+        object_id = (bucket, key)
+        body = Path(filename).read_bytes()
+        self._write_object(object_id, body)
+        self.metadata[object_id] = dict((ExtraArgs or {}).get("Metadata", {}))
+        if (ExtraArgs or {}).get("ChecksumAlgorithm") == "SHA256":
+            self.checksums[object_id] = b64encode(
+                hashlib.sha256(body).digest()
+            ).decode()
+
+    def head_object(
+        self, *, Bucket: str, Key: str, ChecksumMode: str | None = None
+    ) -> dict[str, object]:
+        object_id = (Bucket, Key)
+        if object_id not in self.objects:
+            raise self.exceptions.NoSuchKey
+        return {
+            "ContentLength": len(self.objects[object_id]),
+            "ETag": self.etags[object_id],
+            "Metadata": self.metadata.get(object_id, {}),
+            **(
+                {"ChecksumSHA256": self.checksums[object_id]}
+                if ChecksumMode == "ENABLED" and object_id in self.checksums
+                else {}
+            ),
+        }
+
+    def download_file(self, bucket: str, key: str, filename: str) -> None:
+        destination = Path(filename)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(self.objects[(bucket, key)])
+
+    def _write_object(self, object_id: tuple[str, str], body: bytes) -> None:
+        self.objects[object_id] = body
+        self.metadata.pop(object_id, None)
+        self.checksums.pop(object_id, None)
+        self.etags[object_id] = f'"{hashlib.sha256(body).hexdigest()[:32]}"'
+
+
+def _write_version(root: Path, ref: VersionRef) -> str:
+    d = root / "updates" / Path(ref.identity).name
+    d.mkdir(parents=True)
+    (d / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {"version": ref.version},
+                "weight_map": {"w": "model-00001.safetensors"},
+            }
+        )
+    )
+    (d / "model-00001.safetensors").write_bytes(b"weights")
+    return str(d)
+
+
+def _s3_store(tmp: Path, client: _FakeS3) -> S3Store:
+    store = S3Store("s3://bucket/experiments/run-abc", cache_dir=tmp, run_id="run-abc")
+    store._client = client
+    return store
+
+
+def test_claim_starts_run_at_boot_version() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        store = ModalVolumeStore(Path(tmp), run_id="run-abc")
+        pool = _FakePool()
+        Publisher(store, pool, run_id="run-abc").claim(boot_version=119)
+        assert store.read_pointer() == VersionRef("run-abc", 119)
+        assert pool.woke == [VersionRef("run-abc", 119)]
+
+
+def test_claim_is_rank_zero_only() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        store = ModalVolumeStore(Path(tmp), run_id="run-abc")
+        pool = _FakePool()
+        comms = _RecordingComms(rank=7)
+        Publisher(store, pool, run_id="run-abc", comms=comms).claim()
+        assert store.read_pointer() is None
+        assert pool.woke == []
+
+
+def test_publish_mounted_orders_commit_refresh_publish() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        events: list[str] = []
+        store = _RecordingVolumeStore(events, root, run_id="run-abc")
+        pool = _FakePool()
+        comms = _RecordingComms(events=events)
+        original_publish = publisher.publish_version
+
+        def record_publish(store, pool, version_dir, *, run_id):
+            events.append("publish")
+            return original_publish(store, pool, version_dir, run_id=run_id)
+
+        publisher.publish_version = record_publish
+        try:
+            vdir = _write_version(root, VersionRef("run-abc", 1))
+            Publisher(store, pool, run_id="run-abc", comms=comms).publish(vdir)
+        finally:
+            publisher.publish_version = original_publish
+
+        assert events == ["gather", "commit", "gather", "refresh", "publish", "gather"]
+        assert store.read_pointer() == VersionRef("run-abc", 1)
+        assert pool.woke == [VersionRef("run-abc", 1)]
+
+
+def test_publish_mounted_commits_once_per_mount() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        events: list[str] = []
+        store = _RecordingVolumeStore(events, root, run_id="run-abc")
+
+        def gather_with_rank_zero(value):
+            if isinstance(value, tuple) and len(value) == 4:
+                return [(True, False, None, None), value]
+            return [value]
+
+        comms = _RecordingComms(
+            events=events, rank=1, is_host_leader=False, gather=gather_with_rank_zero
+        )
+        vdir = _write_version(root, VersionRef("run-abc", 1))
+        Publisher(store, _FakePool(), run_id="run-abc", comms=comms).publish(vdir)
+
+        assert "commit" not in events
+        assert events.count("gather") == 3  # snapshot, commit errors, publish errors
+        assert store.read_pointer() is None  # only rank 0 publishes
+
+
+def test_publish_mounted_leaves_an_already_published_version_immutable() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        events: list[str] = []
+        store = _RecordingVolumeStore(events, root, run_id="run-abc")
+        store.advance_pointer(VersionRef("run-abc", 1))
+        vdir = _write_version(root, VersionRef("run-abc", 1))
+
+        Publisher(store, _FakePool(), run_id="run-abc").publish(vdir)
+
+        assert "commit" not in events
+        assert store.read_pointer() == VersionRef("run-abc", 1)
+
+
+def test_publish_rejects_a_rewind_on_every_rank() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        events: list[str] = []
+        store = _RecordingVolumeStore(events, root, run_id="run-abc")
+
+        def gather_with_rank_zero(value):
+            if isinstance(value, tuple) and len(value) == 4:
+                return [(True, False, VersionRef("run-abc", 5), None), value]
+            return [value]
+
+        comms = _RecordingComms(events=events, rank=7, gather=gather_with_rank_zero)
+        vdir = _write_version(root, VersionRef("run-abc", 3))
+
+        with pytest.raises(PointerRewind):
+            Publisher(store, _FakePool(), run_id="run-abc", comms=comms).publish(vdir)
+        assert "commit" not in events
+
+
+def test_publish_baseline_commits_a_mounted_store_without_publishing() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        events: list[str] = []
+        store = _RecordingVolumeStore(events, root, run_id="run-abc")
+        pool = _FakePool()
+        updates = root / "updates"
+        updates.mkdir()
+
+        Publisher(store, pool, run_id="run-abc").publish(str(updates))
+
+        assert events == ["commit"]  # a durability boundary, not a version
+        assert store.read_pointer() is None
+        assert pool.woke == []
+
+
+def test_publish_baseline_is_a_noop_for_an_upload_store() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        client = _FakeS3()
+        store = _s3_store(Path(tmp), client)
+        pool = _FakePool()
+        updates = Path(tmp) / "updates"
+        updates.mkdir()
+
+        Publisher(store, pool, run_id="run-abc").publish(str(updates))
+
+        assert client.objects == {}
+        assert pool.woke == []
+
+
+def test_publish_uploads_directly_to_s3() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        client = _FakeS3()
+        store = _s3_store(Path(tmp), client)
+        pool = _FakePool()
+        vdir = _write_version(Path(tmp), VersionRef("run-abc", 1))
+
+        Publisher(store, pool, run_id="run-abc").publish(vdir)
+
+        assert store.read_pointer() == VersionRef("run-abc", 1)
+        assert pool.woke == [VersionRef("run-abc", 1)]
+        assert (
+            "bucket",
+            "experiments/run-abc/updates/weight_v000001/model-00001.safetensors",
+        ) in client.objects
+
+
+def test_publish_uploaded_verifies_receipts_from_multiple_hosts() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        client = _FakeS3()
+        ref = VersionRef("run-abc", 1)
+        root = Path(tmp)
+        local_dir = root / "updates" / "weight_v000001"
+        remote_dir = root / "remote" / "weight_v000001"
+        local_dir.mkdir(parents=True)
+        remote_dir.mkdir(parents=True)
+        (local_dir / "model.safetensors.index.json").write_text(
+            json.dumps(
+                {
+                    "metadata": {"version": 1},
+                    "weight_map": {
+                        "a": "model-00001-of-00002.safetensors",
+                        "b": "model-00002-of-00002.safetensors",
+                    },
+                }
+            )
+        )
+        (local_dir / "model-00001-of-00002.safetensors").write_bytes(b"local")
+        (remote_dir / "model-00002-of-00002.safetensors").write_bytes(b"remote")
+        remote_receipt = _s3_store(root / "remote-cache", client).upload_version_files(
+            ref, remote_dir
+        )
+
+        def gather_with_remote(value):
+            if (
+                isinstance(value, tuple)
+                and len(value) == 2
+                and isinstance(value[0], UploadReceipt)
+            ):
+                return [value, (remote_receipt, None)]
+            return [value]
+
+        store = _s3_store(root, client)
+        comms = _RecordingComms(gather=gather_with_remote)
+        Publisher(store, _FakePool(), run_id="run-abc", comms=comms).publish(
+            str(local_dir)
+        )
+
+        assert store.read_pointer() == ref
+
+
+def test_publish_upload_fails_when_any_rank_errors() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        client = _FakeS3()
+        store = _s3_store(Path(tmp), client)
+
+        def gather_with_failure(value):
+            if isinstance(value, tuple) and len(value) == 2 and isinstance(
+                value[0], UploadReceipt
+            ):
+                return [value, (None, "rank 3: connection reset")]
+            return [value]
+
+        vdir = _write_version(Path(tmp), VersionRef("run-abc", 1))
+        comms = _RecordingComms(gather=gather_with_failure)
+
+        with pytest.raises(RuntimeError, match="checkpoint upload failed"):
+            Publisher(store, _FakePool(), run_id="run-abc", comms=comms).publish(vdir)
+        assert store.read_pointer() is None  # latest never points at a partial upload
+
+
+def test_pointer_snapshot_demands_exactly_one_rank_zero() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        store = ModalVolumeStore(Path(tmp), run_id="run-abc")
+
+        def gather_with_two_rank_zeros(value):
+            if isinstance(value, tuple) and len(value) == 4:
+                return [(True, False, None, None), (True, False, None, None)]
+            return [value]
+
+        vdir = _write_version(Path(tmp), VersionRef("run-abc", 1))
+        comms = _RecordingComms(gather=gather_with_two_rank_zeros)
+
+        with pytest.raises(RuntimeError, match="exactly one rank 0"):
+            Publisher(store, None, run_id="run-abc", comms=comms).publish(vdir)
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"  ok  {t.__name__}")
+    print(f"publisher harness: {len(tests)} PASS")

--- a/src/stitch/types.py
+++ b/src/stitch/types.py
@@ -14,7 +14,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-_WEIGHT_PREFIX = "weight_v"
+WEIGHT_PREFIX = "weight_v"
 
 
 @dataclass(frozen=True)
@@ -31,7 +31,7 @@ class VersionRef:
 
     @property
     def identity(self) -> str:
-        name = f"{_WEIGHT_PREFIX}{self.version:06d}"
+        name = f"{WEIGHT_PREFIX}{self.version:06d}"
         return f"{self.run_id}/{name}" if self.run_id else name
 
     @classmethod
@@ -40,9 +40,7 @@ class VersionRef:
         # raises — never fall back to base and serve the wrong weights (stitch#31).
         text = (text or "").strip()
         run_id, _, tail = text.rpartition("/")
-        digits = (
-            tail[len(_WEIGHT_PREFIX) :] if tail.startswith(_WEIGHT_PREFIX) else tail
-        )
+        digits = tail[len(WEIGHT_PREFIX) :] if tail.startswith(WEIGHT_PREFIX) else tail
         if not digits.isdigit():
             raise ValueError(f"unparseable snapshot pointer: {text!r}")
         return cls(run_id or None, int(digits))


### PR DESCRIPTION
## What

Moves the modal-agnostic distributed publication protocol out of the cookbook trainer hooks (`cookbook/common/hooks.py`) into core as `src/stitch/publisher.py`:

- **`TrainerComms`** — the rank-rendezvous port (`rank` / `all_gather_object` / `is_host_leader`) with single-process defaults; a distributed trainer subclasses it over its runtime (the cookbook shim implements it via `process.dist_*` as `_TorchComms`).
- **`Publisher`** — owns the protocol that previously lived inline in `commit_and_wake`: rank-0 pointer snapshot with cross-rank agreement, mounted-store flow (host-leader commit → rank-0 refresh + `publish_version`), S3 flow (per-host upload → gathered receipts → rank-0 verify → conditional pointer advance → wake), baseline-dir handling, immutability/rewind guards. It composes `publish.py`'s single-writer helpers rather than replacing them.
- `cookbook/common/hooks.py` is now wiring only; `commit_and_wake`/`claim_pool` signatures unchanged, so all recipe configs and app.py callsites are untouched.
- `stitch/types.py`: `_WEIGHT_PREFIX` → public `WEIGHT_PREFIX` (the protocol gates on the `weight_v` prefix).
- Tests: `publisher_test.py` (12 tests, scripted comms — replaces hooks_test's monkeypatching of `process.dist_*`: publish ordering, once-per-mount commit, rewind on every rank, immutability, S3 multi-host receipts, failed-upload gather, rank-0 uniqueness). `hooks_test.py` keeps glue coverage.

## Verification

- `pytest`: **199 passed** (run outside the agent sandbox, which blocks loopback sockets and executor-thread wakeups); `ruff check` clean. Based on main @ #147.
- Not exercised in Modal: the trainer-side publish path changed shape (same behavior, new wiring). Recommend a canary rollout/publish cycle before merging.

Independent of #149 (no file overlap); whichever lands second rebases trivially.