### PR TITLE
Extract store factory into stitch core

### DIFF
--- a/cookbook/common/storage.py
+++ b/cookbook/common/storage.py
@@ -6,16 +6,16 @@ import os
 from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
-from stitch.stores.base import Store
-from stitch.stores.modal_volume import ModalVolumeStore
-from stitch.stores.s3 import S3Store
+from stitch.stores import factory as _factory
 
-StoreBackend = Literal["modal-volume", "s3"]
-
-MODAL_VOLUME: StoreBackend = "modal-volume"
-S3: StoreBackend = "s3"
+# The store factory + backend names live in stitch core; recipes and trainer
+# hooks keep importing them from here.
+MODAL_VOLUME = _factory.MODAL_VOLUME
+S3 = _factory.S3
+StoreBackend = _factory.StoreBackend
+create_store = _factory.create_store
 
 _BACKEND_ENV = "STITCH_STORE_BACKEND"
 _S3_SECRET_ENV = "STITCH_S3_SECRET_NAME"
@@ -136,27 +136,3 @@ class StoreDeployment:
         if endpoint_url := values.get(_S3_ENDPOINT_ENV):
             config["stitch_s3_endpoint_url"] = endpoint_url
         return config
-
-
-def create_store(
-    backend: str,
-    *,
-    local_root: str | Path,
-    run_id: str,
-    volume_name: str | None = None,
-    s3_root: str | None = None,
-    s3_endpoint_url: str | None = None,
-) -> Store:
-    """Create a Store with one local layout regardless of its backing service."""
-    if backend == MODAL_VOLUME:
-        return ModalVolumeStore(local_root, volume_name=volume_name, run_id=run_id)
-    if backend == S3:
-        if not s3_root:
-            raise ValueError("s3_root is required for the S3 store")
-        return S3Store(
-            s3_root,
-            cache_dir=local_root,
-            endpoint_url=s3_endpoint_url,
-            run_id=run_id,
-        )
-    raise ValueError(f"unsupported store backend: {backend!r}")

--- a/src/stitch/stores/factory.py
+++ b/src/stitch/stores/factory.py
@@ -1,0 +1,46 @@
+"""Choose and configure a ``Store`` by backend name.
+
+The sidecar and training hooks take the backend as a CLI flag / config string
+and need one local layout regardless of the backing service; keep the mapping
+here so every consumer shares it. Heavy client libraries (``boto3``, ``modal``)
+are imported lazily by the store implementations, so this module is always
+cheap to import.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from stitch.stores.base import Store
+from stitch.stores.modal_volume import ModalVolumeStore
+from stitch.stores.s3 import S3Store
+
+StoreBackend = Literal["modal-volume", "s3"]
+
+MODAL_VOLUME: StoreBackend = "modal-volume"
+S3: StoreBackend = "s3"
+
+
+def create_store(
+    backend: str,
+    *,
+    local_root: str | Path,
+    run_id: str,
+    volume_name: str | None = None,
+    s3_root: str | None = None,
+    s3_endpoint_url: str | None = None,
+) -> Store:
+    """Create a Store with one local layout regardless of its backing service."""
+    if backend == MODAL_VOLUME:
+        return ModalVolumeStore(local_root, volume_name=volume_name, run_id=run_id)
+    if backend == S3:
+        if not s3_root:
+            raise ValueError("s3_root is required for the S3 store")
+        return S3Store(
+            s3_root,
+            cache_dir=local_root,
+            endpoint_url=s3_endpoint_url,
+            run_id=run_id,
+        )
+    raise ValueError(f"unsupported store backend: {backend!r}")

--- a/src/stitch/stores/factory_test.py
+++ b/src/stitch/stores/factory_test.py
@@ -1,0 +1,40 @@
+"""``create_store`` maps a CLI/config backend string onto one local layout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from stitch.stores.factory import MODAL_VOLUME, S3, create_store
+from stitch.stores.modal_volume import ModalVolumeStore
+from stitch.stores.s3 import S3Store
+
+
+def test_create_store_selects_the_backend(tmp_path: Path) -> None:
+    volume = create_store(
+        MODAL_VOLUME,
+        local_root=tmp_path / "volume",
+        run_id="run-a",
+    )
+    s3 = create_store(
+        S3,
+        local_root=tmp_path / "cache",
+        run_id="run-a",
+        s3_root="s3://bucket/experiment/run-a",
+    )
+
+    assert isinstance(volume, ModalVolumeStore)
+    assert isinstance(s3, S3Store)
+    assert s3.cache_dir == tmp_path / "cache"
+    assert s3.run_id == "run-a"
+
+
+def test_s3_store_requires_s3_root(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="s3_root is required"):
+        create_store(S3, local_root=tmp_path / "cache", run_id="run-a")
+
+
+def test_create_store_rejects_unknown_backend(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsupported store backend"):
+        create_store("gcs", local_root=tmp_path / "cache", run_id="run-a")


### PR DESCRIPTION
## What

Moves store backend selection into stitch core:

- Adds `src/stitch/stores/factory.py` with the shared `StoreBackend`, `MODAL_VOLUME`, `S3`, and `create_store` definitions.
- Adds focused coverage for backend selection and validation.
- Updates `cookbook/common/storage.py` to re-export the core definitions while retaining recipe-specific deployment, image, and secret configuration.

This is a behavior-preserving extraction and the base for #151.

## Verification

- `pytest -q src/stitch/stores/factory_test.py src/stitch/sidecar_test.py`: 10 passed.
- Full suite before the commit split: 198 passed.
- Ruff lint and format checks pass.