### PR TITLE
Preflight GLM-5.2 NVFP4 DFlash

### DIFF
--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -415,8 +415,7 @@ class _Miles(MilesConfig):
         "MODAL_SWE_SETUP_TIMEOUT": "240",
         "MODAL_SWE_VERIFY_TIMEOUT": "3600",
         "MODAL_SWE_INJECT_PYTEST_REPORTER": "0",
-        "MODAL_SWE_CPUS": "2",
-        "MODAL_SWE_MEMORY_MIB": "16384",
+        "MODAL_SWE_MEMORY_MIB": "2048",
         "MODAL_SWE_AGENT_PROCESSES": "48",
         "MODAL_SWE_AGENT_THREADS_PER_PROCESS": "16",
         # Bound concurrent schedule/setup operations near the requested 500-wide

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -52,7 +52,7 @@ ROLLOUT_INPUTS_PER_ENGINE = 16
 ROLLOUT_MAX_RUNNING_REQUESTS = 24
 # Bound scheduler-poll and routing skew to the headroom above the routing target.
 # Sustained excess load gets a retryable 503 instead of an unbounded engine queue.
-ROLLOUT_MAX_QUEUED_REQUESTS = ROLLOUT_MAX_RUNNING_REQUESTS - ROLLOUT_INPUTS_PER_ENGINE
+ROLLOUT_MAX_QUEUED_REQUESTS = 4
 ROLLOUT_ENGINES = 32
 ROLLOUT_CONCURRENT_SAMPLES = ROLLOUT_ENGINES * ROLLOUT_INPUTS_PER_ENGINE
 MAX_SEQ_LEN = 65_536
@@ -101,19 +101,19 @@ SIDECAR_COMMIT_MODE = "in_place"
 SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 SGLANG_DELTA_UPDATE_MODE = "cpu"
 
-# DFLASH_SERVER_ARGS = {
-#     "--speculative-algorithm": "DFLASH",
-#     "--speculative-attention-mode": "decode",
-#     "--speculative-dflash-block-size": "8",
-#     "--speculative-num-draft-tokens": "8",
-#     "--speculative-num-steps": "1",
-#     "--speculative-eagle-topk": "1",
-#     "--speculative-draft-attention-backend": "flashinfer",
-#     "--speculative-draft-load-format": "fastsafetensors",
-#     "--speculative-draft-model-path": str(DFLASH_CHECKPOINT_PATH),
-#     "--speculative-draft-model-quantization": "unquant",
-#     "--speculative-draft-window-size": "4096",
-# }
+DFLASH_SERVER_ARGS = {
+    "--speculative-algorithm": "DFLASH",
+    "--speculative-attention-mode": "decode",
+    "--speculative-dflash-block-size": "8",
+    "--speculative-num-draft-tokens": "8",
+    "--speculative-num-steps": "1",
+    "--speculative-eagle-topk": "1",
+    "--speculative-draft-attention-backend": "flashinfer",
+    "--speculative-draft-load-format": "fastsafetensors",
+    "--speculative-draft-model-path": str(DFLASH_CHECKPOINT_PATH),
+    "--speculative-draft-model-quantization": "unquant",
+    "--speculative-draft-window-size": "4096",
+}
 
 SGLANG_SERVER_ARGS = {
     # loading / elastic refit
@@ -136,12 +136,10 @@ SGLANG_SERVER_ARGS = {
     "--dsa-decode-backend": "flashmla_kv",
     "--dsa-topk-backend": "flashinfer",
     "--page-size": "64",
-    # One attention-DP and expert-parallel rank per GPU; dense MoE paths remain TP1.
-    "--enable-dp-attention": "",
-    "--dp-size": str(ROLLOUT_GPUS_PER_ENGINE),
+    # The endpoint supplies TP4. DFlash does not support DP attention, so only
+    # expert parallelism is explicit here; dense MoE paths remain TP1.
     "--ep-size": str(ROLLOUT_GPUS_PER_ENGINE),
     "--moe-dense-tp-size": "1",
-    "--enable-dp-lm-head": "",
     # MoE
     "--moe-runner-backend": "flashinfer_trtllm_routed",
     "--disable-shared-experts-fusion": "",
@@ -153,10 +151,10 @@ SGLANG_SERVER_ARGS = {
     "--schedule-conservativeness": "1.0",
     "--schedule-policy": "lpm",
     "--cuda-graph-config": (
-        '{"decode":{"backend":"full","max_bs":32,'
-        '"bs":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32]}}'
+        '{"decode":{"backend":"full","max_bs":24,'
+        '"bs":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24]}}'
     ),
-    # **DFLASH_SERVER_ARGS,
+    **DFLASH_SERVER_ARGS,
     # RL
     "--enable-return-routed-experts": "",
 }
@@ -174,7 +172,7 @@ modal = ModalConfig(
     rollout_max_containers=None,
     rollout_target_inputs=ROLLOUT_INPUTS_PER_ENGINE,
     draft_volume=DFLASH_VOLUME,
-    routing_region="us-west",
+    routing_region="us-east",
     # CPU updates use ephemeral disk only for runtime scratch and spill.
     rollout_ephemeral_disk_mib=524_288,
     trainer_ephemeral_disk_mib=2_097_152,
@@ -215,6 +213,7 @@ class _Miles(MilesConfig):
     # A saturated engine's 503 retry holds its slot, feeding backpressure into
     # session generation instead of admitting another trajectory.
     sglang_server_concurrency = ROLLOUT_CONCURRENT_SAMPLES
+    sglang_speculative_algorithm = "DFLASH"
     rollout_endpoint_url = None
 
     custom_rollout_request_hook_path = (

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -306,6 +306,7 @@ class _Miles(MilesConfig):
     global_batch_size = 256
     rollout_temperature = 1.0
     rollout_top_p = 0.95
+    rollout_top_k = 4096
     rollout_max_response_len = 8192
     max_seq_len = MAX_SEQ_LEN
     use_dynamic_global_batch_size = True

--- a/tools/probes/README.md
+++ b/tools/probes/README.md
@@ -54,3 +54,14 @@ uv run --extra modal modal run -e stitch-dev -m tools.probes.sidecar_config
 ```
 
 Prints one machine-readable ``PROBE_RESULT ok=... detail=...`` line.
+
+## GLM-5.2 image preflight (CPU-only)
+
+This builds the exact pinned trainer and serving images, then validates model
+arguments and the DFlash contract without reserving GPUs:
+
+```bash
+modal run -e stitch-dev tools/probes/glm5_2_nvfp4_dflash_preflight.py
+```
+
+The command finishes with one machine-readable ``VERDICT ... PASS`` line.

--- a/tools/probes/glm5_2_nvfp4_dflash_preflight.py
+++ b/tools/probes/glm5_2_nvfp4_dflash_preflight.py
@@ -1,0 +1,137 @@
+"""CPU-only Modal preflight for the GLM-5.2 NVFP4 DFlash experiment.
+
+Run before any GPU launch:
+
+    modal run -e stitch-dev tools/probes/glm5_2_nvfp4_dflash_preflight.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+from pathlib import Path
+
+import modal
+
+from cookbook.common.constants import HF_CACHE_PATH
+from cookbook.common.serving_image import DEFAULT_SGLANG_RUNTIME, build_serving_image
+from cookbook.miles_disagg import trainer_image
+from cookbook.miles_disagg.configs import glm5_2_nvfp4 as model
+
+APP_NAME = "probe-glm5-2-nvfp4-dflash-preflight"
+EXPERIMENT = "glm5_2_nvfp4"
+
+app = modal.App(APP_NAME)
+trainer_preflight_image = trainer_image.build_trainer_image(
+    hf_cache_path=str(HF_CACHE_PATH),
+    experiment=EXPERIMENT,
+    extra_pip_packages=model.TRAINER_EXTRA_PIP_PACKAGES,
+    image_run_commands=model.TRAINER_IMAGE_RUN_COMMANDS,
+)
+serving_preflight_image = build_serving_image(
+    hf_cache_path=str(HF_CACHE_PATH),
+    experiment=EXPERIMENT,
+    extra_env=model.SGLANG_SERVER_ENV,
+)
+
+
+@app.function(image=trainer_preflight_image, cpu=2, memory=8192, timeout=15 * 60)
+def validate_trainer_contract() -> dict:
+    from miles.utils.external_utils.model_args_utils import load_model_args
+
+    model_args = shlex.split(load_model_args(model.miles.megatron_model_type))
+    expected_prefix = [
+        "--spec",
+        "miles_plugins.models.glm5.glm5",
+        "get_glm5_spec",
+    ]
+    if model_args[:3] != expected_prefix:
+        raise RuntimeError(
+            f"pinned GLM-5.2 model arguments are incorrect: {model_args[:3]}"
+        )
+
+    validation_source = Path("/root/miles/miles/utils/arguments.py").read_text()
+    if 'speculative_algorithm.upper() != "DFLASH"' not in validation_source:
+        raise RuntimeError("Miles does not permit aligned DFlash top-p mask replay")
+
+    sparse_mla_root = Path("/root/miles/miles_plugins/models/glm5/ops")
+    forward_source = (sparse_mla_root / "tilelang_sparse_mla_fwd.py").read_text()
+    backward_source = (sparse_mla_root / "tilelang_sparse_mla_bwd.py").read_text()
+    for direction, source in (
+        ("forward", forward_source),
+        ("backward", backward_source),
+    ):
+        if "kv_i" not in source or "T.if_then_else(mask" not in source:
+            raise RuntimeError(
+                f"Miles GLM sparse-MLA {direction} kernel lacks padded-index handling"
+            )
+
+    result = {
+        "status": "PASS",
+        "miles_commit": trainer_image.MILES_REPO_REF,
+        "model_script_argument_count": len(model_args),
+        "model_script_source": "pinned_checkout",
+        "dflash_top_p_validation": "enabled",
+        "sparse_mla_padded_indices": "guarded",
+    }
+    print(
+        f"VERDICT glm52_trainer_preflight PASS {json.dumps(result, sort_keys=True)}",
+        flush=True,
+    )
+    return result
+
+
+@app.function(image=serving_preflight_image, cpu=2, memory=8192, timeout=15 * 60)
+def validate_server_contract() -> dict:
+    from sglang.srt.arg_groups.speculative_hook import _handle_dflash
+    from sglang.srt.server_args import ServerArgs
+
+    argv = ["--model-path", "dummy"]
+    for flag, value in model.SGLANG_SERVER_ARGS.items():
+        argv.append(flag)
+        if value:
+            argv.append(value)
+
+    parser = argparse.ArgumentParser(prog="glm52-preflight")
+    ServerArgs.add_cli_args(parser)
+    parsed = parser.parse_args(argv)
+    parsed.device = "cuda"
+    _handle_dflash(parsed)
+
+    expected = {
+        "speculative_algorithm": "DFLASH",
+        "enable_dp_attention": False,
+        "ep_size": model.ROLLOUT_GPUS_PER_ENGINE,
+        "max_running_requests": model.ROLLOUT_MAX_RUNNING_REQUESTS,
+        "max_queued_requests": model.ROLLOUT_MAX_QUEUED_REQUESTS,
+    }
+    actual = {name: getattr(parsed, name) for name in expected}
+    if actual != expected:
+        raise RuntimeError(f"parsed SGLang arguments differ: {actual} != {expected}")
+
+    result = {
+        "status": "PASS",
+        "sglang_commit": DEFAULT_SGLANG_RUNTIME.commit,
+        **actual,
+    }
+    print(
+        f"VERDICT glm52_server_preflight PASS {json.dumps(result, sort_keys=True)}",
+        flush=True,
+    )
+    return result
+
+
+@app.local_entrypoint()
+def main() -> None:
+    trainer_result = validate_trainer_contract.remote()
+    server_result = validate_server_contract.remote()
+    result = {
+        "status": "PASS",
+        "trainer": trainer_result,
+        "server": server_result,
+    }
+    print(
+        f"VERDICT glm52_cpu_preflight PASS {json.dumps(result, sort_keys=True)}",
+        flush=True,
+    )


### PR DESCRIPTION
## Summary

- configure the GLM-5.2 NVFP4 rollout recipe for DFlash with expert parallelism and no DP attention
- align its current Miles sampling, queue, CUDA graph, and fully-async settings
- add a CPU-only preflight that validates the trainer and SGLang argument contracts before allocating GPUs
- document how to run that preflight

The independent rollout-recovery work was moved to a separate PR.

## Validation

- `uv run ruff check cookbook/miles_disagg/configs/glm5_2_nvfp4.py tools/probes/glm5_2_nvfp4_dflash_preflight.py`
- `uv run pytest` (223 passed)
- the CPU preflight previously passed both trainer and server contracts