### PR TITLE
Harden sidecar configuration invariants

### DIFF
--- a/src/stitch/publisher.py
+++ b/src/stitch/publisher.py
@@ -183,9 +183,7 @@ class Publisher:
         results = self._comms.all_gather_object((receipt, upload_error))
         upload_errors = [error for _, error in results if error is not None]
         if upload_errors:
-            raise RuntimeError(
-                "checkpoint upload failed:\n" + "\n".join(upload_errors)
-            )
+            raise RuntimeError("checkpoint upload failed:\n" + "\n".join(upload_errors))
         receipts = [receipt for receipt, _ in results if receipt is not None]
         if not receipts:
             raise RuntimeError("checkpoint upload produced no host receipts")

--- a/src/stitch/publisher_test.py
+++ b/src/stitch/publisher_test.py
@@ -380,8 +380,10 @@ def test_publish_upload_fails_when_any_rank_errors() -> None:
         store = _s3_store(Path(tmp), client)
 
         def gather_with_failure(value):
-            if isinstance(value, tuple) and len(value) == 2 and isinstance(
-                value[0], UploadReceipt
+            if (
+                isinstance(value, tuple)
+                and len(value) == 2
+                and isinstance(value[0], UploadReceipt)
             ):
                 return [value, (None, "rank 3: connection reset")]
             return [value]

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -321,7 +321,10 @@ def serve(
         TerminalFailureMonitor(reconciler.wait_for_terminal_error),
     )
     config = uvicorn.Config(
-        create_app(reconciler.gate, reconciler, engine), host=host, port=port, log_level="info"
+        create_app(reconciler.gate, reconciler, engine),
+        host=host,
+        port=port,
+        log_level="info",
     )
     asyncio.run(run_server_with_watchdog(uvicorn.Server(config), watchdog))
 

--- a/src/stitch/sidecar.py
+++ b/src/stitch/sidecar.py
@@ -40,7 +40,7 @@ class SidecarConfig:
     bulletin_root: str
     base_checkpoint_dir: str
     local_checkpoint_dir: str | None = None
-    delta_update_mode: DeltaUpdateMode = "cpu"
+    delta_update_mode: DeltaUpdateMode
     disk_load_format: str = "auto"
     store_backend: StoreBackend = MODAL_VOLUME
     volume_name: str | None = None
@@ -60,6 +60,8 @@ class SidecarConfig:
             raise ValueError("run_id is required")
         if self.boot_version < 0:
             raise ValueError("boot_version must be non-negative")
+        if self.delta_update_mode == "disk" and not self.local_checkpoint_dir:
+            raise ValueError("local_checkpoint_dir is required in disk mode")
 
     def to_argv(self) -> list[str]:
         """Render as CLI flags. ``from_argv(self.to_argv()) == self``, including

--- a/src/stitch/sidecar_test.py
+++ b/src/stitch/sidecar_test.py
@@ -18,15 +18,22 @@ _BASE = dict(
 
 def test_sidecar_config_requires_run_id() -> None:
     with pytest.raises(ValueError, match="run_id is required"):
-        SidecarConfig(**{**_BASE, "run_id": ""})
+        SidecarConfig(**{**_BASE, "run_id": ""}, delta_update_mode="cpu")
 
 
 def test_sidecar_config_requires_nonnegative_boot_version() -> None:
     with pytest.raises(ValueError, match="boot_version must be non-negative"):
-        SidecarConfig(**_BASE, boot_version=-1)
+        SidecarConfig(**_BASE, delta_update_mode="cpu", boot_version=-1)
 
 
-_MINIMAL = SidecarConfig(**_BASE)
+def test_sidecar_config_requires_local_checkpoint_dir_in_disk_mode() -> None:
+    with pytest.raises(
+        ValueError, match="local_checkpoint_dir is required in disk mode"
+    ):
+        SidecarConfig(**_BASE, delta_update_mode="disk")
+
+
+_MINIMAL = SidecarConfig(**_BASE, delta_update_mode="cpu")
 
 _FULL = SidecarConfig(
     **_BASE,


### PR DESCRIPTION
## Summary

- require callers to choose `cpu` or `disk` weight-update mode explicitly
- reject disk-mode `SidecarConfig` values without a local checkpoint directory at construction time
- add direct configuration-invariant coverage
- apply the repository formatter to the files introduced or changed by the recent core extractions

## Why

CPU caching is a material host-RAM policy and should not be selected implicitly by a reusable core configuration object. Likewise, `SidecarConfig` should not represent a disk-mode configuration that the CLI later rejects.

## Validation

- `uv run --frozen pytest -q` — 210 passed
- `uv run --frozen ruff check src cookbook tools/probes/sidecar_config.py`
- `uv run --frozen ruff format --check src cookbook tools/probes/sidecar_config.py`
- `git diff --check`