### PR TITLE
Reuse SGLang CPU loader views across weight updates

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -110,7 +110,8 @@ CPU mode keeps rank-ready images in RAM for the shortest commit:
 
 1. After the boot checkpoint begins serving, SGLang allocates one complete
    rank-ready image per local TP rank and either caches one canonical checkpoint
-   per host in RAM or materializes it on host-local storage.
+   per host in RAM or materializes it on host-local storage. It also builds the
+   model's native loader views once against each rank image.
 2. When the base is the boot checkpoint, it captures the already-realized active
    runtime storages into the rank images instead of repeating a model-sized
    load. A different base goes through the model's ordinary loader and
@@ -159,10 +160,11 @@ pause. Set `--weight-loader-drop-cache-after-load` to release clean checkpoint
 pages after every local TP rank finishes compiling; otherwise the kernel may
 retain those reclaimable pages for later reads.
 
-The group bound limits transient loader work; it does not tune correctness or
-assume a model architecture. An indivisible module larger than the requested
-bound remains intact and is reported. Each staging clone is reclaimed at its
-group boundary, so CUDA-required post-load transforms cannot accumulate a
+The group bound limits CUDA staging work; it does not tune correctness or assume
+a model architecture. An indivisible module larger than the requested bound
+remains intact and is reported. Loader views and their checkpoint-layout state
+remain in RAM so each update can reuse the native loader graph. Temporary GPU
+staging clones are reclaimed at their group boundary and cannot accumulate a
 second model-sized device copy.
 
 With the default in-memory canonical checkpoint, persistent host RAM is:
@@ -170,6 +172,7 @@ With the default in-memory canonical checkpoint, persistent host RAM is:
 ```text
 one canonical checkpoint per host
 + one rank-local runtime image per local TP rank
++ native-loader state per local TP rank
 ```
 
 The canonical checkpoint is interleaved across the host's allowed NUMA nodes so
@@ -178,17 +181,17 @@ images remain GPU-local because they are the source of the latency-sensitive
 CPU-to-GPU commit.
 
 With a storage-backed canonical checkpoint, persistent host RAM is the rank
-images; local storage holds one canonical checkpoint. File-cache pages used
-during preparation are reclaimable.
+images and native-loader state; local storage holds one canonical checkpoint.
+File-cache pages used during preparation are reclaimable.
 
 Measured component sizes are:
 
-| Model | TP | Canonical checkpoint per host | Rank image |
-| --- | ---: | ---: | ---: |
-| GLM-4.5-Air FP8 | 4 | 112.6 GB | 27.2 GB × 4 |
-| Kimi K2.6 NVFP4 | 4 | about 595 GB | about 151 GB × 4 |
-| GLM-5.2 mixed NVFP4/BF16 | 4 | 617.6 GB | 179.3 GB × 4 |
-| Kimi K3 MXFP4 | 8 | 1.561 TB | 207.5 GB × 8 |
+| Model | TP | Canonical checkpoint per host | Rank image | Loader state per rank |
+| --- | ---: | ---: | ---: | ---: |
+| GLM-4.5-Air FP8 | 4 | 112.6 GB | 27.2 GB × 4 | 1.64 GB |
+| Kimi K2.6 NVFP4 | 4 | about 595 GB | about 151 GB × 4 | 4.09 GB |
+| GLM-5.2 mixed NVFP4/BF16 | 4 | 617.6 GB | 179.3 GB × 4 | 20.94 GB |
+| Kimi K3 MXFP4 | 8 | 1.561 TB | 207.5 GB × 8 | 0.14 GB maximum |
 
 Allow additional memory for the engine process, delta decoding, and bounded
 loader staging. The supplied GLM-4.5 recipe requests `(512 GiB, 2 TiB)`;

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -30,7 +30,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.17",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.17",
-    commit="bc992874b335d0b6e314f9e883d9f55df185740d",
+    commit="6843e87bc627a40e0194081e2d8fa99137b5db50",
 )
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -164,6 +164,8 @@ SGLANG_SERVER_ARGS = {
 modal = ModalConfig(
     gpu="B300",
     rollout_gpu="B300",
+    # CPU-cache preparation is host-memory-bandwidth sensitive. For repeatable
+    # latency, profile a B300 pool and pin its cloud and concrete region.
     region="us",
     trainer_memory_mib=(1024 * 1024, 3 * 1024 * 1024),
     # CPU mode retains the canonical checkpoint and TP rank images in memory.

--- a/tools/profiling/_delta_weight_update.py
+++ b/tools/profiling/_delta_weight_update.py
@@ -443,6 +443,48 @@ def _cgroup_cpu_usage_s() -> float | None:
     return None
 
 
+def _cgroup_io_snapshot() -> dict[str, int] | None:
+    path = Path("/sys/fs/cgroup/io.stat")
+    if not path.is_file():
+        return None
+    result: dict[str, int] = {}
+    for line in path.read_text().splitlines():
+        for field in line.split()[1:]:
+            key, separator, value = field.partition("=")
+            if separator:
+                result[key] = result.get(key, 0) + int(value)
+    return result
+
+
+def _io_usage_delta(
+    before: dict[str, int] | None,
+    after: dict[str, int] | None,
+) -> dict[str, int] | None:
+    if before is None or after is None:
+        return None
+    return {
+        key: max(0, after.get(key, 0) - before.get(key, 0))
+        for key in sorted(before.keys() | after.keys())
+    }
+
+
+def _host_snapshot() -> dict[str, Any]:
+    cpuinfo = Path("/proc/cpuinfo").read_text()
+    model_name = next(
+        (
+            line.partition(":")[2].strip()
+            for line in cpuinfo.splitlines()
+            if line.startswith("model name")
+        ),
+        "unknown",
+    )
+    return {
+        "cpu_model": model_name,
+        "allowed_cpus": len(os.sched_getaffinity(0)),
+        "memory": _memory_snapshot(),
+    }
+
+
 def _cpu_usage_delta(
     before: float | None,
     after: float | None,
@@ -564,6 +606,7 @@ def run_delta_weight_update(
         "sample_id": sample_id,
         "tp_size": spec.tp_size,
         "hicache": "disabled",
+        "host": _host_snapshot(),
     }
 
     shutil.rmtree(spec.local_target_checkpoint_dir, ignore_errors=True)
@@ -625,6 +668,7 @@ def run_delta_weight_update(
         with httpx.Client(timeout=None, trust_env=False) as client:
             destination_init_started = time.perf_counter()
             destination_init_cpu_started = _cgroup_cpu_usage_s()
+            destination_init_io_started = _cgroup_io_snapshot()
             generation = _GenerationProbe(url)
             memory = _MemoryProbe()
             try:
@@ -656,6 +700,10 @@ def run_delta_weight_update(
                 _cgroup_cpu_usage_s(),
                 results["destination_init_s"],
             )
+            results["destination_init_io"] = _io_usage_delta(
+                destination_init_io_started,
+                _cgroup_io_snapshot(),
+            )
             results["destination_init_rank_stats"] = initialized.get("rank_stats")
             results["memory_after_destination_init"] = _memory_snapshot()
             if generation.errors or not generation.samples:
@@ -677,6 +725,7 @@ def run_delta_weight_update(
 
             stage_started = time.perf_counter()
             stage_cpu_started = _cgroup_cpu_usage_s()
+            stage_io_started = _cgroup_io_snapshot()
             with _GenerationProbe(url) as generation:
                 stage_payload = {
                     "base_checkpoint_dir": spec.base_checkpoint_dir,
@@ -700,6 +749,10 @@ def run_delta_weight_update(
                 _cgroup_cpu_usage_s(),
                 results["stage_s"],
             )
+            results["stage_io"] = _io_usage_delta(
+                stage_io_started,
+                _cgroup_io_snapshot(),
+            )
             results["stage_rank_stats"] = staged.get("rank_stats")
             results["generation_during_stage"] = generation.summary()
             results["memory_after_stage"] = _memory_snapshot()
@@ -717,6 +770,7 @@ def run_delta_weight_update(
 
             commit_started = time.perf_counter()
             commit_cpu_started = _cgroup_cpu_usage_s()
+            commit_io_started = _cgroup_io_snapshot()
             if update_mode == "cpu":
                 commit_path = "/update_weights_from_cpu"
                 commit_payload = {
@@ -745,6 +799,10 @@ def run_delta_weight_update(
                 commit_cpu_started,
                 _cgroup_cpu_usage_s(),
                 results["commit_rpc_s"],
+            )
+            results["commit_io"] = _io_usage_delta(
+                commit_io_started,
+                _cgroup_io_snapshot(),
             )
             results["commit_rank_stats"] = committed.get("rank_stats")
             results["stage_through_commit_s"] = round(


### PR DESCRIPTION
## Summary

- build each bounded native-loader view graph once during asynchronous CPU destination initialization and reuse it across updates
- retain and report the loader-only checkpoint-layout state required by those views
- capture host and cgroup I/O context in the profiler and refresh the GLM-5.2 measurements

## Physics

The model hierarchy, checkpoint-name mapping, rank-image offsets, and native loading callbacks are invariant for a checkpoint lineage. Rebuilding that object/view graph for every target moved no necessary weight data. The new path prepares it once, then every update still:

1. validates the complete delta lineage;
2. reconstructs and checksums the complete canonical target;
3. restores checkpoint-facing quantization state;
4. runs the complete native loader and post-load transforms; and
5. rebuilds and commits every runtime storage.

The speedup therefore removes repeated control/layout construction, not correctness work or tensor-level-sparsity assumptions. GLM-5.2 retains 20.94 GB of loader state per TP rank; the memory contract now documents measured values for all validated formats.

## Measurements

GLM-5.2 CPU/RAM passed on two different 115-CPU hosts:

| Host | Preparation | Engine pause | Total |
| --- | ---: | ---: | ---: |
| AMD EPYC 9575F | 41.72 s | 3.15 s | 44.87 s |
| Intel Xeon 6776P | 108.62 s | 3.70 s | 112.33 s |

The same CPU/NVMe path passed at 177.09 s preparation and 3.28 s pause. The host spread is explained by delta/index preflight, full canonical transformation, and native compilation throughput; loader-view reuse itself was 0.02 s during recurring GLM-5.2 stages.

## Validation

- SGLang: 36 focused weight-sync tests and the full changed-file pre-commit suite
- Stitch: all 210 tests; Ruff and format checks on changed Python files
- exact checksum and generation correctness before, during, and after updates:
  - GLM-4.5-Air FP8, CPU/RAM
  - Kimi K2.6 NVFP4, CPU/RAM
  - GLM-5.2 mixed NVFP4/BF16, CPU/RAM twice and CPU/NVMe
  - Kimi K3 MXFP4, CPU/NVMe
- every live run changed from base and reproduced identical post-update text, token IDs, and logprobs