### PR TITLE
Delay engine watchdog until startup is monitorable

### DIFF
--- a/cookbook/common/process.py
+++ b/cookbook/common/process.py
@@ -4,6 +4,7 @@ sglang, wait on HTTP liveness, terminate cleanly, monitor host RAM, apply git pa
 
 from __future__ import annotations
 
+import json
 import os
 import signal
 import socket
@@ -94,6 +95,45 @@ def wait_http(url: str, process: subprocess.Popen | None, timeout: int) -> None:
             last_error = f"{type(exc).__name__}: {exc}"
         time.sleep(2)
     raise TimeoutError(f"timed out waiting for {url}; last error: {last_error}")
+
+
+def wait_sidecar_ready(
+    url: str, process: subprocess.Popen | None, timeout: int
+) -> None:
+    """Wait for catch-up and update-destination setup before admitting traffic."""
+    deadline = time.monotonic() + timeout
+    last_status: dict[str, Any] | None = None
+    last_error: str | None = None
+    while time.monotonic() < deadline:
+        if process is not None and process.poll() is not None:
+            raise RuntimeError(
+                f"process exited while waiting for {url}: code={process.returncode}"
+            )
+        try:
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                status = json.load(resp)
+            if not isinstance(status, dict):
+                raise ValueError(f"expected JSON object, got {type(status).__name__}")
+            last_status = status
+            terminal_error = status.get("terminal_error")
+            destination_error = status.get("update_destination_error")
+            if terminal_error:
+                raise RuntimeError(f"sidecar startup failed: {terminal_error}")
+            if destination_error:
+                raise RuntimeError(
+                    "weight update destination initialization failed: "
+                    f"{destination_error}"
+                )
+            if status.get("ready") and status.get("update_destination_ready"):
+                return
+            last_error = None
+        except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+        time.sleep(2)
+    raise TimeoutError(
+        f"timed out waiting for {url}; last status: {last_status}; "
+        f"last error: {last_error}"
+    )
 
 
 def terminate_process(process: subprocess.Popen | None) -> None:

--- a/cookbook/common/process_test.py
+++ b/cookbook/common/process_test.py
@@ -1,8 +1,29 @@
 from __future__ import annotations
 
+import io
+import json
+
+import pytest
+
 from cookbook.common import process, storage
 from stitch.sidecar import SidecarConfig, _load_store_factory
 from stitch.stores.s3 import S3Store
+
+
+class _JsonResponse:
+    status = 200
+
+    def __init__(self, payload: dict) -> None:
+        self._body = io.BytesIO(json.dumps(payload).encode())
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args) -> None:
+        self._body.close()
+
+    def read(self, *args, **kwargs) -> bytes:
+        return self._body.read(*args, **kwargs)
 
 
 def test_start_sidecar_passes_s3_store_settings(monkeypatch) -> None:
@@ -54,3 +75,43 @@ def test_start_sidecar_passes_s3_store_settings(monkeypatch) -> None:
     )
     assert isinstance(store, S3Store)
     assert store.run_id == "run-a"
+
+
+def test_wait_sidecar_ready_waits_for_catchup_and_destination(monkeypatch) -> None:
+    statuses = iter(
+        [
+            {"ready": False, "update_destination_ready": False},
+            {"ready": True, "update_destination_ready": False},
+            {"ready": True, "update_destination_ready": True},
+        ]
+    )
+    calls = 0
+
+    def urlopen(_url: str, timeout: int) -> _JsonResponse:
+        nonlocal calls
+        assert timeout == 5
+        calls += 1
+        return _JsonResponse(next(statuses))
+
+    monkeypatch.setattr(process.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(process.time, "sleep", lambda _seconds: None)
+
+    process.wait_sidecar_ready("http://sidecar/server_info", None, timeout=10)
+
+    assert calls == 3
+
+
+def test_wait_sidecar_ready_surfaces_destination_failure(monkeypatch) -> None:
+    def urlopen(_url: str, timeout: int) -> _JsonResponse:
+        return _JsonResponse(
+            {
+                "ready": True,
+                "update_destination_ready": False,
+                "update_destination_error": "layout failed",
+            }
+        )
+
+    monkeypatch.setattr(process.urllib.request, "urlopen", urlopen)
+
+    with pytest.raises(RuntimeError, match="layout failed"):
+        process.wait_sidecar_ready("http://sidecar/server_info", None, timeout=10)

--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -37,9 +37,12 @@ def serve_startup(
     flush_cache_on_commit: bool = False,
     startup_timeout: int,
 ) -> None:
-    """Start sglang + the versioned-proxy sidecar on a Server replica (from ``@modal.enter``).
-    SGLang starts directly from the immutable boot checkpoint. The sidecar initializes the
-    selected update destination in the background after serving is available."""
+    """Start sglang + the sidecar and cross Modal's admission boundary when ready.
+
+    SGLang starts directly from the immutable boot checkpoint. The sidecar prepares
+    its update destination in the background, but ``@modal.enter`` does not return
+    until both that setup and the first catch-up have finished.
+    """
     from autoinference_utils.endpoint import (
         SGLangEndpoint,
         start_heartbeat_thread,
@@ -97,12 +100,13 @@ def serve_startup(
         commit_mode=commit_mode,
         flush_cache_on_commit=flush_cache_on_commit,
     )
-    # Modal admits the container to Flash routing when @enter returns and never re-polls /health, so
-    # blocking here on /health (503 until the reconciler's first catch-up) is the only thing that keeps a
-    # not-yet-synced replica out of rotation. Fresh boot (no pointer) clears at once; a mid-run joiner
-    # waits until it has applied the live version, bounded by startup_timeout.
-    process.wait_http(
-        f"http://127.0.0.1:{SIDECAR_PORT}/health", replica.sidecar, startup_timeout
+    # Modal admits the container when @enter returns. /health describes sidecar
+    # catch-up only, so use the richer status surface to also keep startup-only
+    # engine preparation outside the traffic-serving lifetime.
+    process.wait_sidecar_ready(
+        f"http://127.0.0.1:{SIDECAR_PORT}/server_info",
+        replica.sidecar,
+        startup_timeout,
     )
 
     def engine_health() -> str | None:

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -315,6 +315,7 @@ def serve(
         EngineWatchdog(
             engine,
             engine_health_may_be_stale=reconciler.engine_health_may_be_stale,
+            wait_until_monitorable=reconciler.wait_for_destination_initialization,
             interval=watchdog_interval,
             failure_threshold=watchdog_failure_threshold,
         ),

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -225,6 +225,7 @@ class Reconciler:
         self._task: asyncio.Task[None] | None = None
         self._wake_pending = False
         self._destination_init_task: asyncio.Task[None] | None = None
+        self._destination_initialization_finished = asyncio.Event()
         self._destination_ready = False
         self._destination_init_error: str | None = None
         self._periodic_task: asyncio.Task[None] | None = None
@@ -276,6 +277,8 @@ class Reconciler:
         except Exception as exc:  # noqa: BLE001
             self._destination_init_error = str(exc)
             logger.exception("weight update destination initialization failed")
+        finally:
+            self._destination_initialization_finished.set()
 
     def server_info(self) -> dict[str, Any]:
         # applied = version on the GPU (the pool reads it to see which version each replica has);
@@ -313,6 +316,10 @@ class Reconciler:
     def engine_health_may_be_stale(self) -> bool:
         """Whether the engine is paused while staged weights are applied."""
         return self.sync_state is SyncState.COMMITTING
+
+    async def wait_for_destination_initialization(self) -> None:
+        """Wait until startup has finished preparing the update destination."""
+        await self._destination_initialization_finished.wait()
 
     async def wait_for_terminal_error(self) -> None:
         """Raise once reconciliation proves this replica must be replaced."""

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -165,6 +165,49 @@ def test_startup_initializes_update_destination() -> None:
     _run(go())
 
 
+def test_destination_initialization_completion_is_exposed_to_monitors() -> None:
+    async def go() -> None:
+        engine = FakeEngine()
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_initialize(boot_version: int = 0) -> None:
+            started.set()
+            await release.wait()
+
+        engine.initialize_update_destination = slow_initialize  # type: ignore[method-assign]
+        r = _make_reconciler(store=FakeStore(), engine=engine, reconcile_interval=0.0)
+        startup = asyncio.create_task(r.startup())
+        await started.wait()
+        waiting = asyncio.create_task(r.wait_for_destination_initialization())
+        await asyncio.sleep(0)
+        assert not waiting.done()
+
+        release.set()
+        await waiting
+        await startup
+        await r.shutdown()
+
+    _run(go())
+
+
+def test_destination_initialization_failure_releases_monitors() -> None:
+    async def go() -> None:
+        engine = FakeEngine()
+
+        async def fail_initialize(boot_version: int = 0) -> None:
+            raise RuntimeError("broken destination")
+
+        engine.initialize_update_destination = fail_initialize  # type: ignore[method-assign]
+        r = _make_reconciler(store=FakeStore(), engine=engine, reconcile_interval=0.0)
+        await r.startup()
+        await asyncio.wait_for(r.wait_for_destination_initialization(), timeout=1.0)
+        assert r.server_info()["update_destination_error"] == "broken destination"
+        await r.shutdown()
+
+    _run(go())
+
+
 @pytest.mark.parametrize(
     "sync_state,expected",
     [

--- a/src/stitch/watchdog.py
+++ b/src/stitch/watchdog.py
@@ -79,6 +79,7 @@ class EngineWatchdog:
         engine: Engine,
         *,
         engine_health_may_be_stale: Callable[[], bool],
+        wait_until_monitorable: Callable[[], Awaitable[None]] | None = None,
         interval: float = 5.0,
         failure_threshold: int = 3,
     ) -> None:
@@ -88,12 +89,17 @@ class EngineWatchdog:
             raise ValueError("watchdog failure threshold must be positive")
         self._engine = engine
         self._engine_health_may_be_stale = engine_health_may_be_stale
+        self._wait_until_monitorable = wait_until_monitorable
         self._interval = interval
         self._failure_threshold = failure_threshold
         self._consecutive_failures = 0
 
     async def run(self) -> None:
         """Run until cancelled or the engine is conclusively unrecoverable."""
+        if self._wait_until_monitorable is not None:
+            logger.info("engine watchdog waiting for startup initialization")
+            await self._wait_until_monitorable()
+        logger.info("engine watchdog started")
         while True:
             health = await self._engine.check_health()
             if health.status is EngineHealthStatus.HEALTHY:

--- a/src/stitch/watchdog_test.py
+++ b/src/stitch/watchdog_test.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 import pytest
 
@@ -21,8 +21,10 @@ class _HealthSequence:
     def __init__(self, *statuses: EngineHealthStatus) -> None:
         self._statuses = iter(statuses)
         self.checked = asyncio.Event()
+        self.check_count = 0
 
     async def check_health(self) -> EngineHealth:
+        self.check_count += 1
         try:
             status = next(self._statuses)
         except StopIteration:
@@ -48,14 +50,41 @@ def _watchdog(
     engine: _HealthSequence,
     *,
     engine_health_may_be_stale: Callable[[], bool] = lambda: False,
+    wait_until_monitorable: Callable[[], Awaitable[None]] | None = None,
     failure_threshold: int = 2,
 ) -> EngineWatchdog:
     return EngineWatchdog(
         engine,  # type: ignore[arg-type]
         engine_health_may_be_stale=engine_health_may_be_stale,
+        wait_until_monitorable=wait_until_monitorable,
         interval=0.001,
         failure_threshold=failure_threshold,
     )
+
+
+def test_engine_watchdog_starts_after_engine_becomes_monitorable() -> None:
+    async def go() -> None:
+        monitorable = asyncio.Event()
+        engine = _HealthSequence(
+            EngineHealthStatus.UNRESPONSIVE,
+            EngineHealthStatus.UNRESPONSIVE,
+        )
+        task = asyncio.create_task(
+            _watchdog(
+                engine,
+                wait_until_monitorable=monitorable.wait,
+            ).run()
+        )
+
+        await asyncio.sleep(0.01)
+        assert engine.check_count == 0
+        assert not task.done()
+
+        monitorable.set()
+        with pytest.raises(UnrecoverableEngineError, match="unresponsive"):
+            await task
+
+    asyncio.run(go())
 
 
 def test_expected_unresponsiveness_during_weight_apply_is_recoverable() -> None:
@@ -124,12 +153,14 @@ def test_sidecar_watchdog_propagates_component_terminal_error() -> None:
         async def terminal_failure() -> None:
             raise UnrecoverableEngineError("cannot restore boot weights")
 
+        monitorable = asyncio.Event()
         engine = _HealthSequence(EngineHealthStatus.HEALTHY)
         watchdog = SidecarWatchdog(
-            _watchdog(engine),
+            _watchdog(engine, wait_until_monitorable=monitorable.wait),
             TerminalFailureMonitor(terminal_failure),
         )
         with pytest.raises(UnrecoverableEngineError, match="restore boot weights"):
             await watchdog.run()
+        assert engine.check_count == 0
 
     asyncio.run(go())


### PR DESCRIPTION
## Summary

- defer engine health monitoring until update-destination initialization finishes
- keep terminal reconciliation failures supervised from sidecar startup
- hold the Modal `enter` boundary until both initial catch-up and update-destination setup are ready
- surface sidecar startup failures immediately from `/server_info`

## Why

During CPU weight-cache initialization, the colocated engine can temporarily stop answering health checks. The watchdog previously started alongside that initialization and could consume its full three-check failure budget before a cold container became traffic-eligible.

`/health` only represents reconciler catch-up; Modal admits traffic when the decorated class finishes `modal.enter`. The cookbook startup path now waits on the richer `/server_info` state before returning.

## Validation

- `172 passed, 50 skipped`
- Ruff lint and formatting checks pass
- Modal lifecycle probe: `PROBE_RESULT ok=true wait_seconds=2.53 checks_before_gate=0 checks_after_gate=1`
- production logs confirmed watchdog checks overlapped update-destination initialization
- full production-size Modal E2E on GLM-5.2 NVFP4 with 4x B300:
  - watchdog waited throughout the 315.083-second CPU weight-cache initialization, with no health checks or failures
  - watchdog started only after `/stage_weight_update` returned 200
  - Modal `enter` then completed and public `/server_info` reported `ready=true`, `update_destination_ready=true`, and no errors
  - a live `/v1/chat/completions` request returned 200 with the expected `PR162_E2E_OK` response
