### PR TITLE
cookbook: bake and honor fastsafetensors config

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -105,7 +105,12 @@ load. Recipes select fastsafetensors as the load format:
 The shared serving image sets `FASTSAFETENSORS_CONFIG` to a baked
 `/etc/fastsafetensors.json`. It selects the base loader with the no-GDS copier,
 a 64 MiB bounce buffer, and four copy threads, so recipes do not duplicate
-loader-specific server arguments.
+loader-specific server arguments. The image applies
+`sglang_fastsafetensors_config.patch` to the pinned fork so SGLang enters
+fastsafetensors through its config-driven `AutoLoader`; the shared endpoint
+policy also removes the historical 64-thread default injected by
+autoinference-utils 0.2.3. Recipe-level model-loader configuration is rejected
+for this load format, leaving the baked file as the single source of truth.
 
 ## CPU destination
 

--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -95,14 +95,17 @@ remains in its configured source.
 
 The commit RPC still reads and transforms the complete target checkpoint. On
 each commit, Stitch forwards the load format selected for the initial server
-load. On hosts without GDS, recipes select fastsafetensors’ supported no-GDS
-mode:
+load. Recipes select fastsafetensors as the load format:
 
 ```python
 "--load-format": "fastsafetensors",
-"--model-loader-extra-config": '{"enable_gds":false}',
 "--weight-loader-drop-cache-after-load": "",
 ```
+
+The shared serving image sets `FASTSAFETENSORS_CONFIG` to a baked
+`/etc/fastsafetensors.json`. It selects the base loader with the no-GDS copier,
+a 64 MiB bounce buffer, and four copy threads, so recipes do not duplicate
+loader-specific server arguments.
 
 ## CPU destination
 

--- a/cookbook/common/fastsafetensors.json
+++ b/cookbook/common/fastsafetensors.json
@@ -1,0 +1,8 @@
+{
+  "loader": "base",
+  "base": {
+    "copier_type": "nogds",
+    "bbuf_size_kb": 65536,
+    "max_threads": 4
+  }
+}

--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -15,6 +15,7 @@ from stitch.service import engine_health_may_be_stale
 
 from . import process
 from .constants import SGLANG_PORT, SIDECAR_PORT
+from .sglang_endpoint import configure_fastsafetensors_endpoint
 
 
 def serve_startup(
@@ -37,9 +38,12 @@ def serve_startup(
     flush_cache_on_commit: bool = False,
     startup_timeout: int,
 ) -> None:
-    """Start sglang + the versioned-proxy sidecar on a Server replica (from ``@modal.enter``).
-    SGLang starts directly from the immutable boot checkpoint. The sidecar initializes the
-    selected update destination in the background after serving is available."""
+    """Start sglang + the sidecar and cross Modal's admission boundary when ready.
+
+    SGLang starts directly from the immutable boot checkpoint. The sidecar prepares
+    its update destination in the background, but ``@modal.enter`` does not return
+    until both that setup and the first catch-up have finished.
+    """
     from autoinference_utils.endpoint import (
         SGLangEndpoint,
         start_heartbeat_thread,
@@ -55,14 +59,17 @@ def serve_startup(
             "--enable-cpu-weight-cache is present in SGLANG_SERVER_ARGS"
         )
 
-    replica.endpoint = SGLangEndpoint(
-        model_path=model_name,
-        worker_port=SGLANG_PORT,
-        tp=tp,
-        extra_server_args=sglang_args,
-        health_timeout=startup_timeout,
-        health_poll_interval=10.0,
-        log_requests_level=-1,
+    replica.endpoint = configure_fastsafetensors_endpoint(
+        SGLangEndpoint(
+            model_path=model_name,
+            worker_port=SGLANG_PORT,
+            tp=tp,
+            extra_server_args=sglang_args,
+            health_timeout=startup_timeout,
+            health_poll_interval=10.0,
+            log_requests_level=-1,
+        ),
+        sglang_args,
     )
     replica.endpoint.start()
     served_model_name = str(sglang_args.get("--served-model-name", model_name))
@@ -97,12 +104,13 @@ def serve_startup(
         commit_mode=commit_mode,
         flush_cache_on_commit=flush_cache_on_commit,
     )
-    # Modal admits the container to Flash routing when @enter returns and never re-polls /health, so
-    # blocking here on /health (503 until the reconciler's first catch-up) is the only thing that keeps a
-    # not-yet-synced replica out of rotation. Fresh boot (no pointer) clears at once; a mid-run joiner
-    # waits until it has applied the live version, bounded by startup_timeout.
-    process.wait_http(
-        f"http://127.0.0.1:{SIDECAR_PORT}/health", replica.sidecar, startup_timeout
+    # Modal admits the container when @enter returns. /health describes sidecar
+    # catch-up only, so use the richer status surface to also keep startup-only
+    # engine preparation outside the traffic-serving lifetime.
+    process.wait_sidecar_ready(
+        f"http://127.0.0.1:{SIDECAR_PORT}/server_info",
+        replica.sidecar,
+        startup_timeout,
     )
 
     def engine_health() -> str | None:

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -36,6 +36,10 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent
 _FASTSAFETENSORS_CONFIG_SOURCE = Path(__file__).with_name("fastsafetensors.json")
 _FASTSAFETENSORS_CONFIG_PATH = "/etc/fastsafetensors.json"
+_SGLANG_FASTSAFETENSORS_PATCH_SOURCE = Path(__file__).with_name(
+    "sglang_fastsafetensors_config.patch"
+)
+_SGLANG_FASTSAFETENSORS_PATCH_PATH = "/tmp/sglang-fastsafetensors-config.patch"
 
 _SERVING_ENV = {
     "FASTSAFETENSORS_CONFIG": _FASTSAFETENSORS_CONFIG_PATH,
@@ -61,14 +65,22 @@ def build_serving_image(
     """Build the rollout-pool image for one experiment config."""
     return (
         modal.Image.from_registry(runtime.image)
+        .add_local_file(
+            _SGLANG_FASTSAFETENSORS_PATCH_SOURCE,
+            remote_path=_SGLANG_FASTSAFETENSORS_PATCH_PATH,
+            copy=True,
+        )
         .run_commands(
             "rm -rf /tmp/stitch-sglang-overlay"
             f" && git clone --filter=blob:none --single-branch --branch {runtime.branch}"
             f" {runtime.repository} /tmp/stitch-sglang-overlay"
             f" && git -C /tmp/stitch-sglang-overlay checkout --detach {runtime.commit}"
+            " && git -C /tmp/stitch-sglang-overlay apply"
+            f" {_SGLANG_FASTSAFETENSORS_PATCH_PATH}"
             " && rm -rf /sgl-workspace/sglang/python/sglang"
             " && cp -a /tmp/stitch-sglang-overlay/python/. /sgl-workspace/sglang/python/"
             " && rm -rf /tmp/stitch-sglang-overlay"
+            f" && rm {_SGLANG_FASTSAFETENSORS_PATCH_PATH}"
         )
         .run_commands(
             f"rm -rf {hf_cache_path}"

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -34,8 +34,11 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
 )
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent
+_FASTSAFETENSORS_CONFIG_SOURCE = Path(__file__).with_name("fastsafetensors.json")
+_FASTSAFETENSORS_CONFIG_PATH = "/etc/fastsafetensors.json"
 
 _SERVING_ENV = {
+    "FASTSAFETENSORS_CONFIG": _FASTSAFETENSORS_CONFIG_PATH,
     "HF_XET_HIGH_PERFORMANCE": "1",
     "HF_HUB_ENABLE_HF_TRANSFER": "1",
     "HF_MODULES_CACHE": "/tmp/huggingface/modules",
@@ -80,6 +83,13 @@ def build_serving_image(
             "blake3",  # engine-side weight-staging checksum
             "fastsafetensors",
             *extra_packages,
+        )
+        # copy=True bakes the shared loader policy into the image instead of
+        # mounting a host file when each container starts.
+        .add_local_file(
+            _FASTSAFETENSORS_CONFIG_SOURCE,
+            remote_path=_FASTSAFETENSORS_CONFIG_PATH,
+            copy=True,
         )
         .env(
             {

--- a/cookbook/common/serving_image_test.py
+++ b/cookbook/common/serving_image_test.py
@@ -62,6 +62,7 @@ def test_build_serving_image_uses_selected_runtime(monkeypatch) -> None:
     assert runtime.repository in source_overlay
     assert runtime.branch in source_overlay
     assert runtime.commit in source_overlay
+    assert "sglang-fastsafetensors-config.patch" in source_overlay
 
 
 def test_build_serving_image_bakes_fastsafetensors_config(monkeypatch) -> None:
@@ -78,15 +79,21 @@ def test_build_serving_image_bakes_fastsafetensors_config(monkeypatch) -> None:
     )
 
     config_path = "/etc/fastsafetensors.json"
+    patch_path = "/tmp/sglang-fastsafetensors-config.patch"
+    local_files = {
+        remote_path: (local_path, copy)
+        for local_path, remote_path, copy in image.local_files
+    }
     assert image.environment["FASTSAFETENSORS_CONFIG"] == config_path
-    assert image.local_files == [
-        (
-            Path(serving_image.__file__).with_name("fastsafetensors.json"),
-            config_path,
-            True,
-        )
-    ]
-    assert json.loads(image.local_files[0][0].read_text()) == {
+    assert local_files[config_path] == (
+        Path(serving_image.__file__).with_name("fastsafetensors.json"),
+        True,
+    )
+    assert local_files[patch_path] == (
+        Path(serving_image.__file__).with_name("sglang_fastsafetensors_config.patch"),
+        True,
+    )
+    assert json.loads(local_files[config_path][0].read_text()) == {
         "loader": "base",
         "base": {
             "copier_type": "nogds",

--- a/cookbook/common/serving_image_test.py
+++ b/cookbook/common/serving_image_test.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from cookbook.common import serving_image
 
 
 class _Image:
     def __init__(self) -> None:
         self.commands: list[str] = []
+        self.environment: dict[str, str] = {}
+        self.local_files: list[tuple[Path, str, bool]] = []
 
     def run_commands(self, command: str) -> _Image:
         self.commands.append(command)
@@ -14,7 +19,14 @@ class _Image:
     def pip_install(self, *_packages: str) -> _Image:
         return self
 
-    def env(self, _values: dict[str, str]) -> _Image:
+    def env(self, values: dict[str, str]) -> _Image:
+        self.environment.update(values)
+        return self
+
+    def add_local_file(
+        self, local_path: str | Path, remote_path: str, *, copy: bool = False
+    ) -> _Image:
+        self.local_files.append((Path(local_path), remote_path, copy))
         return self
 
     def add_local_python_source(self, _module: str) -> _Image:
@@ -50,3 +62,35 @@ def test_build_serving_image_uses_selected_runtime(monkeypatch) -> None:
     assert runtime.repository in source_overlay
     assert runtime.branch in source_overlay
     assert runtime.commit in source_overlay
+
+
+def test_build_serving_image_bakes_fastsafetensors_config(monkeypatch) -> None:
+    image = _Image()
+    monkeypatch.setattr(
+        serving_image.modal.Image,
+        "from_registry",
+        lambda _name: image,
+    )
+
+    serving_image.build_serving_image(
+        hf_cache_path="/cache",
+        experiment="test",
+    )
+
+    config_path = "/etc/fastsafetensors.json"
+    assert image.environment["FASTSAFETENSORS_CONFIG"] == config_path
+    assert image.local_files == [
+        (
+            Path(serving_image.__file__).with_name("fastsafetensors.json"),
+            config_path,
+            True,
+        )
+    ]
+    assert json.loads(image.local_files[0][0].read_text()) == {
+        "loader": "base",
+        "base": {
+            "copier_type": "nogds",
+            "bbuf_size_kb": 65536,
+            "max_threads": 4,
+        },
+    }

--- a/cookbook/common/sglang_endpoint.py
+++ b/cookbook/common/sglang_endpoint.py
@@ -1,0 +1,33 @@
+"""SGLang endpoint policy shared by serving and profiling entrypoints."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TypeVar
+
+_MODEL_LOADER_CONFIG_ARG = "--model-loader-extra-config"
+_Endpoint = TypeVar("_Endpoint")
+
+
+def configure_fastsafetensors_endpoint(
+    endpoint: _Endpoint,
+    server_args: Mapping[str, str],
+) -> _Endpoint:
+    """Make the baked fastsafetensors file the only loader configuration.
+
+    autoinference-utils 0.2.3 injects a historical 64-thread loader argument
+    unless a recipe supplies its own override. Remove that default on this
+    endpoint instance; other endpoint instances and non-fastsafetensors loads
+    keep the dependency's defaults unchanged.
+    """
+    if server_args.get("--load-format") != "fastsafetensors":
+        return endpoint
+    if _MODEL_LOADER_CONFIG_ARG in server_args:
+        raise ValueError(
+            f"{_MODEL_LOADER_CONFIG_ARG} conflicts with FASTSAFETENSORS_CONFIG"
+        )
+
+    operational_args = dict(endpoint.DEFAULT_OPERATIONAL_ARGS)  # type: ignore[attr-defined]
+    operational_args.pop(_MODEL_LOADER_CONFIG_ARG, None)
+    endpoint.DEFAULT_OPERATIONAL_ARGS = operational_args  # type: ignore[attr-defined]
+    return endpoint

--- a/cookbook/common/sglang_endpoint_test.py
+++ b/cookbook/common/sglang_endpoint_test.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from .sglang_endpoint import configure_fastsafetensors_endpoint
+
+
+class _Endpoint:
+    DEFAULT_OPERATIONAL_ARGS = {
+        "--enable-metrics": "",
+        "--model-loader-extra-config": (
+            '{"enable_multithread_load":true,"num_threads":64}'
+        ),
+    }
+
+
+def test_fastsafetensors_uses_only_baked_config() -> None:
+    endpoint = _Endpoint()
+
+    configured = configure_fastsafetensors_endpoint(
+        endpoint,
+        {"--load-format": "fastsafetensors"},
+    )
+
+    assert configured is endpoint
+    assert configured.DEFAULT_OPERATIONAL_ARGS == {"--enable-metrics": ""}
+    assert "--model-loader-extra-config" in _Endpoint.DEFAULT_OPERATIONAL_ARGS
+
+
+def test_fastsafetensors_rejects_recipe_override() -> None:
+    with pytest.raises(ValueError, match="conflicts with FASTSAFETENSORS_CONFIG"):
+        configure_fastsafetensors_endpoint(
+            _Endpoint(),
+            {
+                "--load-format": "fastsafetensors",
+                "--model-loader-extra-config": '{"enable_gds":false}',
+            },
+        )
+
+
+def test_other_load_format_preserves_endpoint_defaults() -> None:
+    endpoint = _Endpoint()
+
+    configure_fastsafetensors_endpoint(endpoint, {"--load-format": "auto"})
+
+    assert endpoint.DEFAULT_OPERATIONAL_ARGS is _Endpoint.DEFAULT_OPERATIONAL_ARGS

--- a/cookbook/common/sglang_fastsafetensors_config.patch
+++ b/cookbook/common/sglang_fastsafetensors_config.patch
@@ -1,0 +1,118 @@
+diff --git a/python/sglang/srt/model_loader/loader.py b/python/sglang/srt/model_loader/loader.py
+index 3e95d71184..14eff21c0a 100644
+--- a/python/sglang/srt/model_loader/loader.py
++++ b/python/sglang/srt/model_loader/loader.py
+@@ -404,15 +404,11 @@ class DefaultModelLoader(BaseModelLoader):
+     def __init__(self, load_config: LoadConfig):
+         super().__init__(load_config)
+         extra_config = load_config.model_loader_extra_config
+-        allowed_keys = {"enable_multithread_load", "num_threads"}
+-        if load_config.load_format == LoadFormat.FASTSAFETENSORS:
+-            allowed_keys.add("enable_gds")
+-            if "enable_gds" in extra_config and not isinstance(
+-                extra_config["enable_gds"], bool
+-            ):
+-                raise ValueError(
+-                    "enable_gds in --model-loader-extra-config must be a boolean"
+-                )
++        allowed_keys = (
++            set()
++            if load_config.load_format == LoadFormat.FASTSAFETENSORS
++            else {"enable_multithread_load", "num_threads"}
++        )
+         unexpected_keys = set(extra_config.keys()) - allowed_keys
+ 
+         if unexpected_keys:
+@@ -623,12 +619,7 @@ class DefaultModelLoader(BaseModelLoader):
+                 use_multithread = False
+ 
+             if self.load_config.load_format == LoadFormat.FASTSAFETENSORS:
+-                enable_gds = extra_config.get("enable_gds", True)
+-                weights_iterator = fastsafetensors_weights_iterator(
+-                    hf_weights_files,
+-                    enable_gds=enable_gds,
+-                    drop_cache_after_load=weight_loader_drop_cache_after_load,
+-                )
++                weights_iterator = fastsafetensors_weights_iterator(hf_weights_files)
+             elif use_multithread:
+                 weights_iterator = buffered_multi_thread_safetensors_weights_iterator(
+                     hf_weights_files,
+diff --git a/python/sglang/srt/model_loader/weight_utils.py b/python/sglang/srt/model_loader/weight_utils.py
+index 506d359a40..4f0946f992 100644
+--- a/python/sglang/srt/model_loader/weight_utils.py
++++ b/python/sglang/srt/model_loader/weight_utils.py
+@@ -66,9 +66,9 @@ from sglang.srt.utils.common import is_cuda_alike
+ from sglang.utils import is_in_ci
+ 
+ try:
+-    from fastsafetensors import SafeTensorsFileLoader, SingleGroup
++    from fastsafetensors import AutoLoader, SingleGroup
+ except ImportError:
+-    SafeTensorsFileLoader = SingleGroup = None
++    AutoLoader = SingleGroup = None
+ 
+ logger = logging.getLogger(__name__)
+ 
+@@ -999,14 +999,9 @@ def safetensors_weights_iterator(
+ 
+ def fastsafetensors_weights_iterator(
+     hf_weights_files: List[str],
+-    enable_gds: bool = True,
+-    drop_cache_after_load: bool = False,
+ ) -> Generator[Tuple[str, torch.Tensor], None, None]:
+-    """
+-    Iterate over the weights in the model safetensor files
+-    using fastsafetensor library to accelerate loading via GPU Direct Storage (if available).
+-    """
+-    if SafeTensorsFileLoader is None:
++    """Load model weights with fastsafetensors' config-driven loader."""
++    if AutoLoader is None:
+         raise ImportError(
+             "Please install fastsafetensors via `pip install fastsafetensors`"
+         )
+@@ -1021,40 +1016,11 @@ def fastsafetensors_weights_iterator(
+     except Exception:
+         rank = 0
+ 
+-    device = torch.device(f"cuda:{rank}")
+-
+-    weight_files_sub_lists = [
+-        hf_weights_files[i : i + pg.size()]
+-        for i in range(0, len(hf_weights_files), pg.size())
+-    ]
+-
+-    _BAR_FORMAT = (
+-        "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]"
+-    )
+-
+-    for f_list in tqdm(
+-        weight_files_sub_lists,
+-        desc="Loading safetensors using Fastsafetensor loader",
+-        disable=False,
+-        bar_format=_BAR_FORMAT,
+-    ):
+-        loader = SafeTensorsFileLoader(pg, device, nogds=not enable_gds)
+-        rank_file_map = {i: [f] for i, f in enumerate(f_list)}
+-        loader.add_filenames(rank_file_map)
+-        try:
+-            fb = loader.copy_files_to_device()
+-            try:
+-                keys = list(fb.key_to_rank_lidx.keys())
+-                for k in keys:
+-                    t = fb.get_tensor(k)
+-                    yield k, t
+-            finally:
+-                pass
+-        finally:
+-            loader.close()
+-        if drop_cache_after_load:
+-            for loaded_file in rank_file_map.get(rank, []):
+-                _drop_file_cache_after_load(loaded_file)
++    loader = AutoLoader(pg, hf_weights_files, device=f"cuda:{rank}")
++    try:
++        yield from loader.iterate_weights()
++    finally:
++        loader.close()
+ 
+ 
+ def multi_thread_safetensors_weights_iterator(

--- a/cookbook/miles_disagg/configs/glm45_air_bf16.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16.py
@@ -29,9 +29,7 @@ MEGATRON_RUNTIME_PATCHES = [
 
 
 SGLANG_SERVER_ARGS = {
-    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--enable-cpu-weight-cache": "",
     "--weight-loader-drop-cache-after-load": "",
     "--reasoning-parser": "glm45",

--- a/cookbook/miles_disagg/configs/glm45_air_fp8.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8.py
@@ -36,9 +36,7 @@ MEGATRON_RUNTIME_PATCHES = [
 ]
 
 SGLANG_SERVER_ARGS = {
-    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--enable-cpu-weight-cache": "",
     "--cpu-weight-cache-max-compile-group-gb": "8",
     "--weight-loader-drop-cache-after-load": "",

--- a/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
+++ b/cookbook/miles_disagg/configs/glm5_2_nvfp4.py
@@ -118,7 +118,6 @@ SGLANG_DELTA_UPDATE_MODE = "cpu"
 SGLANG_SERVER_ARGS = {
     # loading / elastic refit
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--enable-cpu-weight-cache": "",
     "--cpu-weight-cache-max-compile-group-gb": "8",
     "--weight-loader-drop-cache-after-load": "",

--- a/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k25_2layer_nvfp4.py
@@ -30,9 +30,7 @@ MEGATRON_RUNTIME_PATCHES = [
 
 
 SGLANG_SERVER_ARGS = {
-    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--enable-cpu-weight-cache": "",
     "--weight-loader-drop-cache-after-load": "",
     "--tool-call-parser": "kimi_k2",

--- a/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k2_6_nvfp4.py
@@ -32,9 +32,7 @@ MEGATRON_RUNTIME_PATCHES = [
 
 # mem-fraction / context-length are starting points — measure on a warm B200:4.
 SGLANG_SERVER_ARGS = {
-    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--trust-remote-code": "",
     "--enable-cpu-weight-cache": "",
     "--cpu-weight-cache-max-compile-group-gb": "8",

--- a/cookbook/miles_disagg/configs/kimi_k3_mxfp4.py
+++ b/cookbook/miles_disagg/configs/kimi_k3_mxfp4.py
@@ -10,7 +10,6 @@ SGLANG_DELTA_UPDATE_MODE = "cpu"
 SGLANG_SERVER_ARGS = {
     "--trust-remote-code": "",
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--weight-loader-drop-cache-after-load": "",
     "--enable-cpu-weight-cache": "",
     "--cpu-weight-cache-max-compile-group-gb": "16",

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4.py
@@ -31,9 +31,7 @@ MEGATRON_RUNTIME_PATCHES = [
 # No --quantization flag — NVFP4 comes from the served checkpoint's quant config.
 # mem-fraction / context-length are starting points; measure.
 SGLANG_SERVER_ARGS = {
-    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--enable-cpu-weight-cache": "",
     "--weight-loader-drop-cache-after-load": "",
     "--attention-backend": "tokenspeed_mla",

--- a/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
+++ b/cookbook/slime_disagg/configs/kimi_k2_6_int4.py
@@ -24,9 +24,7 @@ SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 SGLANG_DELTA_UPDATE_MODE = "cpu"
 
 SGLANG_SERVER_ARGS = {
-    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--enable-cpu-weight-cache": "",
     "--weight-loader-drop-cache-after-load": "",
     "--tool-call-parser": "kimi_k2",

--- a/cookbook/slime_disagg/configs/moonlight.py
+++ b/cookbook/slime_disagg/configs/moonlight.py
@@ -22,9 +22,7 @@ SGLANG_DELTA_UPDATE_MODE = "cpu"
 
 # mem-fraction-static is a starting point -- measure on a warm container.
 SGLANG_SERVER_ARGS = {
-    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--enable-cpu-weight-cache": "",
     "--weight-loader-drop-cache-after-load": "",
     "--context-length": "8192",

--- a/cookbook/slime_disagg/configs/moonlight_int4.py
+++ b/cookbook/slime_disagg/configs/moonlight_int4.py
@@ -25,9 +25,7 @@ SGLANG_DELTA_UPDATE_MODE = "cpu"
 
 # The pool reuses the trainer image (its SGLang serves native INT4; no Blackwell fork).
 SGLANG_SERVER_ARGS = {
-    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--enable-cpu-weight-cache": "",
     "--weight-loader-drop-cache-after-load": "",
     "--context-length": "16384",

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
@@ -18,9 +18,7 @@ SIDECAR_FLUSH_CACHE_ON_COMMIT = False
 SGLANG_DELTA_UPDATE_MODE = "cpu"
 
 SGLANG_SERVER_ARGS = {
-    # Use the no-GDS fastsafetensors path on hosts without nvidia-fs.
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--enable-cpu-weight-cache": "",
     "--weight-loader-drop-cache-after-load": "",
     "--reasoning-parser": "qwen3",

--- a/tools/profiling/_delta_weight_update.py
+++ b/tools/profiling/_delta_weight_update.py
@@ -584,6 +584,8 @@ def run_delta_weight_update(
     import httpx
     from autoinference_utils.endpoint import SGLangEndpoint
 
+    from cookbook.common.sglang_endpoint import configure_fastsafetensors_endpoint
+
     target_dir = Path(source_dir) / f"weight_v{target_version:06d}"
     target_index = target_dir / "model.safetensors.index.json"
     base_index = Path(spec.base_checkpoint_dir) / "model.safetensors.index.json"
@@ -611,21 +613,25 @@ def run_delta_weight_update(
 
     shutil.rmtree(spec.local_target_checkpoint_dir, ignore_errors=True)
 
-    endpoint = SGLangEndpoint(
-        model_path=spec.base_checkpoint_dir,
-        worker_port=spec.port,
-        tp=spec.tp_size,
-        extra_server_args=server_args_for_mode(
-            spec.server_args,
-            update_mode,
-            canonical_storage,
-            spec.local_canonical_checkpoint_dir,
+    endpoint_args = server_args_for_mode(
+        spec.server_args,
+        update_mode,
+        canonical_storage,
+        spec.local_canonical_checkpoint_dir,
+    )
+    endpoint = configure_fastsafetensors_endpoint(
+        SGLangEndpoint(
+            model_path=spec.base_checkpoint_dir,
+            worker_port=spec.port,
+            tp=spec.tp_size,
+            extra_server_args=endpoint_args,
+            # Allow for a cold, model-sized initial load. Destination initialization
+            # is measured separately after the endpoint begins serving.
+            health_timeout=2 * 60 * 60,
+            health_poll_interval=10,
+            log_requests_level=-1,
         ),
-        # Allow for a cold, model-sized initial load. Destination initialization
-        # is measured separately after the endpoint begins serving.
-        health_timeout=2 * 60 * 60,
-        health_poll_interval=10,
-        log_requests_level=-1,
+        endpoint_args,
     )
     url = f"http://127.0.0.1:{spec.port}"
     try:

--- a/tools/profiling/glm45_air_fp8_delta_weight_update.py
+++ b/tools/profiling/glm45_air_fp8_delta_weight_update.py
@@ -58,7 +58,6 @@ SOURCE_MARKER = ".stitch-source.json"
 SGLANG_SERVER_ARGS = {
     "--served-model-name": model.ROLLOUT_SOURCE_MODEL,
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--weight-loader-drop-cache-after-load": "",
     "--dtype": "auto",
     "--reasoning-parser": "glm45",

--- a/tools/profiling/kimi_k2_6_nvfp4_delta_weight_update.py
+++ b/tools/profiling/kimi_k2_6_nvfp4_delta_weight_update.py
@@ -60,7 +60,6 @@ SGLANG_CACHE_PATH = "/root/.cache/sglang"
 SGLANG_SERVER_ARGS = {
     "--served-model-name": ROLLOUT_MODEL,
     "--load-format": "fastsafetensors",
-    "--model-loader-extra-config": '{"enable_gds":false}',
     "--weight-loader-drop-cache-after-load": "",
     "--trust-remote-code": "",
     "--tool-call-parser": "kimi_k2",


### PR DESCRIPTION
## Summary

- Bake `/etc/fastsafetensors.json` into the serving image and export `FASTSAFETENSORS_CONFIG` with the shared `base`/`nogds`/64 MiB/4-thread settings.
- Patch the pinned SGLang fastsafetensors iterator to use `AutoLoader`, so the environment-backed config is actually honored.
- Remove recipe-level model-loader overrides and centralize the fastsafetensors endpoint defaults for serving and profiling.
- Add colocated tests and document the pinned-fork integration.

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-sync pytest`: 173 passed, 48 sandbox-dependent skips.
- `ruff check .`: passed.
- Modal CPU preflights passed under gVisor and deploy-time `MODAL_FUNCTION_RUNTIME=runc`.
- Four Qwen3.6-35B-A3B GPU runs passed exact post-delta text, token, and logprob fingerprint checks.

| Loader path | Runtime | Endpoint cold | SGLang startup | Delta prep | Reload/pause | Total update |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| Legacy server override | gVisor | 656.17 s | 576.12 s | 43.25 s | 24.86 s | 68.12 s |
| Baked shared config | gVisor | 256.05 s | 198.67 s | 31.10 s | 12.39 s | 43.49 s |
| Legacy server override | runc | 144.02 s | 114.28 s | 10.97 s | 12.97 s | 23.94 s |
| Baked shared config | runc | 216.04 s | 161.66 s | 27.70 s | 14.85 s | 42.55 s |

These are single wall-clock samples in execution order, not a hardware distribution. Weight load itself stayed within 38.60-41.81 seconds; cold-start differences were dominated by CUDA graph compilation and likely host/cache variance. Runtime logs confirmed the requested config exactly and reported 28.84 GB load-phase GPU memory for the new path versus 58.10 GB for the legacy path in both runtime cells.
