### PR TITLE
Clarify rollout watchdog lifecycle

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -38,7 +38,7 @@ images.
 
 ## API
 
-`POST /stage_weight_update` prepares a target while inference continues:
+`POST /stage_weight_update` prepares a target without changing live weights:
 
 ```json
 {
@@ -68,8 +68,8 @@ Commit remains a separate operation:
   target verification preserves generation correctness while its acceptance
   rate may change as the target evolves.
 
-The separation is the pause boundary: staging may overlap rollout generation,
-while commit is the short operation coordinated by Stitch.
+The separation is the pause boundary: after startup, staging may overlap rollout
+generation, while commit is the short operation coordinated by Stitch.
 
 ## Disk destination
 
@@ -87,11 +87,10 @@ final published target checksum remains the commit boundary.
 
 The rollout engine initially loads its boot checkpoint directly from
 `base_checkpoint_dir`. Its logical version is normally v0 and may be a saved
-version for a resumed run. Stitch initializes the mutable local checkpoint in
-the background after the boot checkpoint is serving, so initial rollout
-readiness is not delayed by a second model-sized copy. Local storage must hold
-the mutable checkpoint plus filesystem headroom; the immutable boot checkpoint
-remains in its configured source.
+version for a resumed run. Stitch initializes the mutable local checkpoint
+before the replica enters rotation, then reconciles it to the visible version.
+Local storage must hold the mutable checkpoint plus filesystem headroom; the
+immutable boot checkpoint remains in its configured source.
 
 The commit RPC still reads and transforms the complete target checkpoint. On
 each commit, Stitch forwards the load format selected for the initial server
@@ -108,10 +107,10 @@ mode:
 
 CPU mode keeps rank-ready images in RAM for the shortest commit:
 
-1. After the boot checkpoint begins serving, SGLang allocates one complete
-   rank-ready image per local TP rank and either caches one canonical checkpoint
-   per host in RAM or materializes it on host-local storage. It also builds the
-   model's native loader views once against each rank image.
+1. After loading the boot checkpoint, SGLang allocates one complete rank-ready
+   image per local TP rank and either caches one canonical checkpoint per host in
+   RAM or materializes it on host-local storage. It also builds the model's
+   native loader views once against each rank image.
 2. When the base is the boot checkpoint, it captures the already-realized active
    runtime storages into the rank images instead of repeating a model-sized
    load. A different base goes through the model's ordinary loader and
@@ -124,13 +123,10 @@ CPU mode keeps rank-ready images in RAM for the shortest commit:
    complete images into the existing CUDA storages without replacing storage
    pointers.
 
-Stitch starts step 1 in the background. A published delta waits for that same
-initialization task; it does not start a second cache build. An initialization
-or staging failure is reported and the GPU remains on its prior weights.
-Registering a model-sized rank image as CUDA host memory is also one-time work,
-but can delay active inference on very large models. Initialize the CPU
-destination before routing latency-sensitive traffic when warmup latency
-matters.
+Stitch completes step 1 before the replica enters rotation. An initialization
+failure replaces the replica; a later staging failure is reported and the GPU
+remains on its prior weights. Registering a model-sized rank image as CUDA host
+memory and capturing active GPU weights are one-time startup work.
 
 CPU mode is delta-only. It rejects FULL publications and cannot reset a patched
 live replica to another run; the controller must use disk mode or replace that
@@ -154,11 +150,11 @@ host-local storage:
 ```
 
 Use local NVMe rather than a network or shared filesystem. This path pays a
-complete checkpoint copy during background initialization and adds NVMe
-read/write work during preparation; it does not change the CPU-to-GPU engine
-pause. Set `--weight-loader-drop-cache-after-load` to release clean checkpoint
-pages after every local TP rank finishes compiling; otherwise the kernel may
-retain those reclaimable pages for later reads.
+complete checkpoint copy during initialization and adds NVMe read/write work
+during preparation; it does not change the CPU-to-GPU engine pause. Set
+`--weight-loader-drop-cache-after-load` to release clean checkpoint pages after
+every local TP rank finishes compiling; otherwise the kernel may retain those
+reclaimable pages for later reads.
 
 The group bound limits CUDA staging work; it does not tune correctness or assume
 a model architecture. An indivisible module larger than the requested bound

--- a/cookbook/common/process.py
+++ b/cookbook/common/process.py
@@ -96,6 +96,26 @@ def wait_http(url: str, process: subprocess.Popen | None, timeout: int) -> None:
     raise TimeoutError(f"timed out waiting for {url}; last error: {last_error}")
 
 
+def http_health_error(
+    url: str,
+    process: subprocess.Popen | None,
+    *,
+    timeout: float = 5.0,
+) -> str | None:
+    """Return why a colocated HTTP process is unavailable, or ``None``."""
+    if process is not None and process.poll() is not None:
+        return f"process exited with code {process.returncode}"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            if 200 <= resp.status < 300:
+                return None
+            return f"HTTP {resp.status} from {url}"
+    except urllib.error.HTTPError as exc:
+        return f"HTTP {exc.code} from {url}"
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return f"{type(exc).__name__}: {exc}"
+
+
 def terminate_process(process: subprocess.Popen | None) -> None:
     if process is None or process.poll() is not None:
         return

--- a/cookbook/common/process_test.py
+++ b/cookbook/common/process_test.py
@@ -1,8 +1,64 @@
 from __future__ import annotations
 
+import urllib.error
+
 from cookbook.common import process, storage
 from stitch.sidecar import SidecarConfig, _load_store_factory
 from stitch.stores.s3 import S3Store
+
+
+class _Process:
+    def __init__(self, returncode: int | None = None) -> None:
+        self.returncode = returncode
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+
+class _Response:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args) -> None:
+        return None
+
+
+def test_http_health_error_checks_process_and_http(monkeypatch) -> None:
+    monkeypatch.setattr(
+        process.urllib.request, "urlopen", lambda *_args, **_kwargs: _Response()
+    )
+
+    assert process.http_health_error("http://sidecar/server_info", _Process()) is None
+    assert (
+        process.http_health_error("http://sidecar/server_info", _Process(returncode=7))
+        == "process exited with code 7"
+    )
+
+
+def test_http_health_error_reports_request_failure(monkeypatch) -> None:
+    def fail(*_args, **_kwargs):
+        raise TimeoutError("sidecar stalled")
+
+    monkeypatch.setattr(process.urllib.request, "urlopen", fail)
+
+    assert (
+        process.http_health_error("http://sidecar/server_info", _Process())
+        == "TimeoutError: sidecar stalled"
+    )
+
+
+def test_http_health_error_reports_http_status(monkeypatch) -> None:
+    def fail(url, **_kwargs):
+        raise urllib.error.HTTPError(url, 503, "not ready", {}, None)
+
+    monkeypatch.setattr(process.urllib.request, "urlopen", fail)
+
+    assert (
+        process.http_health_error("http://sidecar/server_info", _Process())
+        == "HTTP 503 from http://sidecar/server_info"
+    )
 
 
 def test_start_sidecar_passes_s3_store_settings(monkeypatch) -> None:

--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from stitch.service import engine_health_may_be_stale
-
 from . import process
 from .constants import SGLANG_PORT, SIDECAR_PORT
 
@@ -38,8 +36,8 @@ def serve_startup(
     startup_timeout: int,
 ) -> None:
     """Start sglang + the versioned-proxy sidecar on a Server replica (from ``@modal.enter``).
-    SGLang starts directly from the immutable boot checkpoint. The sidecar initializes the
-    selected update destination in the background after serving is available."""
+    SGLang starts directly from the immutable boot checkpoint. The sidecar enters
+    rotation after its update destination is initialized and it has caught up."""
     from autoinference_utils.endpoint import (
         SGLangEndpoint,
         start_heartbeat_thread,
@@ -97,35 +95,34 @@ def serve_startup(
         commit_mode=commit_mode,
         flush_cache_on_commit=flush_cache_on_commit,
     )
-    # Modal admits the container to Flash routing when @enter returns and never re-polls /health, so
-    # blocking here on /health (503 until the reconciler's first catch-up) is the only thing that keeps a
-    # not-yet-synced replica out of rotation. Fresh boot (no pointer) clears at once; a mid-run joiner
-    # waits until it has applied the live version, bounded by startup_timeout.
+    # Modal admits the container when @enter returns. The sidecar owns readiness:
+    # /health stays 503 through destination initialization and first catch-up.
     process.wait_http(
         f"http://127.0.0.1:{SIDECAR_PORT}/health", replica.sidecar, startup_timeout
     )
 
-    def engine_health() -> str | None:
-        # Applying staged weights pauses inference. Staging does not, so a health
-        # failure during staging must remain visible as a stalled-engine signal.
-        error = replica.endpoint.health_check()
-        if error is None:
-            return None
-        return (
-            None
-            if engine_health_may_be_stale(
-                f"http://127.0.0.1:{SIDECAR_PORT}/server_info"
-            )
-            else error
+    def sidecar_http_health() -> str | None:
+        # Stitch owns SGLang functional health. This independent parent probe
+        # covers a sidecar that is alive but no longer serving HTTP.
+        return process.http_health_error(
+            f"http://127.0.0.1:{SIDECAR_PORT}/server_info",
+            replica.sidecar,
         )
 
-    import modal.experimental
+    def terminate_unresponsive_sidecar() -> None:
+        # Closing the exposed port makes Modal replace this failed Server. A
+        # graceful stop_fetching_inputs() would incorrectly report it as Done.
+        print(
+            "[heartbeat] sidecar remained unhealthy; terminating it for replacement",
+            flush=True,
+        )
+        process.terminate_process(replica.sidecar)
 
     start_heartbeat_thread(
-        engine_health,
-        on_failure=lambda: modal.experimental.stop_fetching_inputs(),
-        max_consecutive_failures=12,  # ~1 min of sustained idle-state failures
+        sidecar_http_health,
+        on_failure=terminate_unresponsive_sidecar,
     )
+
     print(
         f"Rollout server ready: model={served_model_name}, "
         f"boot_version={boot_version}, target_inputs={concurrency}"

--- a/src/stitch/engines/base.py
+++ b/src/stitch/engines/base.py
@@ -24,12 +24,11 @@ class EngineHealthStatus(str, Enum):
 
 @dataclass(frozen=True)
 class EngineHealth:
-    """One engine-liveness probe result.
+    """One functional engine-health probe result.
 
-    ``UNRESPONSIVE`` includes timeouts and non-200 health responses. Whether a
-    transition explains one is engine-specific; the rollout sidecar exempts only
-    its explicit paused-apply window. ``UNREACHABLE`` means the sidecar could not
-    establish a connection to its colocated engine at all.
+    ``UNRESPONSIVE`` includes timeouts and non-200 health responses.
+    ``UNREACHABLE`` means the sidecar could not establish a connection to its
+    colocated engine at all.
     """
 
     status: EngineHealthStatus
@@ -50,7 +49,8 @@ class Engine:
     ) -> None:
         """Apply the staged checkpoint to the serving weights; the gate covers only this.
         ``flush_cache`` (a commit-policy decision the reconciler passes) evicts the engine's
-        prefix/KV cache as part of the commit."""
+        prefix/KV cache as part of the commit. Once this begins, any failure leaves
+        the live engine state uncertain and requires replacing the replica."""
         raise NotImplementedError
 
     async def flush_cache(self) -> None:
@@ -73,9 +73,8 @@ class Engine:
     async def initialize_update_destination(self, boot_version: int = 0) -> None:
         """Initialize engine state required before staging updates.
 
-        This may run while the engine serves its boot weights. A reconciler waits
-        for it before staging the first published update. ``boot_version`` is the
-        logical version of the immutable checkpoint already loaded by the engine.
+        A replica does not enter rotation until this finishes. ``boot_version`` is
+        the logical version of the immutable checkpoint already loaded by the engine.
         """
         return
 
@@ -103,5 +102,5 @@ class Engine:
         return frozenset()
 
     async def check_health(self) -> EngineHealth:
-        """Probe whether the colocated engine can still serve requests."""
+        """Probe whether the colocated engine can make inference progress."""
         raise NotImplementedError

--- a/src/stitch/engines/sglang.py
+++ b/src/stitch/engines/sglang.py
@@ -61,7 +61,7 @@ class SGLangEngine(Engine):
         )
 
     async def check_health(self) -> EngineHealth:
-        """Distinguish an absent process from an engine busy doing weight work."""
+        """Require scheduler progress through SGLang's generation health probe."""
         import httpx
 
         try:

--- a/src/stitch/engines/sglang_test.py
+++ b/src/stitch/engines/sglang_test.py
@@ -317,6 +317,7 @@ def test_staging_and_commit_have_independent_timeouts() -> None:
 class _HealthClient:
     def __init__(self, outcome) -> None:
         self.outcome = outcome
+        self.urls: list[str] = []
 
     async def __aenter__(self):
         return self
@@ -325,6 +326,7 @@ class _HealthClient:
         pass
 
     async def get(self, url: str) -> httpx.Response:
+        self.urls.append(url)
         if isinstance(self.outcome, Exception):
             raise self.outcome
         return httpx.Response(self.outcome, request=httpx.Request("GET", url))
@@ -351,13 +353,15 @@ class _HealthClient:
 def test_health_check_classifies_engine_failures(
     monkeypatch, outcome, expected
 ) -> None:
+    client = _HealthClient(outcome)
     monkeypatch.setattr(
         httpx,
         "AsyncClient",
-        lambda **_kwargs: _HealthClient(outcome),
+        lambda **_kwargs: client,
     )
     engine = SGLangEngine("http://engine", "/base", "/ckpt")
     assert asyncio.run(engine.check_health()).status is expected
+    assert client.urls == ["http://engine/health"]
 
 
 if __name__ == "__main__":

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -12,10 +12,8 @@ demotes ``request`` to a required query param, 422-ing every call.
 
 import asyncio
 import contextlib
-import json
 import logging
 import time
-import urllib.request
 import uuid
 from collections.abc import Iterable
 from contextlib import asynccontextmanager
@@ -25,7 +23,7 @@ from stitch.engines.base import Engine
 from stitch.pools.base import Pool
 from stitch.stores.base import Store
 from stitch.sync import AdmissionGate, CommitMode, ConstraintUnmet, Reconciler
-from stitch.types import PoolState, ReplicaState, SyncState, VersionConstraint
+from stitch.types import PoolState, ReplicaState, VersionConstraint
 from stitch.watchdog import (
     EngineWatchdog,
     SidecarWatchdog,
@@ -95,7 +93,8 @@ def create_app(
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
-        # Background reconcile so uvicorn answers /health (503 until the first catch-up) while it runs.
+        # Run startup beside the HTTP loop so /health explains why the replica is
+        # not yet admitted while destination initialization and catch-up run.
         syncing = asyncio.create_task(status.startup())
         try:
             yield
@@ -112,10 +111,8 @@ def create_app(
 
     @app.get("/health")
     async def health() -> Response:
-        # 503 until the reconciler's first catch-up, so a deployment that gates routing on readiness
-        # keeps a not-yet-synced replica out of rotation (else it's routed to and 409s the whole
-        # catch-up). A fresh boot clears at once; a mid-run joiner waits until it has applied the
-        # live version. Liveness/boot checks use /server_info instead.
+        # 503 until destination initialization and first catch-up complete. This
+        # is the routing-readiness contract; liveness and details use /server_info.
         if not status.ready:
             return JSONResponse(
                 {"ready": False, "reason": status.readiness_reason()},
@@ -314,7 +311,7 @@ def serve(
     watchdog = SidecarWatchdog(
         EngineWatchdog(
             engine,
-            engine_health_may_be_stale=reconciler.engine_health_may_be_stale,
+            expects_engine_progress=reconciler.expects_engine_progress,
             interval=watchdog_interval,
             failure_threshold=watchdog_failure_threshold,
         ),
@@ -348,22 +345,6 @@ async def readiness(pool: Pool, *, timeout: float = 15.0) -> PoolState:
         replicas = await pool.discover_replicas_async()
         states = await asyncio.gather(*(probe(c, url) for url in replicas))
     return PoolState(list(states))
-
-
-def engine_health_may_be_stale(server_info_url: str, *, timeout: float = 5.0) -> bool:
-    """Whether the engine is paused while staged weights are applied.
-
-    Staging and destination initialization run alongside inference. Suppressing
-    their health failures would mask a stalled scheduler, so only the short
-    commit window is exempt. An unreachable sidecar returns ``False`` so the
-    caller still reports an actual failure.
-    """
-    try:
-        with urllib.request.urlopen(server_info_url, timeout=timeout) as resp:
-            info = json.loads(resp.read())
-    except Exception:  # noqa: BLE001
-        return False
-    return info.get("sync_state") == SyncState.COMMITTING.value
 
 
 def await_pool_ready(

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -1,20 +1,16 @@
-"""Engine-health suppression derived from the sidecar's ``/server_info`` state."""
+"""Versioned sidecar proxy behavior."""
 
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import logging
-import threading
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 
 import httpx
-import pytest
 
 from stitch.engines.base import Engine
-from stitch.service import create_app, engine_health_may_be_stale
+from stitch.service import create_app
 from stitch.sync import AdmissionGate
 from stitch.types import VersionRef
 
@@ -266,60 +262,3 @@ def test_metrics_bypasses_weight_admission_before_first_pointer(monkeypatch):
         assert gate_sidecar.gate.active_requests == 0
 
     asyncio.run(go())
-
-
-@contextlib.contextmanager
-def _server_info(payload):
-    """Serve ``payload`` as JSON at /server_info on a throwaway localhost port."""
-
-    class Handler(BaseHTTPRequestHandler):
-        def do_GET(self):  # noqa: N802
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(json.dumps(payload).encode())
-
-        def log_message(self, *_):  # silence
-            pass
-
-    server = HTTPServer(("127.0.0.1", 0), Handler)
-    threading.Thread(target=server.serve_forever, daemon=True).start()
-    try:
-        yield f"http://127.0.0.1:{server.server_port}/server_info"
-    finally:
-        server.shutdown()
-
-
-@pytest.mark.parametrize(
-    "info,expected",
-    [
-        ({"update_destination_ready": True, "sync_state": "COMMITTING"}, True),
-        ({"update_destination_ready": True, "sync_state": "STAGING"}, False),
-        ({"update_destination_ready": True, "sync_state": "FETCHING"}, False),
-        (
-            {
-                "update_destination_ready": False,
-                "update_destination_error": None,
-            },
-            False,
-        ),
-        ({"update_destination_ready": True, "sync_state": "IDLE"}, False),
-        (
-            {
-                "update_destination_ready": False,
-                "update_destination_error": "boom",
-            },
-            False,
-        ),
-    ],
-)
-def test_engine_health_may_be_stale(info, expected):
-    with _server_info(info) as url:
-        assert engine_health_may_be_stale(url) is expected
-
-
-def test_unreachable_sidecar_reports_error():
-    # Nothing listening: best-effort False so the caller surfaces the engine error.
-    assert (
-        engine_health_may_be_stale("http://127.0.0.1:1/server_info", timeout=0.2)
-        is False
-    )

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -20,7 +20,7 @@ from contextlib import asynccontextmanager, contextmanager, suppress
 from typing import Any, Literal
 
 from stitch.engines.base import Engine
-from stitch.errors import UnrecoverableSidecarError
+from stitch.errors import UnrecoverableEngineError, UnrecoverableSidecarError
 from stitch.stores.base import Store
 from stitch.types import (
     SyncState,
@@ -218,13 +218,13 @@ class Reconciler:
         self.reconcile_interval = reconcile_interval
         self.sync_state = SyncState.IDLE
         self.last_error: str | None = None
-        self.ready = False  # latches on first catch-up, stays set even when later stale; the /health routing gate
+        # Latches after first catch-up unless the replica becomes terminal.
+        self.ready = False
         self.metrics: dict[str, Any] = {}
         self._boot_monotonic = time.monotonic()
         self._catchup_passes = 0
         self._task: asyncio.Task[None] | None = None
         self._wake_pending = False
-        self._destination_init_task: asyncio.Task[None] | None = None
         self._destination_ready = False
         self._destination_init_error: str | None = None
         self._periodic_task: asyncio.Task[None] | None = None
@@ -233,28 +233,21 @@ class Reconciler:
         self._lock = asyncio.Lock()
 
     async def startup(self) -> None:
-        # Serving the boot weights does not depend on this one-time setup. A
-        # published update waits for the task before it can enter staging.
-        self._destination_init_task = asyncio.create_task(
-            self._initialize_update_destination()
-        )
-        # Inspect the store's initially visible pointer without refreshing it:
-        # destination setup may still have boot-checkpoint files open. A replica
-        # already at that view can serve immediately while setup continues; a
-        # mid-run joiner stays out of rotation until catch-up.
-        pointer = await asyncio.to_thread(self.store.read_pointer)
-        if not self._behind(pointer):
-            self.ready = True
+        # A replica enters rotation only after it can both serve and follow the
+        # version stream. Initialization also releases boot-checkpoint files before
+        # reconciliation refreshes a shared backing store.
+        await self._initialize_update_destination()
+        if self._terminal_error is not None:
+            return
         await self.reconcile()
         if self.reconcile_interval > 0 and self._terminal_error is None:
             self._periodic_task = asyncio.create_task(self._periodic_reconcile())
 
     async def shutdown(self) -> None:
-        for task in (self._periodic_task, self._destination_init_task):
-            if task is not None:
-                task.cancel()
-                with suppress(BaseException):
-                    await task
+        if self._periodic_task is not None:
+            self._periodic_task.cancel()
+            with suppress(BaseException):
+                await self._periodic_task
 
     async def _periodic_reconcile(self) -> None:
         # Convergence backstop: re-check the pointer so a replica that missed its wake (raced the
@@ -275,7 +268,14 @@ class Reconciler:
             )
         except Exception as exc:  # noqa: BLE001
             self._destination_init_error = str(exc)
-            logger.exception("weight update destination initialization failed")
+            error = UnrecoverableEngineError(
+                "weight update destination initialization failed: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            self._record_terminal_error(error)
+            logger.exception(
+                "weight update destination initialization failed terminally"
+            )
 
     def server_info(self) -> dict[str, Any]:
         # applied = version on the GPU (the pool reads it to see which version each replica has);
@@ -310,9 +310,9 @@ class Reconciler:
         applied = self.applied.identity if self.applied else "boot"
         return f"catching up to live version (applied={applied}, state={self.sync_state.value})"
 
-    def engine_health_may_be_stale(self) -> bool:
-        """Whether the engine is paused while staged weights are applied."""
-        return self.sync_state is SyncState.COMMITTING
+    def expects_engine_progress(self) -> bool:
+        """Whether this replica should currently make inference progress."""
+        return self.ready and self.sync_state is not SyncState.COMMITTING
 
     async def wait_for_terminal_error(self) -> None:
         """Raise once reconciliation proves this replica must be replaced."""
@@ -322,6 +322,7 @@ class Reconciler:
 
     def _record_terminal_error(self, error: UnrecoverableSidecarError) -> None:
         if self._terminal_error is None:
+            self.ready = False
             self._terminal_error = error
             self._terminal_error_event.set()
 
@@ -433,20 +434,6 @@ class Reconciler:
                         )
 
     async def _reconcile_once_measured(self, m: dict[str, Any]) -> bool:
-        # Destination initialization reads the immutable boot checkpoint. Let it
-        # release those files before refreshing a shared backing store.
-        if self._destination_init_task is not None:
-            if self._destination_init_task.done():
-                await self._destination_init_task
-            else:
-                with _timed(m, "destination_init_wait_s"):
-                    await self._destination_init_task
-        if self._destination_init_error is not None:
-            raise RuntimeError(
-                "weight update destination initialization failed: "
-                f"{self._destination_init_error}"
-            )
-
         await asyncio.to_thread(self.store.refresh)
         pointer = await asyncio.to_thread(self.store.read_pointer)
         if pointer is None:
@@ -538,12 +525,19 @@ class Reconciler:
                         flush_cache=self.flush_cache_on_commit,
                     )
 
-            await self.gate.commit(
-                apply=apply,
-                on_applied=on_applied,
-                pause=self.engine.pause,
-                resume=self.engine.resume,
-            )
+            try:
+                await self.gate.commit(
+                    apply=apply,
+                    on_applied=on_applied,
+                    pause=self.engine.pause,
+                    resume=self.engine.resume,
+                )
+            except UnrecoverableSidecarError:
+                raise
+            except Exception as exc:
+                raise UnrecoverableEngineError(
+                    "weight commit failed; live engine state is uncertain"
+                ) from exc
         self.sync_state = SyncState.FETCHING
         pointer = await asyncio.to_thread(self.store.read_pointer)
         return not self._behind(pointer)  # a mid-pass publish is next tick's work
@@ -576,10 +570,17 @@ class Reconciler:
             self.applied = VersionRef(new_run, self.boot_version)
             self.last_error = None
 
-        await self.gate.commit(
-            apply=apply,
-            on_applied=on_applied,
-            pause=self.engine.pause if was_patched else None,
-            resume=self.engine.resume if was_patched else None,
-            drain_all=True,
-        )
+        try:
+            await self.gate.commit(
+                apply=apply,
+                on_applied=on_applied,
+                pause=self.engine.pause if was_patched else None,
+                resume=self.engine.resume if was_patched else None,
+                drain_all=True,
+            )
+        except UnrecoverableSidecarError:
+            raise
+        except Exception as exc:
+            raise UnrecoverableEngineError(
+                "boot checkpoint restore failed; live engine state is uncertain"
+            ) from exc

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -159,29 +159,35 @@ def test_startup_initializes_update_destination() -> None:
             store=FakeStore(), engine=engine
         )  # unclaimed pool: reconcile is a no-op
         await r.startup()
-        await r._destination_init_task
         assert "initialize_update_destination" in engine.calls
+        assert r.ready
 
     _run(go())
 
 
 @pytest.mark.parametrize(
-    "sync_state,expected",
+    "ready,sync_state,expects_progress",
     [
-        (SyncState.IDLE, False),
-        (SyncState.FETCHING, False),
-        (SyncState.STAGING, False),
-        (SyncState.COMMITTING, True),
-        (SyncState.ERROR, False),
+        (False, SyncState.IDLE, False),
+        (False, SyncState.FETCHING, False),
+        (False, SyncState.STAGING, False),
+        (False, SyncState.COMMITTING, False),
+        (False, SyncState.ERROR, False),
+        (True, SyncState.IDLE, True),
+        (True, SyncState.FETCHING, True),
+        (True, SyncState.STAGING, True),
+        (True, SyncState.COMMITTING, False),
+        (True, SyncState.ERROR, True),
     ],
 )
-def test_engine_health_may_be_stale_only_during_commit(
-    sync_state: SyncState, expected: bool
+def test_engine_progress_expectation_follows_serving_lifecycle(
+    ready: bool, sync_state: SyncState, expects_progress: bool
 ) -> None:
     reconciler = _make_reconciler(store=FakeStore(), engine=FakeEngine())
+    reconciler.ready = ready
     reconciler.sync_state = sync_state
 
-    assert reconciler.engine_health_may_be_stale() is expected
+    assert reconciler.expects_engine_progress() is expects_progress
 
 
 def test_catch_up() -> None:
@@ -370,7 +376,7 @@ def test_run_switch_exposes_paused_reset_to_engine_watchdog() -> None:
         await reset_started.wait()
         assert engine.calls == ["pause", "reset"]
         assert r.sync_state is SyncState.COMMITTING
-        assert r.engine_health_may_be_stale()
+        assert not r.expects_engine_progress()
 
         finish_reset.set()
         await switch
@@ -581,10 +587,12 @@ def test_reconcile_interval_zero_disables_backstop() -> None:
 def test_stage_waits_for_update_destination() -> None:
     async def go() -> None:
         engine = FakeEngine()
+        started = asyncio.Event()
         release = asyncio.Event()
         initialize = engine.initialize_update_destination
 
         async def slow_initialize(boot_version: int = 0) -> None:
+            started.set()
             await release.wait()
             await initialize(boot_version)
 
@@ -596,25 +604,28 @@ def test_stage_waits_for_update_destination() -> None:
         )
         r.applied = VersionRef("r1", 0)  # same run, behind -> stage v2 (no run switch)
         task = asyncio.create_task(r.startup())
-        await asyncio.sleep(0.05)
+        await started.wait()
         assert "stage:2" not in engine.calls
+        assert not r.ready
         release.set()
         await task
         assert engine.calls.index("initialize_update_destination") < engine.calls.index(
             "stage:2"
         )
-        assert r.metrics["destination_init_wait_s"] > 0
+        assert r.ready
         await r.shutdown()
 
     _run(go())
 
 
-def test_boot_weights_serve_before_update_destination_is_ready() -> None:
+def test_boot_weights_wait_for_update_destination() -> None:
     async def go() -> None:
         engine = FakeEngine()
+        started = asyncio.Event()
         release = asyncio.Event()
 
         async def slow_initialize(boot_version: int = 0) -> None:
+            started.set()
             await release.wait()
             engine.initialized_versions.append(boot_version)
             engine.calls.append("initialize_update_destination")
@@ -626,15 +637,15 @@ def test_boot_weights_serve_before_update_destination_is_ready() -> None:
             reconcile_interval=0.0,
         )
         startup = asyncio.create_task(r.startup())
-        while not r.ready:
-            await asyncio.sleep(0)
-        assert r.ready
+        await started.wait()
+        assert not r.ready
         assert r.applied == VersionRef("r1", 0)
         assert "pause" not in engine.calls
         assert not r._destination_ready
         release.set()
         await startup
         assert r._destination_ready
+        assert r.ready
         await r.shutdown()
 
     _run(go())
@@ -643,9 +654,11 @@ def test_boot_weights_serve_before_update_destination_is_ready() -> None:
 def test_store_refresh_waits_for_update_destination() -> None:
     async def go() -> None:
         engine = FakeEngine()
+        started = asyncio.Event()
         release = asyncio.Event()
 
         async def slow_initialize(boot_version: int = 0) -> None:
+            started.set()
             await release.wait()
             engine.initialized_versions.append(boot_version)
             engine.calls.append("initialize_update_destination")
@@ -662,9 +675,8 @@ def test_store_refresh_waits_for_update_destination() -> None:
         store = GuardedStore(VersionRef("r1", 0))
         r = _make_reconciler(store=store, engine=engine, reconcile_interval=0.0)
         startup = asyncio.create_task(r.startup())
-        while not r.ready:
-            await asyncio.sleep(0)
-        assert r.ready
+        await started.wait()
+        assert not r.ready
         assert store.refreshed == 0
 
         release.set()
@@ -691,14 +703,14 @@ def test_update_fails_after_update_destination_initialization_fails() -> None:
         r.applied = VersionRef("r1", 0)
         terminal = asyncio.create_task(r.wait_for_terminal_error())
         await r.startup()
-        assert r.sync_state is SyncState.ERROR
-        assert r.last_error is not None
-        assert "broken destination" in r.last_error
+        assert not r.ready
         assert "stage:2" not in engine.calls
-        assert not terminal.done()
-        terminal.cancel()
-        with pytest.raises(asyncio.CancelledError):
+        with pytest.raises(
+            UnrecoverableEngineError,
+            match="weight update destination initialization failed.*broken destination",
+        ):
             await terminal
+        assert "broken destination" in r.server_info()["terminal_error"]
         await r.shutdown()
 
     _run(go())
@@ -721,6 +733,43 @@ def test_unrecoverable_reconcile_error_reaches_terminal_monitor() -> None:
         with pytest.raises(UnrecoverableEngineError, match="process is gone"):
             await r.wait_for_terminal_error()
         assert r.server_info()["terminal_error"] == "engine process is gone"
+        await r.shutdown()
+
+    _run(go())
+
+
+def test_commit_failure_is_terminal() -> None:
+    async def go() -> None:
+        engine = FakeEngine()
+
+        async def fail_commit(
+            _manifest: VersionManifest,
+            *,
+            flush_cache: bool = False,
+        ) -> None:
+            raise RuntimeError("partial weight copy")
+
+        engine.commit = fail_commit  # type: ignore[method-assign]
+        r = _make_reconciler(
+            store=FakeStore(VersionRef("r1", 1), _delta("r1", 1, files=["v1"])),
+            engine=engine,
+            reconcile_interval=0,
+        )
+        await r.startup()
+
+        with pytest.raises(
+            UnrecoverableEngineError,
+            match="weight commit failed; live engine state is uncertain",
+        ):
+            await r.wait_for_terminal_error()
+        assert not r.ready
+        assert r.applied == VersionRef("r1", 0)
+        assert engine.calls == [
+            "initialize_update_destination",
+            "stage:1",
+            "pause",
+            "resume",
+        ]
         await r.shutdown()
 
     _run(go())

--- a/src/stitch/watchdog.py
+++ b/src/stitch/watchdog.py
@@ -1,8 +1,7 @@
 """Supervise a sidecar's colocated engine and propagate terminal failures.
 
-The reconciler owns weight-sync retries; this module owns process liveness. Keeping
-those policies separate lets a transient store or engine-control error remain
-retryable while a persistently dead local engine tears down the sidecar process.
+The reconciler owns weight-sync recovery and says when inference progress is
+expected. This module owns engine supervision and the sidecar process boundary.
 """
 
 from __future__ import annotations
@@ -67,18 +66,17 @@ class SidecarWatchdog:
 class EngineWatchdog:
     """Turn repeated engine-health failures into one terminal sidecar error.
 
-    An unresponsive health endpoint is ignored while the engine is paused to apply
-    staged weights. Staging itself runs alongside inference and is not exempt: a
-    health failure then is evidence of scheduler starvation or failure. A connection
-    failure is never expected, but still receives the consecutive-failure budget so
-    a one-off socket race does not recycle an otherwise healthy replica.
+    Probe only while the reconciler promises inference progress. Destination
+    initialization and commits supervise their own engine RPCs and may occupy the
+    engine's HTTP loop, so a concurrent health request is not an independent signal.
+    Staging runs alongside inference and remains functionally monitored.
     """
 
     def __init__(
         self,
         engine: Engine,
         *,
-        engine_health_may_be_stale: Callable[[], bool],
+        expects_engine_progress: Callable[[], bool],
         interval: float = 5.0,
         failure_threshold: int = 3,
     ) -> None:
@@ -87,7 +85,7 @@ class EngineWatchdog:
         if failure_threshold < 1:
             raise ValueError("watchdog failure threshold must be positive")
         self._engine = engine
-        self._engine_health_may_be_stale = engine_health_may_be_stale
+        self._expects_engine_progress = expects_engine_progress
         self._interval = interval
         self._failure_threshold = failure_threshold
         self._consecutive_failures = 0
@@ -95,18 +93,14 @@ class EngineWatchdog:
     async def run(self) -> None:
         """Run until cancelled or the engine is conclusively unrecoverable."""
         while True:
+            if not self._expects_engine_progress():
+                self._consecutive_failures = 0
+                await asyncio.sleep(self._interval)
+                continue
+
             health = await self._engine.check_health()
             if health.status is EngineHealthStatus.HEALTHY:
                 self._consecutive_failures = 0
-            elif (
-                health.status is EngineHealthStatus.UNRESPONSIVE
-                and self._engine_health_may_be_stale()
-            ):
-                self._consecutive_failures = 0
-                logger.debug(
-                    "ignoring engine health failure while applying weights: %s",
-                    health.detail,
-                )
             else:
                 self._consecutive_failures += 1
                 logger.warning(
@@ -133,7 +127,7 @@ async def run_server_with_watchdog(
 ) -> None:
     """Run uvicorn and make a terminal watchdog error reach the process boundary."""
     server_task = asyncio.create_task(server.serve(), name="sidecar-server")
-    watchdog_task = asyncio.create_task(watchdog.run(), name="engine-watchdog")
+    watchdog_task = asyncio.create_task(watchdog.run(), name="sidecar-watchdog")
     try:
         done, _pending = await asyncio.wait(
             {server_task, watchdog_task}, return_when=asyncio.FIRST_COMPLETED
@@ -148,7 +142,7 @@ async def run_server_with_watchdog(
         try:
             await watchdog_task
         except BaseException:
-            logger.critical("engine watchdog terminated the sidecar", exc_info=True)
+            logger.critical("sidecar watchdog terminated the process", exc_info=True)
             await _stop_server(server, server_task, timeout=shutdown_timeout)
             raise
         await _stop_server(server, server_task, timeout=shutdown_timeout)

--- a/src/stitch/watchdog_test.py
+++ b/src/stitch/watchdog_test.py
@@ -20,9 +20,11 @@ from stitch.watchdog import (
 class _HealthSequence:
     def __init__(self, *statuses: EngineHealthStatus) -> None:
         self._statuses = iter(statuses)
+        self.checks = 0
         self.checked = asyncio.Event()
 
     async def check_health(self) -> EngineHealth:
+        self.checks += 1
         try:
             status = next(self._statuses)
         except StopIteration:
@@ -47,28 +49,26 @@ class _FakeServer:
 def _watchdog(
     engine: _HealthSequence,
     *,
-    engine_health_may_be_stale: Callable[[], bool] = lambda: False,
+    expects_engine_progress: Callable[[], bool] = lambda: True,
     failure_threshold: int = 2,
 ) -> EngineWatchdog:
     return EngineWatchdog(
         engine,  # type: ignore[arg-type]
-        engine_health_may_be_stale=engine_health_may_be_stale,
+        expects_engine_progress=expects_engine_progress,
         interval=0.001,
         failure_threshold=failure_threshold,
     )
 
 
-def test_expected_unresponsiveness_during_weight_apply_is_recoverable() -> None:
+def test_watchdog_does_not_probe_when_progress_is_not_expected() -> None:
     async def go() -> None:
-        engine = _HealthSequence(
-            EngineHealthStatus.UNRESPONSIVE,
-            EngineHealthStatus.UNRESPONSIVE,
-        )
+        engine = _HealthSequence(EngineHealthStatus.UNRESPONSIVE)
         task = asyncio.create_task(
-            _watchdog(engine, engine_health_may_be_stale=lambda: True).run()
+            _watchdog(engine, expects_engine_progress=lambda: False).run()
         )
-        await asyncio.wait_for(engine.checked.wait(), timeout=1)
+        await asyncio.sleep(0.01)
         assert not task.done()
+        assert engine.checks == 0
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
@@ -89,18 +89,6 @@ def test_transient_idle_failure_does_not_trip_watchdog() -> None:
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
-
-    asyncio.run(go())
-
-
-def test_unreachable_engine_is_terminal_even_during_weight_apply() -> None:
-    async def go() -> None:
-        engine = _HealthSequence(
-            EngineHealthStatus.UNREACHABLE,
-            EngineHealthStatus.UNREACHABLE,
-        )
-        with pytest.raises(UnrecoverableEngineError, match="unreachable"):
-            await _watchdog(engine, engine_health_may_be_stale=lambda: True).run()
 
     asyncio.run(go())
 


### PR DESCRIPTION
## What changed

- Initialize each replica weight-update destination before its first catch-up and before routing traffic to it.
- Run the SGLang functional watchdog only while the reconciler expects inference progress. Initialization and commit RPCs retain their own bounded timeouts.
- Treat destination-initialization and live-weight commit failures as terminal replica failures.
- Supervise the sidecar HTTP boundary independently; a persistently unresponsive sidecar is terminated so Modal replaces the failed Server instead of reporting a graceful Done.
- Update the lifecycle documentation and tests.

## Why

Destination initialization can occupy the SGLang HTTP loop. A concurrent SGLang health probe is therefore not an independent liveness signal and could recycle a healthy replica while its one-time initialization was still running.

The reconciler owns readiness and expected-progress state. The sidecar owns SGLang functional health and propagates terminal errors through its process boundary. The parent probes only the sidecar HTTP boundary, covering a wedged-but-still-listening sidecar that Modal port supervision does not recycle. Modal owns replacement after that port closes.

## Impact

A new replica enters rotation only after destination initialization and first catch-up complete. This intentionally removes startup overlap in exchange for one consistent lifecycle for v0 and mid-run joiners. Steady-state staging still overlaps inference; only commit is exempt from SGLang functional health probing.

## Validation

- `uv run ruff check .`
- `uv run pytest` (218 passed)
- GLM-4.7 Flash BF16 cold-start on one H200 with the production CPU-cache settings:
  - the sidecar remained unready throughout the 56.6s CPU destination initialization without watchdog recycling;
  - it entered rotation at v0 after initialization and catch-up, then both sidecar and SGLang health probes remained healthy;
  - a versioned chat-completion request returned `OK` at weight version 0.
- Modal Server process-exit injection:
  - an injected child-process `RuntimeError` and its message were preserved in the container logs;
  - Modal closed the failed replica tunnel about 15 seconds later and launched its replacement four seconds afterward.
- Modal Server HTTP-hang injection:
  - the exposed port remained open while `/health` and `/metrics` stopped responding;
  - Modal retained the same container for more than 50 seconds, confirming that an independent HTTP-progress probe is required for this failure mode.