### PR TITLE
Gate trainer launch on rollout fleet readiness

### DIFF
--- a/cookbook/common/launch.py
+++ b/cookbook/common/launch.py
@@ -47,14 +47,13 @@ def materialize_node_local_yaml(
 
 
 def deploy_pool_and_spawn(run: Any) -> Any:
-    """The shared body of a recipe's ``launch`` entrypoint: deploy this run's pool, block until its
-    gateway is healthy, then spawn training. ``run`` is the recipe's ``app`` module (its ``app`` /
-    ``APP_NAME`` / ``spawn_train``). Readiness rides the session-routing LB gateway, so the
-    check validates the whole traffic path (router + pool), not just the pool. Returns the
-    trainer call so the recipe can either detach or supervise it."""
+    """Deploy a run's pool, wait for it to be ready, then spawn its trainer."""
     from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
     from stitch.service import await_pool_ready
 
     run.app.deploy()
-    await_pool_ready(ModalFlashLBPool(run.APP_NAME, "Server"))
+    await_pool_ready(
+        ModalFlashLBPool(run.APP_NAME, "Server"),
+        replica_floor=run.modal_cfg.rollout_min_containers,
+    )
     return run.spawn_train()

--- a/cookbook/common/launch_test.py
+++ b/cookbook/common/launch_test.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+from cookbook.common import launch
+from stitch import service
+
+
+def test_deploy_pool_waits_for_readiness_before_spawning(monkeypatch) -> None:
+    events = []
+    run = SimpleNamespace(
+        APP_NAME="app-run",
+        app=SimpleNamespace(deploy=lambda: events.append("deploy")),
+        modal_cfg=SimpleNamespace(rollout_min_containers=32),
+        spawn_train=lambda: events.append("spawn") or "call",
+    )
+
+    def wait(pool, **kwargs):
+        events.append(("ready", pool.app_name, kwargs))
+
+    monkeypatch.setattr(service, "await_pool_ready", wait)
+
+    assert launch.deploy_pool_and_spawn(run) == "call"
+    assert events == [
+        "deploy",
+        ("ready", "app-run", {"replica_floor": 32}),
+        "spawn",
+    ]

--- a/cookbook/miles_disagg/launch.py
+++ b/cookbook/miles_disagg/launch.py
@@ -205,7 +205,10 @@ def _run_attempt(*, supervise: bool) -> None:
         volume = modal.Volume.from_name(run.exp.EXPERIMENT_VOLUME_NAME, version=2)
         target = restore_resume_point(volume, resume_point)
         print(f"Restored {target.identity}; waiting for the recreated pool", flush=True)
-        await_pool_ready(ModalFlashLBPool(run.APP_NAME, "Server"))
+        await_pool_ready(
+            ModalFlashLBPool(run.APP_NAME, "Server"),
+            replica_floor=run.modal_cfg.rollout_min_containers,
+        )
         trainer_call = run.spawn_train()
 
     if not supervise:

--- a/cookbook/miles_disagg/launch_test.py
+++ b/cookbook/miles_disagg/launch_test.py
@@ -159,6 +159,7 @@ def test_resume_restores_pointer_before_pool_readiness(monkeypatch) -> None:
     volume = object()
     run = SimpleNamespace(
         APP_NAME="app-run",
+        modal_cfg=SimpleNamespace(rollout_min_containers=2),
         exp=SimpleNamespace(EXPERIMENT_VOLUME_NAME="runs"),
         app=SimpleNamespace(
             deploy=lambda *, strategy: events.append(("deploy", strategy))
@@ -185,7 +186,7 @@ def test_resume_restores_pointer_before_pool_readiness(monkeypatch) -> None:
     monkeypatch.setattr(
         stitch.service,
         "await_pool_ready",
-        lambda _pool: events.append(("ready",)),
+        lambda _pool, **_kwargs: events.append(("ready",)),
     )
 
     launch._run_attempt(supervise=False)

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -17,6 +17,7 @@ import time
 import uuid
 from collections.abc import Iterable
 from contextlib import asynccontextmanager
+from math import ceil
 from typing import Any, Protocol
 
 from stitch.engines.base import Engine
@@ -34,6 +35,9 @@ from stitch.watchdog import (
 logger = logging.getLogger(__name__)
 
 VERSIONED_ROUTES = ("generate", "v1/chat/completions", "v1/completions")
+
+# Temporary launch threshold; tune as we collect fleet startup and throughput data.
+POOL_READY_FRACTION = 0.75
 
 # Hop-by-hop / rewritten headers the proxy never forwards upstream.
 _DROP_HEADERS = {"host", "content-length", "connection"}
@@ -348,24 +352,57 @@ async def readiness(pool: Pool, *, timeout: float = 15.0) -> PoolState:
 
 
 def await_pool_ready(
-    pool: Pool, *, timeout: float = 20 * 60, interval: float = 30.0
+    pool: Pool,
+    *,
+    replica_floor: int,
+    timeout: float = 60 * 60,
+    interval: float = 30.0,
 ) -> bool:
-    """Block until the pool's gateway answers /health 200 — Flash holds requests through a
-    cold-starting pool, so the first rollout/hot-load meets a ready pool instead of a 5xx storm
-    while engines load. Returns True when ready; on timeout, warns and returns False (the caller
-    proceeds anyway — the trainer retries). A launch-script helper: synchronous, unlike ``readiness``."""
-    import httpx
+    """Block until the configured fraction of ``replica_floor`` reports routing readiness.
 
-    gateway = pool.gateway_url().rstrip("/")
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        try:
-            if httpx.get(f"{gateway}/health", timeout=10).status_code == 200:
-                return True
-        except Exception:  # noqa: BLE001
-            pass
-        time.sleep(interval)
-    print(
-        f"WARNING: pool at {gateway} not ready after {timeout:.0f}s; proceeding (the trainer retries)"
-    )
-    return False
+    Readiness is counted from each replica's ``/server_info`` rather than inferred from the
+    pool gateway: one healthy replica makes a gateway probe succeed, but is not enough capacity
+    for a large rollout launch. Once the floor is met, the gateway is checked as well so the
+    trainer sees a working traffic path. Timeout is terminal so training never starts below the
+    requested floor. This launch-script helper is synchronous, unlike :func:`readiness`.
+    """
+    if replica_floor < 1:
+        raise ValueError(f"replica_floor must be positive, got {replica_floor}")
+    min_ready = ceil(POOL_READY_FRACTION * replica_floor)
+
+    async def wait() -> bool:
+        import httpx
+
+        deadline = time.monotonic() + timeout
+        last_counts: tuple[int, int] | None = None
+        while time.monotonic() < deadline:
+            state = await readiness(pool)
+            counts = (
+                sum(replica.ready for replica in state.replicas),
+                len(state.replicas),
+            )
+            if counts != last_counts:
+                print(
+                    f"Rollout fleet readiness: {counts[0]}/{min_ready} required "
+                    f"({counts[1]} discovered)",
+                    flush=True,
+                )
+                last_counts = counts
+            if counts[0] >= min_ready:
+                try:
+                    gateway = (await pool.gateway_url_async()).rstrip("/")
+                    async with httpx.AsyncClient(trust_env=False) as client:
+                        response = await client.get(f"{gateway}/health", timeout=10)
+                    if response.status_code == 200:
+                        return True
+                except Exception:  # noqa: BLE001
+                    pass
+            await asyncio.sleep(interval)
+
+        ready, discovered = last_counts or (0, 0)
+        raise TimeoutError(
+            f"rollout pool not ready after {timeout:.0f}s: "
+            f"{ready}/{min_ready} required ({discovered} discovered)"
+        )
+
+    return asyncio.run(wait())

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from types import SimpleNamespace
 from typing import Any
 
 import httpx
+import pytest
 
+import stitch.service as stitch_service
 from stitch.engines.base import Engine
 from stitch.service import create_app
 from stitch.sync import AdmissionGate
-from stitch.types import VersionRef
+from stitch.types import PoolState, ReplicaState, VersionRef
 
 
 class _ProxyEngine(Engine):
@@ -262,3 +265,77 @@ def test_metrics_bypasses_weight_admission_before_first_pointer(monkeypatch):
         assert gate_sidecar.gate.active_requests == 0
 
     asyncio.run(go())
+
+
+def test_await_pool_ready_waits_for_replica_threshold(monkeypatch) -> None:
+    states = iter(
+        [
+            PoolState(
+                [
+                    ReplicaState(ready=True),
+                    ReplicaState(ready=True),
+                    ReplicaState(),
+                    ReplicaState(),
+                ]
+            ),
+            PoolState(
+                [
+                    ReplicaState(ready=True),
+                    ReplicaState(ready=True),
+                    ReplicaState(ready=True),
+                    ReplicaState(),
+                ]
+            ),
+        ]
+    )
+
+    async def pool_readiness(_pool):
+        return next(states)
+
+    async def no_sleep(_seconds):
+        pass
+
+    class Pool:
+        async def gateway_url_async(self):
+            return "http://gateway"
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            pass
+
+        async def get(self, _url, **_kwargs):
+            return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(stitch_service, "readiness", pool_readiness)
+    monkeypatch.setattr(stitch_service.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: Client())
+
+    assert stitch_service.await_pool_ready(Pool(), replica_floor=4, interval=0)
+
+
+def test_await_pool_ready_fails_closed_below_threshold(monkeypatch) -> None:
+    async def pool_readiness(_pool):
+        return PoolState([ReplicaState(ready=True), ReplicaState()])
+
+    async def no_sleep(_seconds):
+        pass
+
+    times = iter([0.0, 0.0, 2.0])
+    monkeypatch.setattr(stitch_service, "readiness", pool_readiness)
+    monkeypatch.setattr(stitch_service.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(
+        stitch_service,
+        "time",
+        SimpleNamespace(monotonic=lambda: next(times)),
+    )
+
+    with pytest.raises(
+        TimeoutError,
+        match=r"1/2 required \(2 discovered\)",
+    ):
+        stitch_service.await_pool_ready(
+            object(), replica_floor=2, timeout=1, interval=0
+        )

--- a/src/stitch/types.py
+++ b/src/stitch/types.py
@@ -132,6 +132,7 @@ _SYNC_STATES = {s.value for s in SyncState}
 class ReplicaState:
     """One replica's ``server_info``: the version it has applied + its reconcile lifecycle."""
 
+    ready: bool = False
     applied: VersionRef | None = None
     sync_state: SyncState | None = None
     reason: str | None = None
@@ -145,13 +146,14 @@ class ReplicaState:
     def from_dict(cls, data: dict[str, Any]) -> ReplicaState:
         applied, state = data.get("applied"), data.get("sync_state")
         return cls(
+            ready=bool(data.get("ready", False)),
             applied=VersionRef.parse(applied) if applied else None,
             sync_state=SyncState(state) if state in _SYNC_STATES else None,
             reason=data.get("reason"),
         )
 
     def to_dict(self) -> dict[str, Any]:
-        data: dict[str, Any] = {}
+        data: dict[str, Any] = {"ready": self.ready}
         if self.applied is not None:
             data["applied"] = self.applied.identity
         if self.sync_state is not None:


### PR DESCRIPTION
## Summary

- define pool readiness using the temporary `POOL_READY_FRACTION = 0.75` threshold
- enforce the readiness gate in `deploy_pool_and_spawn()` before trainer creation
- apply the same pool-readiness primitive in the resume launch sequence after pointer restoration
- verify the session-routing front door after the replica threshold is met

## Why

The previous pool-readiness check treated one successful gateway health check as sufficient. A large run could therefore dispatch its entire rollout batch as soon as one or two engines were ready, overloading their queues and producing 503/502 transport failures.

Pool orchestration now waits for the current fleet threshold and fails closed after the startup timeout. The 75% value is isolated for future tuning as we collect fleet startup and throughput data. Trainer creation remains responsible only for launching training.

## Validation

- `uv run ruff check src cookbook`
- `uv run ruff format --check src cookbook`
- `uv run pytest -q` — 221 passed