### PR TITLE
Honor explicit Miles run IDs

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -84,10 +84,10 @@ uv run --extra modal python -m cookbook.miles_disagg.launch
 uv run --extra modal python -m cookbook.slime_disagg.launch
 ```
 
-The launcher creates an eight-character run ID, deploys a run-scoped rollout
-pool, waits for its gateway, and starts the trainer. It prints the app name and
-stop command. Repeating the command creates a separate run and checkpoint
-lineage.
+The launcher creates an eight-character run ID unless `RUN_ID` is set explicitly,
+deploys a run-scoped rollout pool, waits for its gateway, and starts the trainer.
+It prints the app name and stop command. Repeating the command creates a separate
+run and checkpoint lineage.
 
 #### Resume a Miles run
 

--- a/cookbook/miles_disagg/launch.py
+++ b/cookbook/miles_disagg/launch.py
@@ -75,7 +75,7 @@ def main() -> None:
         run_id = args.resume_from
     else:
         resume_point = None
-        run_id = uuid.uuid4().hex[:8]
+        run_id = os.environ.get("RUN_ID") or uuid.uuid4().hex[:8]
     _set_attempt_env(
         os.environ,
         run_id=run_id,
@@ -86,7 +86,7 @@ def main() -> None:
 
 def _run_auto_resume(exp: Any, resume_from: str | None) -> None:
     validate_auto_resume_config(exp.miles)
-    run_id = resume_from or uuid.uuid4().hex[:8]
+    run_id = resume_from or os.environ.get("RUN_ID") or uuid.uuid4().hex[:8]
     resume_point = (
         _resume_point_for_run(exp, resume_from) if resume_from is not None else None
     )

--- a/cookbook/miles_disagg/launch_test.py
+++ b/cookbook/miles_disagg/launch_test.py
@@ -35,6 +35,7 @@ def test_supervised_attempt_preserves_run_id(monkeypatch) -> None:
 def test_auto_resume_uses_checkpoint_from_failed_attempt(monkeypatch) -> None:
     launches = []
     point = ResumePoint(19, "first-re", "/trainer", "/rollout")
+    monkeypatch.delenv("RUN_ID", raising=False)
     monkeypatch.setattr(launch.uuid, "uuid4", lambda: SimpleNamespace(hex="first-rest"))
     monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
     monkeypatch.setattr(launch, "_resume_point_for_run", lambda _exp, run_id: point)
@@ -69,6 +70,21 @@ def test_auto_resume_starts_from_requested_checkpoint(monkeypatch) -> None:
     launch._run_auto_resume(SimpleNamespace(miles=object()), "old")
 
     assert launches == [{"run_id": "old", "resume_point": point}]
+
+
+def test_auto_resume_honors_explicit_run_id(monkeypatch) -> None:
+    launches = []
+    monkeypatch.setenv("RUN_ID", "hero-run")
+    monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
+    monkeypatch.setattr(
+        launch,
+        "_run_supervised_attempt",
+        lambda **kwargs: launches.append(kwargs) or subprocess.CompletedProcess([], 0),
+    )
+
+    launch._run_auto_resume(SimpleNamespace(miles=object()), None)
+
+    assert launches == [{"run_id": "hero-run", "resume_point": None}]
 
 
 def test_set_attempt_env_uses_one_resume_payload() -> None:
@@ -135,6 +151,38 @@ def test_manual_launch_runs_directly_without_attempt_subprocess(monkeypatch) -> 
 
     assert configured == {"run_id": "old", "resume_point": point}
     assert ran == [False]
+
+
+def test_fresh_manual_launch_honors_explicit_run_id(monkeypatch) -> None:
+    configured = {}
+    monkeypatch.setattr(
+        launch,
+        "_parser",
+        lambda: SimpleNamespace(
+            parse_args=lambda: SimpleNamespace(
+                run_attempt=False,
+                auto_resume=False,
+                resume_from=None,
+            )
+        ),
+    )
+    monkeypatch.setenv("EXPERIMENT_CONFIG", "test")
+    monkeypatch.setenv("RUN_ID", "hero-run")
+    monkeypatch.setattr(
+        launch.importlib,
+        "import_module",
+        lambda _name: SimpleNamespace(miles=object()),
+    )
+    monkeypatch.setattr(
+        launch,
+        "_set_attempt_env",
+        lambda _env, **kwargs: configured.update(kwargs),
+    )
+    monkeypatch.setattr(launch, "_run_attempt", lambda *, supervise: None)
+
+    launch.main()
+
+    assert configured == {"run_id": "hero-run", "resume_point": None}
 
 
 def test_supervised_attempt_leaves_pool_deployed_when_trainer_fails(


### PR DESCRIPTION
## Summary

- honor an explicitly supplied `RUN_ID` for fresh Miles launches
- preserve that identity across `--auto-resume` attempts
- retain generated IDs when `RUN_ID` is absent and `--resume-from` identity for resumed runs
- document the optional explicit run ID

## Why

The launcher previously overwrote `RUN_ID` with a generated value, so users could not choose a stable identity for a fresh auto-resumed run.

## Validation

- `uv run ruff check src cookbook`
- `uv run ruff format --check src cookbook`
- `uv run pytest -q` — 223 passed