### PR TITLE
Profile GLM-5.2 FP8 weight updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ activation pauses the engine.
 | GLM-5.2 mixed NVFP4/BF16 | 4 | CPU cache; canonical in RAM | 116.4 s | 3.30 s | 119.7 s |
 | GLM-5.2 mixed NVFP4/BF16 | 4 | CPU cache; canonical on NVMe | 164.5 s | 3.26 s | 167.7 s |
 | GLM-5.2 mixed NVFP4/BF16 | 4 | Disk checkpoint | 128.0 s | 299.38 s | 427.4 s |
+| GLM-5.2 FP8 | 4 | CPU cache; canonical in RAM | 108.0 s | 3.44 s | 111.5 s |
+| GLM-5.2 FP8 | 4 | CPU cache; canonical on NVMe | 340.2 s | 3.47 s | 343.7 s |
+| GLM-5.2 FP8 | 4 | Disk checkpoint | 183.8 s | 239.60 s | 423.4 s |
 | Kimi K3 MXFP4 | 8 | CPU cache; canonical in RAM | 120.5 s | 3.84 s | 124.3 s |
 | Kimi K3 MXFP4 | 8 | CPU cache; canonical on NVMe | 1,089.7 s | 3.83 s | 1,093.6 s |
 | Kimi K3 MXFP4 | 8 | Disk checkpoint | 704.0 s | 300.37 s | 1,004.4 s |
@@ -77,8 +80,8 @@ are therefore host-specific rather than model-only transformation costs. K3's
 canonical checkpoint and eight rank images occupy 3.22 TB before engine and
 staging overhead; the all-RAM sample reached 3.29 TB after staging. Its supplied
 recipe therefore keeps the canonical checkpoint on NVMe to preserve operating
-headroom. The mixed GLM-5.2 and K3 deltas are 10.04 GB and 24.13 GB compressed,
-respectively.
+headroom. The GLM-5.2 FP8, mixed GLM-5.2, and K3 deltas are 11.71 GB, 10.04 GB,
+and 24.13 GB compressed, respectively.
 
 Each profiler reconstructs and checksums the complete target and validates
 generation before, during, and after activation. See

--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -187,12 +187,14 @@ Measured component sizes are:
 | GLM-4.5-Air FP8 | 4 | 112.6 GB | 27.2 GB × 4 | 1.64 GB |
 | Kimi K2.6 NVFP4 | 4 | about 595 GB | about 151 GB × 4 | 4.09 GB |
 | GLM-5.2 mixed NVFP4/BF16 | 4 | 617.6 GB | 179.3 GB × 4 | 20.94 GB |
+| GLM-5.2 FP8 | 4 | 755.6 GB | 189.4 GB × 4 | 20.94 GB |
 | Kimi K3 MXFP4 | 8 | 1.561 TB | 207.5 GB × 8 | 0.14 GB maximum |
 
 Allow additional memory for the engine process, delta decoding, and bounded
 loader staging. The supplied GLM-4.5 recipe requests `(512 GiB, 2 TiB)`;
 GLM-5.2, Kimi K2.6, and Kimi K3 request `(1 TiB, 3 TiB)`, expressed as
-`(request, limit)`.
+`(request, limit)`. GLM-5.2 FP8 reached 1.63 TB with both the canonical and rank
+images in RAM, and 1.19 TB with the canonical checkpoint on NVMe.
 
 All runtime storages are prepared and committed. Element-wise sparsity reduces
 the compressed delta transport and storage, but not the full-target checksum,

--- a/tools/profiling/glm5_2_fp8_delta_weight_update.py
+++ b/tools/profiling/glm5_2_fp8_delta_weight_update.py
@@ -1,0 +1,240 @@
+"""Profile one GLM-5.2 FP8 delta weight update on four B300s.
+
+The entrypoint downloads the pinned public checkpoint, constructs one
+deterministic element-wise synthetic delta, and verifies one complete update.
+
+    MODAL_FUNCTION_RUNTIME=runc uv run --extra modal modal run -d \
+      tools/profiling/glm5_2_fp8_delta_weight_update.py \
+      --update-mode cpu --canonical-storage memory
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import modal
+
+from cookbook.common.constants import HF_CACHE_PATH
+from cookbook.common.serving_image import build_serving_image
+from tools.profiling._delta_weight_update import (
+    WeightUpdateSpec,
+    modal_runtime_label,
+    parse_canonical_storage,
+    parse_update_destination,
+    parse_update_mode,
+    run_delta_weight_update,
+)
+from tools.profiling._hf_checkpoint import (
+    download_snapshot,
+    materialize_checkpoint_view,
+)
+from tools.profiling._synthetic_delta import (
+    SyntheticDeltaSpec,
+    prepare_standard_delta,
+    synthetic_delta_profile_id,
+)
+
+APP_NAME = "profile-glm5-2-fp8-delta-weight-update"
+EXPERIMENT = "glm5_2_fp8"
+ROLLOUT_MODEL = "zai-org/GLM-5.2-FP8"
+ROLLOUT_REVISION = "ba978f7d347eaf65d22f1a86833408afdb953541"
+ROLLOUT_GPUS = 4
+DELTA_MOUNT = "/synthetic-delta"
+DELTA_SPEC = SyntheticDeltaSpec(
+    checkpoint_format="fp8",
+    quantized_value_density=0.006,
+    high_precision_value_density=0.01,
+    output_shards=4,
+    output_shard_layout="miles-pp4-layer-placement-v1",
+    # The target-model optimizer does not update the bundled MTP layer.
+    immutable_prefixes=("model.layers.78.",),
+)
+DELTA_ID = f"glm5-2-fp8/{ROLLOUT_REVISION}/{synthetic_delta_profile_id(DELTA_SPEC)}"
+DELTA_SOURCE_DIR = f"{DELTA_MOUNT}/{DELTA_ID}"
+HF_SNAPSHOT_DIR = (
+    f"{HF_CACHE_PATH}/models--zai-org--GLM-5.2-FP8/snapshots/{ROLLOUT_REVISION}"
+)
+LOCAL_CHECKPOINT_ROOT = "/local-checkpoint/glm5-2-fp8"
+BASE_CHECKPOINT_DIR = f"{LOCAL_CHECKPOINT_ROOT}/base"
+LOCAL_TARGET_CHECKPOINT_DIR = f"{LOCAL_CHECKPOINT_ROOT}/target"
+LOCAL_CANONICAL_CHECKPOINT_DIR = f"{LOCAL_CHECKPOINT_ROOT}/canonical"
+SGLANG_CACHE_PATH = "/root/.cache/sglang"
+_REPO_ROOT = Path(__file__).resolve().parents[2] if modal.is_local() else Path("/root")
+
+SGLANG_SERVER_ARGS = {
+    "--served-model-name": ROLLOUT_MODEL,
+    "--load-format": "fastsafetensors",
+    "--model-loader-extra-config": '{"enable_gds":false}',
+    "--weight-loader-drop-cache-after-load": "",
+    "--dtype": "auto",
+    "--reasoning-parser": "glm45",
+    "--tool-call-parser": "glm47",
+    "--dist-timeout": "3600",
+    "--watchdog-timeout": "3600",
+    "--context-length": "32768",
+    "--attention-backend": "dsa",
+    "--dsa-prefill-backend": "flashmla_sparse",
+    "--dsa-decode-backend": "flashmla_kv",
+    "--dsa-topk-backend": "flashinfer",
+    "--page-size": "64",
+    "--ep-size": str(ROLLOUT_GPUS),
+    "--moe-dense-tp-size": "1",
+    "--moe-runner-backend": "flashinfer_trtllm_routed",
+    "--disable-shared-experts-fusion": "",
+    "--mem-fraction-static": "0.80",
+    "--chunked-prefill-size": "16384",
+    "--max-running-requests": "24",
+    "--decode-log-interval": "100",
+    "--random-seed": "42",
+    "--skip-server-warmup": "",
+}
+
+app = modal.App(APP_NAME)
+hf_cache_volume = modal.Volume.from_name(
+    "huggingface-cache", create_if_missing=True, version=2
+)
+delta_volume = modal.Volume.from_name(
+    "stitch-synthetic-deltas", create_if_missing=True, version=2
+)
+sglang_cache_volume = modal.Volume.from_name(
+    "sglang-cache", create_if_missing=True, version=2
+)
+download_image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install("huggingface_hub[hf_transfer]")
+    .env(
+        {
+            "HF_XET_HIGH_PERFORMANCE": "1",
+            "HF_HUB_ENABLE_HF_TRANSFER": "1",
+        }
+    )
+    .add_local_dir(
+        str(_REPO_ROOT / "tools"),
+        remote_path="/root/tools",
+        ignore=["**/__pycache__", "**/*.pyc"],
+    )
+    .add_local_dir(
+        str(_REPO_ROOT / "cookbook"),
+        remote_path="/root/cookbook",
+        ignore=["**/__pycache__", "**/*.pyc"],
+    )
+)
+serving_image = build_serving_image(
+    hf_cache_path=str(HF_CACHE_PATH),
+    experiment=EXPERIMENT,
+    extra_env={"SGLANG_DG_CACHE_DIR": f"{SGLANG_CACHE_PATH}/deep_gemm"},
+).add_local_dir(
+    str(_REPO_ROOT / "tools"),
+    remote_path="/root/tools",
+    ignore=["**/__pycache__", "**/*.pyc"],
+)
+
+
+def _pipeline_shard_for_tensor(name: str) -> int:
+    if name == "model.embed_tokens.weight":
+        return 0
+    if name in {"lm_head.weight", "model.norm.weight"}:
+        return 3
+    prefix = "model.layers."
+    if not name.startswith(prefix):
+        raise ValueError(f"no pipeline placement for tensor {name!r}")
+    layer = int(name[len(prefix) :].partition(".")[0])
+    for stage, layer_end in enumerate((18, 38, 58, 78)):
+        if layer < layer_end:
+            return stage
+    raise ValueError(f"layer {layer} is outside the target model")
+
+
+@app.function(
+    image=download_image,
+    cpu=32,
+    memory=(16 * 1024, 256 * 1024),
+    volumes={str(HF_CACHE_PATH): hf_cache_volume},
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    timeout=6 * 60 * 60,
+)
+def download_model() -> str:
+    return download_snapshot(
+        ROLLOUT_MODEL,
+        ROLLOUT_REVISION,
+        str(HF_CACHE_PATH),
+        commit=hf_cache_volume.commit,
+    )
+
+
+@app.function(
+    image=serving_image,
+    cpu=64,
+    memory=(64 * 1024, 512 * 1024),
+    volumes={
+        str(HF_CACHE_PATH): hf_cache_volume.read_only(),
+        DELTA_MOUNT: delta_volume,
+    },
+    timeout=6 * 60 * 60,
+)
+def prepare_delta() -> dict:
+    return prepare_standard_delta(
+        HF_SNAPSHOT_DIR,
+        DELTA_SOURCE_DIR,
+        spec=DELTA_SPEC,
+        commit=delta_volume.commit,
+        output_shard_for_tensor=_pipeline_shard_for_tensor,
+    )
+
+
+@app.function(
+    image=serving_image,
+    gpu=f"B300:{ROLLOUT_GPUS}",
+    cpu=64,
+    memory=(1024 * 1024, 3 * 1024 * 1024),
+    # Disk mode reconstructs the complete 756 GB target on local storage.
+    ephemeral_disk=2 * 1024 * 1024,
+    volumes={
+        str(HF_CACHE_PATH): hf_cache_volume.read_only(),
+        DELTA_MOUNT: delta_volume.read_only(),
+        SGLANG_CACHE_PATH: sglang_cache_volume,
+    },
+    timeout=6 * 60 * 60,
+)
+def benchmark(
+    update_mode: str,
+    canonical_storage: str | None,
+    runtime: str,
+    sample_id: str,
+) -> dict:
+    materialize_checkpoint_view(HF_SNAPSHOT_DIR, BASE_CHECKPOINT_DIR)
+    return run_delta_weight_update(
+        WeightUpdateSpec(
+            model_name="GLM-5.2 FP8",
+            base_checkpoint_dir=BASE_CHECKPOINT_DIR,
+            local_target_checkpoint_dir=LOCAL_TARGET_CHECKPOINT_DIR,
+            local_canonical_checkpoint_dir=LOCAL_CANONICAL_CHECKPOINT_DIR,
+            server_args=SGLANG_SERVER_ARGS,
+            tp_size=ROLLOUT_GPUS,
+        ),
+        source_dir=DELTA_SOURCE_DIR,
+        target_version=1,
+        update_mode=parse_update_mode(update_mode),
+        canonical_storage=parse_canonical_storage(canonical_storage),
+        runtime=runtime,
+        sample_id=sample_id,
+    )
+
+
+@app.local_entrypoint()
+def main(
+    update_mode: str = "disk",
+    canonical_storage: str | None = None,
+    sample_id: str = "1",
+    skip_preparation: bool = False,
+) -> None:
+    mode, storage = parse_update_destination(update_mode, canonical_storage)
+    if not skip_preparation:
+        download_model.remote()
+        prepare_delta.remote()
+    benchmark.remote(
+        mode,
+        storage,
+        modal_runtime_label(),
+        sample_id,
+    )


### PR DESCRIPTION
## What changed

- add a self-contained TP4 B300 profiler for the pinned public `zai-org/GLM-5.2-FP8` checkpoint
- construct a deterministic, element-wise FP8 delta with per-tensor target checksums while excluding the immutable MTP layer
- exercise disk, CPU/NVMe, and CPU/RAM destinations using the pinned Stitch SGLang v0.5.17 runtime
- document the verified update timings, delta size, and CPU-cache memory footprint

## Results

All three destinations reconstructed and verified all 116,465 changed tensors, changed from v0, and reproduced identical target text, token IDs, and logprobs.

| Destination | Preparation | Engine pause | Total |
| --- | ---: | ---: | ---: |
| CPU/RAM | 108.0 s | 3.44 s | 111.5 s |
| CPU/NVMe | 340.2 s | 3.47 s | 343.7 s |
| Disk | 183.8 s | 239.60 s | 423.4 s |

The synthetic delta is 11.71 GB compressed. CPU/RAM peaked at 1.63 TB; CPU/NVMe peaked at 1.19 TB.

## Validation

- complete live Modal runs on B300:4 under runc for all three destinations
- target checksum verification for every changed tensor
- exact deterministic generation fingerprint agreement across destinations
- `uv run ruff format --check tools/profiling/glm5_2_fp8_delta_weight_update.py`
- `uv run ruff check tools/profiling/glm5_2_fp8_delta_weight_update.py`
- `uv run pytest` (223 passed)