### PR TITLE
Make rollout recovery reentrant

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -74,26 +74,36 @@ dependent format conversion. Dataset preparation is independent.
 
 ### 5. Launch an isolated run
 
-Use the launcher for the selected trainer:
+Deploy the run's pool, then launch its trainer (Slime swaps in
+`cookbook.slime_disagg`):
 
 ```bash
-# Miles
-uv run --extra modal python -m cookbook.miles_disagg.launch
+export RUN_ID=myrun01  # any unique id; each id is its own run and lineage
 
-# Slime
-uv run --extra modal python -m cookbook.slime_disagg.launch
+uv run --extra modal modal deploy -m cookbook.miles_disagg.app
+uv run --extra modal python -m cookbook.miles_disagg.launch
 ```
 
-The launcher creates an eight-character run ID unless `RUN_ID` is set explicitly,
-deploys a run-scoped rollout pool, waits for its gateway, and starts the trainer.
-It prints the app name and stop command. Repeating the command creates a separate
-run and checkpoint lineage.
+The launcher waits for the pool's floor and spawns the trainer; it prints the
+app name and stop command. It never deploys — the pool's lifecycle belongs to
+explicit `modal deploy` invocations (the same command applies infra changes
+later), and a missing pool fails fast with that instruction.
 
 #### Resume a Miles run
 
-Use the same recipe and Modal environment as the source run. A resumable point
-is the latest saved Megatron checkpoint with a matching complete Hugging Face
-export. Resume it once with:
+Recovery is automatic. The trainer runs under Modal retries with an
+attempt-invariant input, and every attempt derives its state from the run
+volume: the newest saved Megatron checkpoint whose Hugging Face export and
+published version both exist. A failed attempt resumes from that pair — live
+replicas ahead of it rewind in place — and a run that dies before its first
+pair restarts from scratch. If the pair is iteration 119, the run resumes at
+v120 and publishes v121 next; version numbers never change meaning across
+attempts. Resume requires the Modal Volume store, `update_weights_interval = 1`,
+`save_interval`, `save_hf`, and optimizer/RNG checkpointing — a launch without
+those warns and restarts from scratch on retry.
+
+Past the retry budget (ten attempts of up to 24 hours each), or to take over a
+run manually, relaunch with the same recipe and Modal environment:
 
 ```bash
 export EXPERIMENT_CONFIG=your_config_name
@@ -103,25 +113,10 @@ uv run --extra modal python -m cookbook.miles_disagg.launch \
   --resume-from existing_run_id
 ```
 
-The launcher keeps the existing run ID, recreates its rollout deployment, and
-resets `latest` before replacement engines load the saved checkpoint. If the
-checkpoint is v120, the run resumes at v120 and publishes a replacement v121
-next. Resume currently requires the Modal Volume store and
-`update_weights_interval = 1`.
-
-Add automatic resume to a fresh or resumed launch with:
-
-```bash
-uv run --extra modal python -m cookbook.miles_disagg.launch \
-  --resume-from existing_run_id \
-  --auto-resume
-```
-
-`--auto-resume` stays attached to the trainer. An unexpected exit recreates the
-same run from its newest complete checkpoint and retries until the trainer
-returns normally. Stop it with Ctrl-C. It is off by default and requires
-`save_interval`, `save_hf`, and optimizer/RNG checkpointing. A fresh run becomes
-resumable after its first complete Megatron/Hugging Face checkpoint pair.
+This reuses the run's identity and its pool — a live pool is never redeployed
+or replaced on the launch path — and spawns a fresh trainer call that
+supersedes the previous one (each run records its active trainer call ID) and
+resumes exactly like a retry.
 
 With the Modal Volume store, complete Hugging Face checkpoints also accelerate
 elastic rollout startup. When a Miles recipe saves checkpoints and updates
@@ -262,6 +257,7 @@ Each experiment Volume contains only run-scoped state:
 /stitch/
 └── <run-id>/
     ├── latest
+    ├── trainer_call_id
     ├── updates/weight_vNNNNNN/
     ├── checkpoints/
     ├── hf_checkpoints/weight_vNNNNNN/
@@ -270,9 +266,11 @@ Each experiment Volume contains only run-scoped state:
 ```
 
 The training framework owns `updates/` and the saved checkpoints; Stitch owns
-`latest`. Resume keeps the same run ID, restores `latest` to the checkpoint,
-and replaces the abandoned update suffix as training continues. Each finished
-trainer attempt writes a separate log; use Modal app logs while it is running.
+`latest` and `trainer_call_id` (the run's active trainer call — a superseded
+call exits instead of fighting a newer spawn). A resuming attempt restores
+`latest` to the checkpoint's published version and replaces the abandoned
+update suffix as training continues. Each finished trainer attempt writes a
+separate log; use Modal app logs while it is running.
 
 Datasets are independent of models and runs:
 

--- a/cookbook/common/launch.py
+++ b/cookbook/common/launch.py
@@ -46,14 +46,34 @@ def materialize_node_local_yaml(
         setattr(cfg, field, path)
 
 
-def deploy_pool_and_spawn(run: Any) -> Any:
-    """Deploy a run's pool, wait for it to be ready, then spawn its trainer."""
+def spawn_on_pool(run: Any) -> Any:
+    """Spawn a run's trainer on its deployed pool. The launch path never deploys
+    or redeploys — the pool's whole lifecycle belongs to explicit ``modal
+    deploy`` invocations of the run's app — so a missing pool fails fast with
+    that instruction instead."""
     from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
     from stitch.service import await_pool_ready
 
-    run.app.deploy()
-    await_pool_ready(
-        ModalFlashLBPool(run.APP_NAME, "Server"),
-        replica_floor=run.modal_cfg.rollout_min_containers,
-    )
+    pool = ModalFlashLBPool(run.APP_NAME, "Server")
+    if not _pool_reachable(pool):
+        raise SystemExit(
+            f"No deployed pool for {run.APP_NAME!r}. Deploy it first:\n"
+            f"  EXPERIMENT_CONFIG={os.environ.get('EXPERIMENT_CONFIG', '<experiment>')} "
+            f"RUN_ID={os.environ['RUN_ID']} "
+            f"uv run --extra modal modal deploy -m {run.__name__}"
+        )
+    await_pool_ready(pool, replica_floor=run.modal_cfg.rollout_min_containers)
     return run.spawn_train()
+
+
+def _pool_reachable(pool: Any) -> bool:
+    """Whether the pool's gateway resolves; a stopped or never-deployed app does
+    not. Only those two outcomes fail the launch — an unexpected error propagates
+    rather than second-guess a live pool."""
+    from modal.exception import NotFoundError
+
+    try:
+        pool.gateway_url()
+    except (NotFoundError, RuntimeError):
+        return False
+    return True

--- a/cookbook/common/launch_test.py
+++ b/cookbook/common/launch_test.py
@@ -1,26 +1,41 @@
 from types import SimpleNamespace
 
+import pytest
+
 from cookbook.common import launch
 from stitch import service
 
 
-def test_deploy_pool_waits_for_readiness_before_spawning(monkeypatch) -> None:
-    events = []
-    run = SimpleNamespace(
+def _run(events: list) -> SimpleNamespace:
+    return SimpleNamespace(
+        __name__="cookbook.miles_disagg.app",
         APP_NAME="app-run",
-        app=SimpleNamespace(deploy=lambda: events.append("deploy")),
         modal_cfg=SimpleNamespace(rollout_min_containers=32),
         spawn_train=lambda: events.append("spawn") or "call",
     )
 
-    def wait(pool, **kwargs):
-        events.append(("ready", pool.app_name, kwargs))
 
-    monkeypatch.setattr(service, "await_pool_ready", wait)
+def test_spawn_waits_for_the_deployed_pool_floor(monkeypatch) -> None:
+    events = []
+    monkeypatch.setattr(launch, "_pool_reachable", lambda _pool: True)
+    monkeypatch.setattr(
+        service,
+        "await_pool_ready",
+        lambda pool, **kwargs: events.append(("ready", pool.app_name, kwargs)),
+    )
 
-    assert launch.deploy_pool_and_spawn(run) == "call"
+    assert launch.spawn_on_pool(_run(events)) == "call"
     assert events == [
-        "deploy",
         ("ready", "app-run", {"replica_floor": 32}),
         "spawn",
     ]
+
+
+def test_spawn_fails_fast_with_the_deploy_instruction(monkeypatch) -> None:
+    events = []
+    monkeypatch.setenv("RUN_ID", "myrun01")
+    monkeypatch.setattr(launch, "_pool_reachable", lambda _pool: False)
+
+    with pytest.raises(SystemExit, match="modal deploy -m cookbook.miles_disagg.app"):
+        launch.spawn_on_pool(_run(events))
+    assert events == []  # never deploys, never spawns

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -53,7 +53,7 @@ from cookbook.miles_disagg.config import YAML_CONFIG_FIELDS, MilesConfig
 from cookbook.miles_disagg.resume import (
     RESUME_POINT_ENV,
     ResumePoint,
-    saved_checkpoint_version,
+    export_version,
     wait_for_restored_pointer,
 )
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
@@ -274,10 +274,7 @@ class Server:
                         rollout_id=saved_rollout_id
                     ):
                         continue
-                    saved_version = saved_checkpoint_version(
-                        saved_rollout_id,
-                        resumed=resume_point is not None,
-                    )
+                    saved_version = export_version(saved_rollout_id)
                     if boot_version <= saved_version <= latest.version:
                         checkpoints.append((saved_version, marker.parent))
                 if checkpoints:
@@ -423,6 +420,11 @@ class Trainer:
             list(getattr(exp, "MEGATRON_RUNTIME_PATCHES", [])),
             MEGATRON_PATH,
             "Megatron patch",
+        )
+        process.apply_git_patches(
+            list(trainer_image.MILES_RUNTIME_PATCHES),
+            MILES_ROOT,
+            "Miles patch",
         )
         self.rank = rank
         process.start_host_mem_monitor()  # per-node host-RAM trace

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -5,12 +5,12 @@ Server (sglang + stitch sidecar) is the shared common one; the Trainer runs mile
 and publishes XOR deltas through the configured checkpoint store.
 
 Prepare the checkpoints once first (a separate app, so prep never spins up the rollout Server
-floor — see ``cookbook.miles_disagg.prep_app``), then launch a run with one command — it mints a
-unique run id, stands up that run's pool, and starts training. A fresh launch is isolated even
-from an identical-config launch; resume retains the existing run id (see
-``cookbook.miles_disagg.launch``):
+floor — see ``cookbook.miles_disagg.prep_app``), then deploy the run's pool and launch its
+trainer under one run id. A fresh run id is isolated even from an identical-config run;
+resume retains the existing one (see ``cookbook.miles_disagg.launch``):
 
-    EXPERIMENT_CONFIG=glm45_air_fp8 uv run --extra modal python -m cookbook.miles_disagg.launch
+    EXPERIMENT_CONFIG=glm45_air_fp8 RUN_ID=myrun01 uv run --extra modal modal deploy -m cookbook.miles_disagg.app
+    EXPERIMENT_CONFIG=glm45_air_fp8 RUN_ID=myrun01 uv run --extra modal python -m cookbook.miles_disagg.launch
 
 Config access is uniform: the experiment module ``exp`` is the single source of truth —
 its ``exp.modal`` (infra), ``exp.miles`` (training), and ``exp.<CONST>`` are read directly;
@@ -455,14 +455,12 @@ class Trainer:
             resume_point = prepare_attempt(
                 run_volume, run_id=RUN_ID, save_hf=getattr(cfg, "save_hf", None)
             )
+        pool = ModalFlashLBPool(APP_NAME, "Server")
         # Post-restore, replicas ahead of the checkpoint leave rotation to
         # restage, so the ready floor counts only converged capacity.
-        await_pool_ready(
-            ModalFlashLBPool(APP_NAME, "Server"),
-            replica_floor=modal_cfg.rollout_min_containers,
-        )
+        await_pool_ready(pool, replica_floor=modal_cfg.rollout_min_containers)
 
-        cfg.rollout_endpoint_url = ModalFlashLBPool(APP_NAME, "Server").gateway_url()
+        cfg.rollout_endpoint_url = pool.gateway_url()
         if resume_point is not None:
             cfg.load = resume_point.trainer_checkpoint
             cfg.hf_checkpoint = resume_point.rollout_checkpoint
@@ -554,9 +552,10 @@ def _build_train_cmd(cfg: MilesConfig) -> str:
 
 # ── Entrypoints (preparation lives in a separate app: cookbook.miles_disagg.prep_app) ──
 def spawn_train() -> Any:
-    """Spawn the trainer on this run's already-deployed pool (config ships as data, so config
-    edits run without a redeploy; infra changes still require one). Recording the call id
-    fences the run: a superseded call's next attempt exits instead of fighting this one."""
+    """Spawn the trainer on this run's already-deployed pool (config ships as data, so
+    config edits run without a redeploy; infra changes still require one). Recording the
+    call id fences the run: a superseded call's next attempt exits instead of fighting
+    this one."""
     trainer = modal.Cls.from_name(APP_NAME, "Trainer")()
     call = trainer.train.spawn(miles_cfg.to_payload())
     record_trainer_call(run_volume, RUN_ID, call.object_id)

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -54,10 +54,14 @@ from cookbook.miles_disagg.resume import (
     RESUME_POINT_ENV,
     ResumePoint,
     export_version,
+    prepare_attempt,
+    read_trainer_call,
+    record_trainer_call,
     wait_for_restored_pointer,
 )
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
 from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
+from stitch.service import await_pool_ready
 from stitch.types import VersionRef
 
 EXPERIMENT = os.environ[
@@ -396,6 +400,11 @@ _MULTINODE = miles_cfg.n_train_nodes > 1
     timeout=24 * 60 * MINUTES,
     startup_timeout=20 * MINUTES,
     scaledown_window=30 * MINUTES,
+    # Modal owns the retry loop: a failed attempt restarts with identical input
+    # and train() re-derives its resume state from the run volume. Containers
+    # are NOT single-use: non-zero ranks return their input immediately while
+    # serving Ray workers, so reaping a returned input would dissolve the gang.
+    retries=modal.Retries(initial_delay=0.0, max_retries=10),
     include_source=False,
     **({"experimental_options": {"efa_enabled": True}} if _MULTINODE else {}),
 )
@@ -406,7 +415,7 @@ _MULTINODE = miles_cfg.n_train_nodes > 1
 )
 class Trainer:
     """miles actor cluster. Ray comes up once per container in enter(), so back-to-back
-    runs reuse it."""
+    attempts reuse it."""
 
     @modal.enter()
     def start_ray(self) -> None:
@@ -442,20 +451,41 @@ class Trainer:
         )
 
     @modal.method()
-    def train(self, payload: dict, resume_payload: str | None = None) -> None:
-        """Run one training job from a MilesConfig payload (see MilesConfig.to_payload)."""
+    def train(self, payload: dict) -> None:
+        """Run one training attempt from a MilesConfig payload (see MilesConfig.to_payload).
+
+        Reentrant: the input is attempt-invariant, and each attempt re-derives its
+        resume state from the run volume — the newest complete checkpoint pair, or
+        a scratch restart before the first one — so a Modal retry continues the
+        run instead of replaying the original attempt's world."""
         for volume in train_volumes.values():
             volume.reload()
 
-        resume_point = (
-            ResumePoint.from_json(resume_payload)
-            if resume_payload is not None
-            else None
-        )
         cfg = MilesConfig.from_payload(payload)
         launch.materialize_node_local_yaml(cfg, "te_precision_config_file")
         if self.rank != 0:
             return
+
+        call_id = modal.current_function_call_id()
+        recorded = read_trainer_call(run_volume, RUN_ID)
+        if recorded is not None and call_id is not None and recorded != call_id:
+            print(
+                f"Run {RUN_ID} was taken over by trainer call {recorded}; exiting",
+                flush=True,
+            )
+            return
+
+        resume_point = None
+        if STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME:
+            resume_point = prepare_attempt(
+                run_volume, run_id=RUN_ID, save_hf=getattr(cfg, "save_hf", None)
+            )
+        # Post-restore, replicas ahead of the checkpoint leave rotation to
+        # restage, so the ready floor counts only converged capacity.
+        await_pool_ready(
+            ModalFlashLBPool(APP_NAME, "Server"),
+            replica_floor=modal_cfg.rollout_min_containers,
+        )
 
         cfg.rollout_endpoint_url = ModalFlashLBPool(APP_NAME, "Server").gateway_url()
         if resume_point is not None:
@@ -550,12 +580,11 @@ def _build_train_cmd(cfg: MilesConfig) -> str:
 # ── Entrypoints (preparation lives in a separate app: cookbook.miles_disagg.prep_app) ──
 def spawn_train() -> Any:
     """Spawn the trainer on this run's already-deployed pool (config ships as data, so config
-    edits run without a redeploy; infra changes still require one)."""
+    edits run without a redeploy; infra changes still require one). Recording the call id
+    fences the run: a superseded call's next attempt exits instead of fighting this one."""
     trainer = modal.Cls.from_name(APP_NAME, "Trainer")()
-    call = trainer.train.spawn(
-        miles_cfg.to_payload(),
-        os.environ.get(RESUME_POINT_ENV),
-    )
+    call = trainer.train.spawn(miles_cfg.to_payload())
+    record_trainer_call(run_volume, RUN_ID, call.object_id)
     print(f"Spawned train on {APP_NAME}: {call.object_id}")
     return call
 

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -51,13 +51,10 @@ from cookbook.common.constants import (
 from cookbook.miles_disagg import trainer_image
 from cookbook.miles_disagg.config import YAML_CONFIG_FIELDS, MilesConfig
 from cookbook.miles_disagg.resume import (
-    RESUME_POINT_ENV,
-    ResumePoint,
     export_version,
     prepare_attempt,
     read_trainer_call,
     record_trainer_call,
-    wait_for_restored_pointer,
 )
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
 from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
@@ -74,17 +71,6 @@ MILES_LOCAL_DIR = os.environ.get(
 exp = importlib.import_module(f"cookbook.miles_disagg.configs.{EXPERIMENT}")
 modal_cfg = exp.modal
 miles_cfg = exp.miles
-
-
-def _resume_point() -> ResumePoint | None:
-    if payload := os.environ.get(RESUME_POINT_ENV):
-        return ResumePoint.from_json(payload)
-    return None
-
-
-def _rollout_boot_checkpoint() -> str:
-    point = _resume_point()
-    return point.rollout_checkpoint if point is not None else miles_cfg.hf_checkpoint
 
 
 # Minted once for a run and retained across resume. The same identity scopes the
@@ -116,7 +102,6 @@ image = trainer_image.build_trainer_image(
     image_run_commands=getattr(exp, "TRAINER_IMAGE_RUN_COMMANDS", ()),
     extra_env=STORE_DEPLOYMENT.image_environment,
 )
-# Server containers re-import this module, so persist this attempt's resume point.
 server_image = serving_image.build_serving_image(
     hf_cache_path=str(HF_CACHE_PATH),
     experiment=EXPERIMENT,
@@ -124,7 +109,6 @@ server_image = serving_image.build_serving_image(
     extra_packages=STORE_DEPLOYMENT.extra_packages,
     extra_env={
         **(getattr(exp, "SGLANG_SERVER_ENV", None) or {}),
-        RESUME_POINT_ENV: os.environ.get(RESUME_POINT_ENV, ""),
         **STORE_DEPLOYMENT.image_environment,
     },
     runtime=getattr(exp, "SGLANG_RUNTIME", serving_image.DEFAULT_SGLANG_RUNTIME),
@@ -173,7 +157,7 @@ train_volumes = {
 app = modal.App(APP_NAME)
 
 SGLANG_SERVER_ARGS = {
-    "--served-model-name": _rollout_boot_checkpoint(),
+    "--served-model-name": miles_cfg.hf_checkpoint,
     **(
         {}
         if "--cuda-graph-config" in exp.SGLANG_SERVER_ARGS
@@ -226,19 +210,8 @@ class Server:
     def startup(self) -> None:
         STORE_DEPLOYMENT.bootstrap_credentials()
         store_config = STORE_DEPLOYMENT.hook_config(APP_NAME)
-        resume_point = _resume_point()
-        if resume_point is not None:
-            wait_for_restored_pointer(
-                run_volume,
-                resume_point,
-                timeout=SERVER_STARTUP_TIMEOUT,
-            )
-        model_name = (
-            resume_point.rollout_checkpoint
-            if resume_point is not None
-            else miles_cfg.hf_checkpoint
-        )
-        boot_version = resume_point.version if resume_point is not None else 0
+        model_name = miles_cfg.hf_checkpoint
+        boot_version = 0
         save_hf = getattr(miles_cfg, "save_hf", None)
         # TODO: support larger update intervals once saved checkpoints expose the
         # exact published weight version instead of only Miles' rollout ID.
@@ -254,7 +227,9 @@ class Server:
                 raise ValueError("save_hf must be a run-relative path")
 
             # Read complete HF exports and the published pointer from one Volume
-            # snapshot. A save ahead of latest is not eligible yet.
+            # snapshot. A save ahead of latest is not eligible yet — including
+            # the abandoned suffix of a resume whose restore has not landed;
+            # the reconciler rewinds a replica that raced it.
             run_volume.reload()
             store = storage.create_store(
                 store_config["stitch_store_backend"],
@@ -279,7 +254,7 @@ class Server:
                     ):
                         continue
                     saved_version = export_version(saved_rollout_id)
-                    if boot_version <= saved_version <= latest.version:
+                    if saved_version <= latest.version:
                         checkpoints.append((saved_version, marker.parent))
                 if checkpoints:
                     saved_version, checkpoint = max(checkpoints)

--- a/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46_e2e.py
+++ b/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46_e2e.py
@@ -1,0 +1,68 @@
+"""Kill-and-resume e2e: the Qwen3-30B NVFP4 recipe with a fast checkpoint cadence.
+
+Reuses the base recipe's prepared checkpoints and dataset; this derivation only
+sets the checkpoint policy resume needs, a light rollout load so steps take
+minutes on the single-replica floor, and a run-scoped app/volume identity. Kill
+the trainer after the first complete pair; its Modal retry must resume from it,
+rewinding the live replica in place.
+
+Known Miles caveat: the qwen3moe bridge-mode ``save_hf`` export writes an
+incomplete weight map, so a replica that boots from an export cannot apply
+later deltas (its forward staging fails and retries while it keeps serving).
+"""
+
+from __future__ import annotations
+
+from cookbook.common.config import ModalConfig
+from cookbook.miles_disagg.configs.qwen3_30b_a3b_nvfp4_46 import *  # noqa: F401,F403
+from cookbook.miles_disagg.configs.qwen3_30b_a3b_nvfp4_46 import (
+    _Miles,
+)
+from cookbook.miles_disagg.configs.qwen3_30b_a3b_nvfp4_46 import (
+    modal as _base_modal,
+)
+
+APP_NAME = "stitch-qwen3-30b-nvfp4-e2e"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-qwen3-30b-nvfp4-e2e"
+
+# Megatron saves spill through the trainer's ephemeral disk (see the base
+# recipe's save_interval note); the e2e writes several. Host RAM must cover the
+# CPU-offloaded optimizer plus the saves' write-back cache — the 1 TiB default
+# OOMed at the second save.
+modal = ModalConfig(
+    **vars(_base_modal),
+    trainer_ephemeral_disk_mib=1024 * 1024,
+    trainer_memory_mib=(1024 * 1024, 1792 * 1024),
+)
+
+
+class _E2EMiles(_Miles):
+    num_rollout = 7
+    save_interval = 3
+    save_hf = "hf_checkpoints/weight_v{rollout_id:06d}"
+
+    # The pinned Miles routes an external rollout endpoint through the v2
+    # session server (v1 assumes a Miles-managed router); the default v2
+    # picker/postprocessor cover single-turn math prompts.
+    use_session_server = "v2"
+    session_server_port = 21000
+    session_server_startup_timeout_seconds = 180
+    # The default generate builds Miles-router URLs; the hub's single_turn
+    # honors rollout_endpoint_url (the runtime Miles patch). The GLM recipes
+    # instead route through custom session-agent functions.
+    custom_generate_function_path = "miles.rollout.generate_hub.single_turn.generate"
+    pause_generation_mode = "in_place"  # overlap weight sync, as the GLM recipes do
+    # The default rollout loop aborts stragglers through the Miles router; the
+    # fully-async loop is the external-fleet path the GLM recipes run.
+    fully_async = True
+    async_max_concurrent_samples = 16
+    async_data_buffer_capacity_factor = 3.0
+    async_unused_samples_handler = "drop"
+
+    rollout_batch_size = 8
+    n_samples_per_prompt = 4
+    global_batch_size = 32
+    rollout_max_response_len = 3072
+
+
+miles = _E2EMiles()

--- a/cookbook/miles_disagg/launch.py
+++ b/cookbook/miles_disagg/launch.py
@@ -1,16 +1,22 @@
-"""Launch an isolated Miles/Stitch run, optionally resuming its saved checkpoint.
+"""Launch a Miles/Stitch run's trainer on its deployed pool.
 
-A run's pool is a deployed Flash app the trainer reaches by name, so the run id has to be in the
-app name before either half runs — which is why deploy and launch can't be one CLI call. This
-closes that: mint the id, deploy ``app.py``'s pool under it, wait for it to be ready, then spawn
-the trainer. A resume keeps that identity and recreates the rollout deployment
-from its latest complete trainer/rollout checkpoint.
+Mint or accept the run id, wait for the pool's floor, then spawn the trainer.
+The pool's lifecycle belongs to explicit deploys — first bring it up (and later
+change its infra) with the same run id:
 
-    EXPERIMENT_CONFIG=glm45_air_fp8 uv run --extra modal python -m cookbook.miles_disagg.launch
+    EXPERIMENT_CONFIG=glm45_air_fp8 RUN_ID=myrun01 uv run --extra modal modal deploy -m cookbook.miles_disagg.app
+    EXPERIMENT_CONFIG=glm45_air_fp8 RUN_ID=myrun01 uv run --extra modal python -m cookbook.miles_disagg.launch
 
-A plain script, not a ``modal run`` entrypoint: ``App.deploy()`` only persists outside a ``modal
-run`` session (inside one the deployed app is torn down with the session). Minting the id here,
-before importing the pool module, also lets the pool's app name resolve from ``RUN_ID`` at import.
+Recovery is Modal's job, not this script's: the trainer retries with identical
+input and re-derives its resume state from the run volume (see
+``cookbook.miles_disagg.resume``), so nothing here supervises a running trainer
+and a live pool is never redeployed or replaced here. ``--resume-from RUN_ID``
+reuses an existing run's identity — for a run past its retry budget or a manual
+takeover; the new trainer call supersedes the old one and resumes like any
+retry.
+
+Minting the id here, before importing the pool module, lets the pool's app name
+resolve from ``RUN_ID`` at import.
 """
 
 from __future__ import annotations
@@ -18,23 +24,10 @@ from __future__ import annotations
 import argparse
 import importlib
 import os
-import subprocess
-import sys
 import uuid
-from collections.abc import MutableMapping
 from typing import Any
 
-import modal
-
-from cookbook.miles_disagg.resume import (
-    RESUME_POINT_ENV,
-    ResumePoint,
-    ResumePointNotFound,
-    resolve_resume_point,
-    restore_resume_point,
-    validate_auto_resume_config,
-    validate_resume_config,
-)
+from cookbook.miles_disagg.resume import validate_resumable_config
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -42,186 +35,43 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--resume-from",
         metavar="RUN_ID",
-        help="resume RUN_ID from its latest complete Megatron/HF checkpoint pair",
-    )
-    parser.add_argument(
-        "--auto-resume",
-        action="store_true",
-        help="wait for training and recover unexpected termination from its latest checkpoint",
-    )
-    parser.add_argument(
-        "--run-attempt",
-        action="store_true",
-        help=argparse.SUPPRESS,
+        help="reuse RUN_ID; its trainer resumes from the newest complete checkpoint pair",
     )
     return parser
 
 
 def main() -> None:
     args = _parser().parse_args()
-    if args.run_attempt:
-        _run_attempt(supervise=True)
-        return
-
     experiment = os.environ["EXPERIMENT_CONFIG"]
     exp = importlib.import_module(f"cookbook.miles_disagg.configs.{experiment}")
-    if args.auto_resume:
-        _run_auto_resume(exp, args.resume_from)
-        return
 
     if args.resume_from is not None:
-        validate_resume_config(exp.miles)
-        resume_point = _resume_point_for_run(exp, args.resume_from)
+        validate_resumable_config(exp.miles)
         run_id = args.resume_from
     else:
-        resume_point = None
         run_id = os.environ.get("RUN_ID") or uuid.uuid4().hex[:8]
-    _set_attempt_env(
-        os.environ,
-        run_id=run_id,
-        resume_point=resume_point,
-    )
-    _run_attempt(supervise=False)
+        _warn_unless_resumable(exp.miles)
+    os.environ["RUN_ID"] = run_id
 
-
-def _run_auto_resume(exp: Any, resume_from: str | None) -> None:
-    validate_auto_resume_config(exp.miles)
-    run_id = resume_from or os.environ.get("RUN_ID") or uuid.uuid4().hex[:8]
-    resume_point = (
-        _resume_point_for_run(exp, resume_from) if resume_from is not None else None
-    )
-    while True:
-        result = _run_supervised_attempt(
-            run_id=run_id,
-            resume_point=resume_point,
-        )
-        if result.returncode == 0:
-            return
-
-        resume_point = _resume_point_after_failure(exp, run_id, resume_point)
-        print(
-            f"Trainer stopped unexpectedly; resuming run {run_id} from "
-            f"checkpoint v{resume_point.version}",
-            flush=True,
-        )
-
-
-def _resume_point_for_run(exp: Any, run_id: str) -> ResumePoint:
-    from cookbook.common import storage
-
-    if storage.StoreDeployment.from_environment().backend != storage.MODAL_VOLUME:
-        raise ValueError("Miles resume currently requires the Modal Volume store")
-    volume = modal.Volume.from_name(exp.EXPERIMENT_VOLUME_NAME, version=2)
-    resume_point = resolve_resume_point(
-        volume,
-        source_run_id=run_id,
-        save_hf=exp.miles.save_hf,
-    )
-    print(
-        f"Resolved resume checkpoint: run_id={resume_point.source_run_id}, "
-        f"version={resume_point.version}, "
-        f"trainer={resume_point.trainer_checkpoint}, "
-        f"rollout={resume_point.rollout_checkpoint}",
-        flush=True,
-    )
-    return resume_point
-
-
-def _resume_point_after_failure(
-    exp: Any, failed_run_id: str, previous: ResumePoint | None
-) -> ResumePoint:
-    try:
-        return _resume_point_for_run(exp, failed_run_id)
-    except ResumePointNotFound:
-        if previous is None:
-            raise
-        print(
-            f"Run {failed_run_id} produced no newer complete checkpoint; "
-            f"retrying checkpoint v{previous.version}",
-            flush=True,
-        )
-        return previous
-
-
-def _set_attempt_env(
-    env: MutableMapping[str, str],
-    *,
-    run_id: str,
-    resume_point: ResumePoint | None,
-) -> None:
-    env["RUN_ID"] = run_id
-    if resume_point is None:
-        env.pop(RESUME_POINT_ENV, None)
-        print(f"Launching fresh run {run_id}", flush=True)
-        return
-    if resume_point.source_run_id != run_id:
-        raise ValueError(
-            f"resume checkpoint belongs to run {resume_point.source_run_id!r}, "
-            f"not {run_id!r}"
-        )
-    env[RESUME_POINT_ENV] = resume_point.to_json()
-    print(
-        f"Resuming run {run_id} from checkpoint v{resume_point.version}; "
-        f"Stitch boot={run_id}/weight_v{resume_point.version:06d}",
-        flush=True,
-    )
-
-
-def _run_supervised_attempt(
-    *, run_id: str, resume_point: ResumePoint | None
-) -> subprocess.CompletedProcess:
-    env = os.environ.copy()
-    _set_attempt_env(env, run_id=run_id, resume_point=resume_point)
-
-    return subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "cookbook.miles_disagg.launch",
-            "--run-attempt",
-        ],
-        env=env,
-        check=False,
-    )
-
-
-def _run_attempt(*, supervise: bool) -> None:
     from cookbook.common import launch
-    from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
-    from stitch.service import await_pool_ready
 
     run = importlib.import_module("cookbook.miles_disagg.app")
-    resume_point = (
-        ResumePoint.from_json(payload)
-        if (payload := os.environ.get(RESUME_POINT_ENV))
-        else None
-    )
-    if resume_point is None:
-        trainer_call = launch.deploy_pool_and_spawn(run)
-    else:
-        # Replacement servers block before engine startup until this pointer is
-        # restored, so none can reconcile against the abandoned suffix.
-        run.app.deploy(strategy="recreate")
-        volume = modal.Volume.from_name(run.exp.EXPERIMENT_VOLUME_NAME, version=2)
-        target = restore_resume_point(volume, resume_point)
-        print(f"Restored {target.identity}; waiting for the recreated pool", flush=True)
-        await_pool_ready(
-            ModalFlashLBPool(run.APP_NAME, "Server"),
-            replica_floor=run.modal_cfg.rollout_min_containers,
-        )
-        trainer_call = run.spawn_train()
-
-    if not supervise:
-        print(
-            f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; "
-            f"stop it with: modal app stop {run.APP_NAME}"
-        )
-        return
+    call = launch.spawn_on_pool(run)
     print(
-        f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; "
-        "the auto-resume launcher is supervising its trainer"
+        f"run {run_id} up on {run.APP_NAME}; trainer call {call.object_id} "
+        f"retries and resumes on its own — stop the run with: modal app stop {run.APP_NAME}"
     )
-    trainer_call.get()
+
+
+def _warn_unless_resumable(cfg: Any) -> None:
+    try:
+        validate_resumable_config(cfg)
+    except ValueError as exc:
+        print(
+            f"WARNING: this config is not resumable ({exc}); "
+            "a trainer retry restarts from scratch",
+            flush=True,
+        )
 
 
 if __name__ == "__main__":

--- a/cookbook/miles_disagg/launch_test.py
+++ b/cookbook/miles_disagg/launch_test.py
@@ -22,7 +22,7 @@ def test_supervised_attempt_preserves_run_id(monkeypatch) -> None:
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(launch.subprocess, "run", run)
-    point = ResumePoint(9, "old", "/trainer", "/rollout")
+    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
 
     launch._run_supervised_attempt(run_id="old", resume_point=point)
 
@@ -34,7 +34,7 @@ def test_supervised_attempt_preserves_run_id(monkeypatch) -> None:
 
 def test_auto_resume_uses_checkpoint_from_failed_attempt(monkeypatch) -> None:
     launches = []
-    point = ResumePoint(19, "first-re", "/trainer", "/rollout")
+    point = ResumePoint(19, 18, "first-re", "/trainer", "/rollout")
     monkeypatch.delenv("RUN_ID", raising=False)
     monkeypatch.setattr(launch.uuid, "uuid4", lambda: SimpleNamespace(hex="first-rest"))
     monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
@@ -55,7 +55,7 @@ def test_auto_resume_uses_checkpoint_from_failed_attempt(monkeypatch) -> None:
 
 
 def test_auto_resume_starts_from_requested_checkpoint(monkeypatch) -> None:
-    point = ResumePoint(9, "old", "/trainer", "/rollout")
+    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
     launches = []
     monkeypatch.setattr(launch.uuid, "uuid4", lambda: SimpleNamespace(hex="new"))
     monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
@@ -89,7 +89,7 @@ def test_auto_resume_honors_explicit_run_id(monkeypatch) -> None:
 
 def test_set_attempt_env_uses_one_resume_payload() -> None:
     env = {"STITCH_UNUSED": "value"}
-    point = ResumePoint(9, "old", "/trainer", "/rollout")
+    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
 
     launch._set_attempt_env(env, run_id="old", resume_point=point)
 
@@ -109,7 +109,7 @@ def test_set_attempt_env_clears_a_stale_resume_point() -> None:
 
 
 def test_set_attempt_env_rejects_cross_run_resume() -> None:
-    point = ResumePoint(9, "old", "/trainer", "/rollout")
+    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
 
     with pytest.raises(ValueError, match="belongs to run"):
         launch._set_attempt_env({}, run_id="new", resume_point=point)
@@ -117,7 +117,7 @@ def test_set_attempt_env_rejects_cross_run_resume() -> None:
 
 def test_manual_launch_runs_directly_without_attempt_subprocess(monkeypatch) -> None:
     exp = SimpleNamespace(miles=object())
-    point = ResumePoint(9, "old", "/trainer", "/rollout")
+    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
     configured = {}
     ran = []
     monkeypatch.setattr(
@@ -203,7 +203,7 @@ def test_supervised_attempt_leaves_pool_deployed_when_trainer_fails(
 
 def test_resume_restores_pointer_before_pool_readiness(monkeypatch) -> None:
     events = []
-    point = ResumePoint(9, "run", "/trainer", "/rollout")
+    point = ResumePoint(9, 8, "run", "/trainer", "/rollout")
     volume = object()
     run = SimpleNamespace(
         APP_NAME="app-run",
@@ -250,7 +250,7 @@ def test_resume_restores_pointer_before_pool_readiness(monkeypatch) -> None:
 def test_auto_resume_reuses_previous_checkpoint_when_attempt_has_no_new_checkpoint(
     monkeypatch,
 ) -> None:
-    previous = ResumePoint(9, "old", "/trainer", "/rollout")
+    previous = ResumePoint(9, 8, "old", "/trainer", "/rollout")
 
     def missing(_exp, _run_id):
         raise ResumePointNotFound("no checkpoint")

--- a/cookbook/miles_disagg/launch_test.py
+++ b/cookbook/miles_disagg/launch_test.py
@@ -1,270 +1,106 @@
 from __future__ import annotations
 
-import subprocess
 from types import SimpleNamespace
 
 import pytest
 
 from cookbook.common import launch as common_launch
 from cookbook.miles_disagg import launch
-from cookbook.miles_disagg.resume import (
-    RESUME_POINT_ENV,
-    ResumePoint,
-    ResumePointNotFound,
-)
 
 
-def test_supervised_attempt_preserves_run_id(monkeypatch) -> None:
-    captured = {}
-
-    def run(command, *, env, check):
-        captured.update(command=command, env=env, check=check)
-        return subprocess.CompletedProcess(command, 0)
-
-    monkeypatch.setattr(launch.subprocess, "run", run)
-    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
-
-    launch._run_supervised_attempt(run_id="old", resume_point=point)
-
-    assert captured["env"]["RUN_ID"] == "old"
-    assert ResumePoint.from_json(captured["env"][RESUME_POINT_ENV]) == point
-    assert captured["command"][-1] == "--run-attempt"
-    assert captured["check"] is False
+def _resumable() -> SimpleNamespace:
+    return SimpleNamespace(
+        save_interval=20,
+        save_hf="hf_checkpoints/weight_v{rollout_id:06d}",
+    )
 
 
-def test_auto_resume_uses_checkpoint_from_failed_attempt(monkeypatch) -> None:
-    launches = []
-    point = ResumePoint(19, 18, "first-re", "/trainer", "/rollout")
+def _launch(
+    monkeypatch,
+    *,
+    argv_resume_from: str | None,
+    miles: object | None = None,
+) -> tuple[dict, list[str]]:
+    """Run launch.main() with the config and app modules stubbed out."""
+    spawned: dict = {}
+    prints: list[str] = []
+    exp = SimpleNamespace(miles=miles if miles is not None else _resumable())
+    run = SimpleNamespace(APP_NAME="app-run")
+
+    def import_module(name: str):
+        return exp if name.endswith(".configs.test") else run
+
+    def ensure(actual_run):
+        spawned["run"] = actual_run
+        spawned["run_id"] = launch.os.environ["RUN_ID"]
+        return SimpleNamespace(object_id="fc-1")
+
+    monkeypatch.setenv("EXPERIMENT_CONFIG", "test")
+    monkeypatch.setattr(launch.importlib, "import_module", import_module)
+    monkeypatch.setattr(common_launch, "spawn_on_pool", ensure)
+    monkeypatch.setattr(
+        launch,
+        "_parser",
+        lambda: SimpleNamespace(
+            parse_args=lambda: SimpleNamespace(resume_from=argv_resume_from)
+        ),
+    )
+    monkeypatch.setattr(
+        "builtins.print",
+        lambda *args, **kwargs: prints.append(" ".join(map(str, args))),
+    )
+
+    launch.main()
+    return spawned, prints
+
+
+def test_fresh_launch_mints_a_run_id(monkeypatch) -> None:
     monkeypatch.delenv("RUN_ID", raising=False)
-    monkeypatch.setattr(launch.uuid, "uuid4", lambda: SimpleNamespace(hex="first-rest"))
-    monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
-    monkeypatch.setattr(launch, "_resume_point_for_run", lambda _exp, run_id: point)
+    monkeypatch.setattr(
+        launch.uuid, "uuid4", lambda: SimpleNamespace(hex="feedc0dedeadbeef")
+    )
 
-    def launch_attempt(**kwargs):
-        launches.append(kwargs)
-        return subprocess.CompletedProcess([], 1 if len(launches) == 1 else 0)
+    spawned, _prints = _launch(monkeypatch, argv_resume_from=None)
 
-    monkeypatch.setattr(launch, "_run_supervised_attempt", launch_attempt)
-
-    launch._run_auto_resume(SimpleNamespace(miles=object()), None)
-
-    assert launches == [
-        {"run_id": "first-re", "resume_point": None},
-        {"run_id": "first-re", "resume_point": point},
-    ]
+    assert spawned["run_id"] == "feedc0de"
+    assert spawned["run"].APP_NAME == "app-run"
 
 
-def test_auto_resume_starts_from_requested_checkpoint(monkeypatch) -> None:
-    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
-    launches = []
-    monkeypatch.setattr(launch.uuid, "uuid4", lambda: SimpleNamespace(hex="new"))
-    monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
-    monkeypatch.setattr(launch, "_resume_point_for_run", lambda _exp, _run_id: point)
-
-    def launch_attempt(**kwargs):
-        launches.append(kwargs)
-        return subprocess.CompletedProcess([], 0)
-
-    monkeypatch.setattr(launch, "_run_supervised_attempt", launch_attempt)
-
-    launch._run_auto_resume(SimpleNamespace(miles=object()), "old")
-
-    assert launches == [{"run_id": "old", "resume_point": point}]
-
-
-def test_auto_resume_honors_explicit_run_id(monkeypatch) -> None:
-    launches = []
+def test_fresh_launch_honors_explicit_run_id(monkeypatch) -> None:
     monkeypatch.setenv("RUN_ID", "hero-run")
-    monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
-    monkeypatch.setattr(
-        launch,
-        "_run_supervised_attempt",
-        lambda **kwargs: launches.append(kwargs) or subprocess.CompletedProcess([], 0),
-    )
 
-    launch._run_auto_resume(SimpleNamespace(miles=object()), None)
+    spawned, _prints = _launch(monkeypatch, argv_resume_from=None)
 
-    assert launches == [{"run_id": "hero-run", "resume_point": None}]
+    assert spawned["run_id"] == "hero-run"
 
 
-def test_set_attempt_env_uses_one_resume_payload() -> None:
-    env = {"STITCH_UNUSED": "value"}
-    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
+def test_resume_reuses_the_run_id(monkeypatch) -> None:
+    monkeypatch.delenv("RUN_ID", raising=False)
 
-    launch._set_attempt_env(env, run_id="old", resume_point=point)
+    spawned, _prints = _launch(monkeypatch, argv_resume_from="old-run")
 
-    assert env == {
-        "STITCH_UNUSED": "value",
-        "RUN_ID": "old",
-        RESUME_POINT_ENV: point.to_json(),
-    }
+    assert spawned["run_id"] == "old-run"
 
 
-def test_set_attempt_env_clears_a_stale_resume_point() -> None:
-    env = {RESUME_POINT_ENV: "stale"}
-
-    launch._set_attempt_env(env, run_id="fresh", resume_point=None)
-
-    assert env == {"RUN_ID": "fresh"}
-
-
-def test_set_attempt_env_rejects_cross_run_resume() -> None:
-    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
-
-    with pytest.raises(ValueError, match="belongs to run"):
-        launch._set_attempt_env({}, run_id="new", resume_point=point)
+def test_resume_requires_a_resumable_config(monkeypatch) -> None:
+    with pytest.raises(ValueError, match="requires save_hf"):
+        _launch(
+            monkeypatch,
+            argv_resume_from="old-run",
+            miles=SimpleNamespace(save_interval=20, save_hf=None),
+        )
 
 
-def test_manual_launch_runs_directly_without_attempt_subprocess(monkeypatch) -> None:
-    exp = SimpleNamespace(miles=object())
-    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
-    configured = {}
-    ran = []
-    monkeypatch.setattr(
-        launch,
-        "_parser",
-        lambda: SimpleNamespace(
-            parse_args=lambda: SimpleNamespace(
-                run_attempt=False,
-                auto_resume=False,
-                resume_from="old",
-            )
-        ),
-    )
-    monkeypatch.setenv("EXPERIMENT_CONFIG", "test")
-    monkeypatch.setattr(launch.importlib, "import_module", lambda _name: exp)
-    monkeypatch.setattr(launch, "validate_resume_config", lambda _cfg: None)
-    monkeypatch.setattr(launch, "_resume_point_for_run", lambda _exp, _run_id: point)
-    monkeypatch.setattr(
-        launch,
-        "_set_attempt_env",
-        lambda _env, **kwargs: configured.update(kwargs),
-    )
-    monkeypatch.setattr(
-        launch, "_run_attempt", lambda *, supervise: ran.append(supervise)
-    )
-    monkeypatch.setattr(
-        launch.uuid, "uuid4", lambda: SimpleNamespace(hex="newrunid-rest")
-    )
-
-    launch.main()
-
-    assert configured == {"run_id": "old", "resume_point": point}
-    assert ran == [False]
-
-
-def test_fresh_manual_launch_honors_explicit_run_id(monkeypatch) -> None:
-    configured = {}
-    monkeypatch.setattr(
-        launch,
-        "_parser",
-        lambda: SimpleNamespace(
-            parse_args=lambda: SimpleNamespace(
-                run_attempt=False,
-                auto_resume=False,
-                resume_from=None,
-            )
-        ),
-    )
-    monkeypatch.setenv("EXPERIMENT_CONFIG", "test")
-    monkeypatch.setenv("RUN_ID", "hero-run")
-    monkeypatch.setattr(
-        launch.importlib,
-        "import_module",
-        lambda _name: SimpleNamespace(miles=object()),
-    )
-    monkeypatch.setattr(
-        launch,
-        "_set_attempt_env",
-        lambda _env, **kwargs: configured.update(kwargs),
-    )
-    monkeypatch.setattr(launch, "_run_attempt", lambda *, supervise: None)
-
-    launch.main()
-
-    assert configured == {"run_id": "hero-run", "resume_point": None}
-
-
-def test_supervised_attempt_leaves_pool_deployed_when_trainer_fails(
+def test_fresh_launch_warns_but_proceeds_without_a_resumable_config(
     monkeypatch,
 ) -> None:
-    run = SimpleNamespace(APP_NAME="app")
-    monkeypatch.setattr(launch.importlib, "import_module", lambda _name: run)
-    monkeypatch.delenv(RESUME_POINT_ENV, raising=False)
+    monkeypatch.setenv("RUN_ID", "smoke")
 
-    def fail(_run):
-        raise RuntimeError("not ready")
-
-    monkeypatch.setattr(common_launch, "deploy_pool_and_spawn", fail)
-
-    with pytest.raises(RuntimeError, match="not ready"):
-        launch._run_attempt(supervise=True)
-
-
-def test_resume_restores_pointer_before_pool_readiness(monkeypatch) -> None:
-    events = []
-    point = ResumePoint(9, 8, "run", "/trainer", "/rollout")
-    volume = object()
-    run = SimpleNamespace(
-        APP_NAME="app-run",
-        modal_cfg=SimpleNamespace(rollout_min_containers=2),
-        exp=SimpleNamespace(EXPERIMENT_VOLUME_NAME="runs"),
-        app=SimpleNamespace(
-            deploy=lambda *, strategy: events.append(("deploy", strategy))
-        ),
-        spawn_train=lambda: events.append(("spawn",)) or object(),
-    )
-    monkeypatch.setenv("RUN_ID", "run")
-    monkeypatch.setenv(RESUME_POINT_ENV, point.to_json())
-    monkeypatch.setattr(launch.importlib, "import_module", lambda _name: run)
-    monkeypatch.setattr(
-        launch.modal.Volume, "from_name", lambda *_args, **_kwargs: volume
-    )
-    monkeypatch.setattr(
-        launch,
-        "restore_resume_point",
-        lambda actual_volume, actual_point: (
-            events.append(("restore", actual_volume, actual_point))
-            or SimpleNamespace(identity="run/weight_v000009")
-        ),
+    spawned, prints = _launch(
+        monkeypatch,
+        argv_resume_from=None,
+        miles=SimpleNamespace(save_interval=None, save_hf=None),
     )
 
-    import stitch.service
-
-    monkeypatch.setattr(
-        stitch.service,
-        "await_pool_ready",
-        lambda _pool, **_kwargs: events.append(("ready",)),
-    )
-
-    launch._run_attempt(supervise=False)
-
-    assert events == [
-        ("deploy", "recreate"),
-        ("restore", volume, point),
-        ("ready",),
-        ("spawn",),
-    ]
-
-
-def test_auto_resume_reuses_previous_checkpoint_when_attempt_has_no_new_checkpoint(
-    monkeypatch,
-) -> None:
-    previous = ResumePoint(9, 8, "old", "/trainer", "/rollout")
-
-    def missing(_exp, _run_id):
-        raise ResumePointNotFound("no checkpoint")
-
-    monkeypatch.setattr(launch, "_resume_point_for_run", missing)
-
-    assert launch._resume_point_after_failure(object(), "failed", previous) == previous
-
-
-def test_auto_resume_requires_a_checkpoint_before_first_retry(monkeypatch) -> None:
-    def missing(_exp, _run_id):
-        raise ResumePointNotFound("no checkpoint")
-
-    monkeypatch.setattr(launch, "_resume_point_for_run", missing)
-
-    with pytest.raises(ValueError, match="no checkpoint"):
-        launch._resume_point_after_failure(object(), "failed", None)
+    assert spawned["run_id"] == "smoke"
+    assert any("not resumable" in line for line in prints)

--- a/cookbook/miles_disagg/patches/miles-seed-baseline-scalars.patch
+++ b/cookbook/miles_disagg/patches/miles-seed-baseline-scalars.patch
@@ -1,0 +1,15 @@
+diff --git a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
+index 42619b1..30c6eda 100644
+--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
++++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
+@@ -170,7 +170,9 @@ class UpdateWeightFromDiskDelta(DistBucketedWeightUpdateMixin):
+                 except KeyError as exc:
+                     raise ValueError(f"Trainer emitted unsupported dtype {tensor.dtype} for {name!r}") from exc
+                 if resumed_external:
+-                    baseline = tensor.detach().cpu().contiguous().view(torch.uint8).numpy().reshape(-1).copy()
++                    # Flatten before the byte view: a 0-dim tensor (a scalar
++                    # buffer) cannot dtype-view directly.
++                    baseline = tensor.detach().reshape(-1).cpu().contiguous().view(torch.uint8).numpy().copy()
+                 else:
+                     try:
+                         baseline = read_hf(

--- a/cookbook/miles_disagg/patches/miles-single-turn-external-endpoint.patch
+++ b/cookbook/miles_disagg/patches/miles-single-turn-external-endpoint.patch
@@ -1,0 +1,18 @@
+diff --git a/miles/rollout/generate_hub/single_turn.py b/miles/rollout/generate_hub/single_turn.py
+index bc74457..6bd0085 100644
+--- a/miles/rollout/generate_hub/single_turn.py
++++ b/miles/rollout/generate_hub/single_turn.py
+@@ -18,7 +18,12 @@ async def generate(input: GenerateFnInput) -> GenerateFnOutput:
+     sample = input.sample
+     sampling_params = input.sampling_params
+     assert sample.status in {Sample.Status.PENDING, Sample.Status.ABORTED}, f"{sample.status=}"
+-    url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}/generate"
++    # An opaque external fleet serves /generate at its own gateway; the Miles
++    # router only exists for Miles-managed engines.
++    if getattr(args, "rollout_endpoint_url", None):
++        url = f"{args.rollout_endpoint_url}/generate"
++    else:
++        url = f"http://{args.sglang_router_ip}:{args.sglang_router_port}/generate"
+ 
+     prompt_ids = compute_prompt_ids_from_sample(input.state, sample)
+ 

--- a/cookbook/miles_disagg/patches/miles-stable-weight-versions.patch
+++ b/cookbook/miles_disagg/patches/miles-stable-weight-versions.patch
@@ -1,0 +1,24 @@
+diff --git a/miles/backends/megatron_utils/actor.py b/miles/backends/megatron_utils/actor.py
+index 9a4c965..da98220 100644
+--- a/miles/backends/megatron_utils/actor.py
++++ b/miles/backends/megatron_utils/actor.py
+@@ -276,10 +276,15 @@ class MegatronTrainRayActor(TrainRayActor):
+ 
+                 update_weight_cls = UpdateWeightFromDiskDelta
+                 if getattr(args, "rollout_endpoint_url", None):
+-                    # The opaque fleet boots the loaded checkpoint under its
+-                    # checkpoint iteration. Continue that service-owned version
+-                    # namespace; the next delta publication increments it.
+-                    update_weight_kwargs["initial_weight_version"] = max(0, loaded_rollout_id)
++                    # The opaque fleet boots a loaded checkpoint under the
++                    # version it was published as: the one after its iteration
++                    # (a save at N precedes the publication of vN+1). Continue
++                    # the counter there so version numbers stay stable across
++                    # resume. A fresh actor reports iteration 0 (megatron loads
++                    # nothing) and starts the namespace at 0.
++                    update_weight_kwargs["initial_weight_version"] = (
++                        loaded_rollout_id + 1 if loaded_rollout_id > 0 else 0
++                    )
+             else:
+                 # Mooncake loads its RDMA shared libraries at import time.
+                 # Broadcast and disk-delta must not depend on a compatible

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from io import BytesIO
 from pathlib import PurePosixPath
 from typing import Any
@@ -12,7 +12,6 @@ from typing import Any
 from cookbook.common.constants import STITCH_PATH
 from stitch.types import WEIGHT_PREFIX, VersionRef
 
-RESUME_POINT_ENV = "STITCH_RESUME_POINT"
 TRAINER_CALL_FILE = "trainer_call_id"
 
 
@@ -34,20 +33,6 @@ class ResumePoint:
     trainer_checkpoint: str
     rollout_checkpoint: str
 
-    def to_json(self) -> str:
-        return json.dumps(asdict(self), separators=(",", ":"), sort_keys=True)
-
-    @classmethod
-    def from_json(cls, value: str) -> ResumePoint:
-        data = json.loads(value)
-        return cls(
-            version=int(data["version"]),
-            iteration=int(data["iteration"]),
-            source_run_id=str(data["source_run_id"]),
-            trainer_checkpoint=str(data["trainer_checkpoint"]),
-            rollout_checkpoint=str(data["rollout_checkpoint"]),
-        )
-
 
 def export_version(iteration: int) -> int:
     """Return the published weight version of the export saved at ``iteration``.
@@ -60,15 +45,15 @@ def export_version(iteration: int) -> int:
     return iteration + 1
 
 
-def validate_auto_resume_config(cfg: Any) -> None:
-    """Require an explicit, resumable checkpoint policy before automatic resume."""
+def validate_resumable_config(cfg: Any) -> None:
+    """Require the checkpoint policy a trainer retry needs to resume a run."""
     validate_resume_config(cfg)
     if (interval := getattr(cfg, "save_interval", None)) is None or int(interval) <= 0:
-        raise ValueError("--auto-resume requires a positive save_interval")
+        raise ValueError("resume requires a positive save_interval")
     if getattr(cfg, "no_save_optim", False):
-        raise ValueError("--auto-resume requires optimizer checkpointing")
+        raise ValueError("resume requires optimizer checkpointing")
     if getattr(cfg, "no_save_rng", False):
-        raise ValueError("--auto-resume requires RNG checkpointing")
+        raise ValueError("resume requires RNG checkpointing")
 
 
 def validate_resume_config(cfg: Any) -> None:

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import re
-import time
 from dataclasses import asdict, dataclass
 from io import BytesIO
 from pathlib import PurePosixPath
@@ -254,40 +253,6 @@ def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:
             f"{point.source_run_id}/checkpoints/latest_checkpointed_iteration.txt",
         )
     return target
-
-
-def wait_for_restored_pointer(
-    volume: Any,
-    point: ResumePoint,
-    *,
-    timeout: float,
-) -> VersionRef:
-    """Block engine startup until the launcher has restored this run's pointer."""
-    target = VersionRef(point.source_run_id, point.version)
-    pointer_path = f"{point.source_run_id}/latest"
-    deadline = time.monotonic() + timeout
-    current = None
-    while time.monotonic() < deadline:
-        volume.reload()
-        try:
-            current = VersionRef.parse(
-                _read_volume_file(volume, pointer_path).decode().strip()
-            )
-        except FileNotFoundError:
-            current = None
-        if current == target:
-            return target
-        if current is not None and (
-            current.run_id != target.run_id or current.version < target.version
-        ):
-            raise ValueError(
-                f"cannot boot {target.identity!r} from {current.identity!r}"
-            )
-        time.sleep(1)
-    actual = current.identity if current is not None else "<unset>"
-    raise TimeoutError(
-        f"latest was not restored to {target.identity}; observed {actual}"
-    )
 
 
 def _validate_save_hf_template(value: str | None) -> str:

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -11,7 +11,7 @@ from pathlib import PurePosixPath
 from typing import Any
 
 from cookbook.common.constants import STITCH_PATH
-from stitch.types import VersionRef
+from stitch.types import WEIGHT_PREFIX, VersionRef
 
 RESUME_POINT_ENV = "STITCH_RESUME_POINT"
 
@@ -22,9 +22,14 @@ class ResumePointNotFound(ValueError):
 
 @dataclass(frozen=True)
 class ResumePoint:
-    """One paired trainer/rollout checkpoint produced by a run."""
+    """One paired trainer/rollout checkpoint produced by a run.
+
+    ``version`` is the export's published weight version; ``iteration`` is the
+    Megatron iteration that produced it (``version == iteration + 1``).
+    """
 
     version: int
+    iteration: int
     source_run_id: str
     trainer_checkpoint: str
     rollout_checkpoint: str
@@ -37,20 +42,22 @@ class ResumePoint:
         data = json.loads(value)
         return cls(
             version=int(data["version"]),
+            iteration=int(data["iteration"]),
             source_run_id=str(data["source_run_id"]),
             trainer_checkpoint=str(data["trainer_checkpoint"]),
             rollout_checkpoint=str(data["rollout_checkpoint"]),
         )
 
 
-def saved_checkpoint_version(rollout_id: int, *, resumed: bool) -> int:
-    """Return the Stitch version stored by a Miles ``save_hf`` checkpoint.
+def export_version(iteration: int) -> int:
+    """Return the published weight version of the export saved at ``iteration``.
 
-    A fresh trainer starts rollout 0 from Stitch v0, so save N precedes the
-    publication of vN+1. A resumed trainer starts rollout N+1 from Stitch vN,
-    so subsequent save IDs and Stitch versions are equal.
+    A save at iteration N precedes the publication of vN+1, and a resumed
+    trainer continues the version counter from there (the runtime Miles patch),
+    so this mapping holds for a run's whole lifetime: version numbers are never
+    relabeled across attempts.
     """
-    return rollout_id if resumed else rollout_id + 1
+    return iteration + 1
 
 
 def validate_auto_resume_config(cfg: Any) -> None:
@@ -104,34 +111,63 @@ def resolve_resume_point(
     if tracked_version < 0:
         raise ValueError(f"invalid checkpoint version {tracked_version} in {tracker}")
 
-    checkpoint_versions = []
+    iterations = []
     for entry in volume.iterdir(str(checkpoint_root), recursive=False):
         if match := re.fullmatch(r"iter_(\d+)", PurePosixPath(entry.path).name):
-            version = int(match.group(1))
-            if version <= tracked_version:
-                checkpoint_versions.append(version)
+            iteration = int(match.group(1))
+            # Iteration 0 is never a resume point: a fresh actor also reports
+            # iteration 0, which is how the version counter tells fresh from
+            # resumed (the runtime Miles patch).
+            if 0 < iteration <= tracked_version:
+                iterations.append(iteration)
 
     save_hf = _validate_save_hf_template(save_hf)
-    for version in sorted(checkpoint_versions, reverse=True):
-        relative_hf = save_hf.format(rollout_id=version)
+    for iteration in sorted(iterations, reverse=True):
+        relative_hf = save_hf.format(rollout_id=iteration)
         hf_root = run_root / relative_hf
         try:
             _read_volume_file(volume, str(hf_root / ".complete"))
         except FileNotFoundError:
             continue
+        # A resumed run republishes the abandoned suffix in place, so the resume
+        # point's own publication must exist and identify itself — a crash
+        # between save and publish falls back one save interval instead.
+        try:
+            _check_published_version(
+                volume, run_root, version=export_version(iteration)
+            )
+        except FileNotFoundError:
+            continue
         break
     else:
         raise ResumePointNotFound(
-            f"run {source_run_id!r} has no complete Megatron/HF checkpoint pair at or "
-            f"before v{tracked_version}"
+            f"run {source_run_id!r} has no complete Megatron/HF checkpoint pair "
+            f"with a published export at or before iteration {tracked_version}"
         )
 
     return ResumePoint(
-        version=version,
+        version=export_version(iteration),
+        iteration=iteration,
         source_run_id=source_run_id,
         trainer_checkpoint=str(STITCH_PATH / checkpoint_root),
         rollout_checkpoint=str(STITCH_PATH / hf_root),
     )
+
+
+def _check_published_version(
+    volume: Any, run_root: PurePosixPath, *, version: int
+) -> None:
+    """Require ``updates/weight_vNNNNNN`` to exist and identify itself as ``version``."""
+    index_path = (
+        run_root
+        / "updates"
+        / f"{WEIGHT_PREFIX}{version:06d}"
+        / "model.safetensors.index.json"
+    )
+    index = json.loads(_read_volume_file(volume, str(index_path)))
+    published = int((index.get("metadata") or {})["version"])
+    if published != version:
+        raise ValueError(f"{index_path} identifies v{published}, not v{version}")
 
 
 def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:
@@ -158,7 +194,7 @@ def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:
     with volume.batch_upload(force=True) as upload:
         upload.put_file(BytesIO(target.identity.encode()), pointer_path)
         upload.put_file(
-            BytesIO(str(point.version).encode()),
+            BytesIO(str(point.iteration).encode()),
             f"{point.source_run_id}/checkpoints/latest_checkpointed_iteration.txt",
         )
     return target

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -14,6 +14,7 @@ from cookbook.common.constants import STITCH_PATH
 from stitch.types import WEIGHT_PREFIX, VersionRef
 
 RESUME_POINT_ENV = "STITCH_RESUME_POINT"
+TRAINER_CALL_FILE = "trainer_call_id"
 
 
 class ResumePointNotFound(ValueError):
@@ -170,6 +171,59 @@ def _check_published_version(
         raise ValueError(f"{index_path} identifies v{published}, not v{version}")
 
 
+def prepare_attempt(
+    volume: Any, *, run_id: str, save_hf: str | None
+) -> ResumePoint | None:
+    """Derive one trainer attempt's resume state from the run volume alone.
+
+    Every attempt — the first, a Modal retry, or a manual re-spawn — calls this
+    with identical inputs: the newest complete checkpoint pair is restored and
+    returned, and a run that crashed before its first pair restarts from
+    scratch with the pointer rewound to the boot version, so replicas abandon
+    the unsaved suffix either way.
+    """
+    try:
+        point = resolve_resume_point(volume, source_run_id=run_id, save_hf=save_hf)
+    except ResumePointNotFound:
+        restore_boot_pointer(volume, run_id)
+        return None
+    restore_resume_point(volume, point)
+    return point
+
+
+def restore_boot_pointer(volume: Any, run_id: str) -> None:
+    """Rewind ``latest`` to the boot version when a run has nothing to resume."""
+    pointer_path = f"{run_id}/latest"
+    try:
+        current = VersionRef.parse(
+            _read_volume_file(volume, pointer_path).decode().strip()
+        )
+    except FileNotFoundError:
+        return  # nothing claimed yet; the attempt's own claim writes v0
+    if current.run_id != run_id:
+        raise ValueError(f"latest belongs to run {current.run_id!r}, not {run_id!r}")
+    if current.version == 0:
+        return
+    with volume.batch_upload(force=True) as upload:
+        upload.put_file(BytesIO(VersionRef(run_id, 0).identity.encode()), pointer_path)
+
+
+def record_trainer_call(volume: Any, run_id: str, call_id: str) -> None:
+    """Record the run's active trainer call; a newer spawn supersedes the old."""
+    with volume.batch_upload(force=True) as upload:
+        upload.put_file(BytesIO(call_id.encode()), f"{run_id}/{TRAINER_CALL_FILE}")
+
+
+def read_trainer_call(volume: Any, run_id: str) -> str | None:
+    """Return the run's recorded trainer call id, or None before the first spawn."""
+    try:
+        return (
+            _read_volume_file(volume, f"{run_id}/{TRAINER_CALL_FILE}").decode().strip()
+        )
+    except FileNotFoundError:
+        return None
+
+
 def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:
     """Restore the trainer tracker and Stitch pointer to one checkpoint pair."""
     target = VersionRef(point.source_run_id, point.version)
@@ -186,7 +240,9 @@ def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:
         raise ValueError(
             f"cannot restore {target.identity!r} from {current.identity!r}"
         )
-    if target.version > current.version:
+    # One ahead is a publish interrupted between its verified files and the
+    # pointer advance; restoring forward by one completes it.
+    if target.version > current.version + 1:
         raise ValueError(
             f"resume checkpoint v{target.version} is newer than latest v{current.version}"
         )

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -6,13 +6,20 @@ import pytest
 
 from cookbook.miles_disagg.resume import (
     ResumePoint,
+    export_version,
     resolve_resume_point,
     restore_resume_point,
-    saved_checkpoint_version,
     validate_auto_resume_config,
     validate_resume_config,
     wait_for_restored_pointer,
 )
+
+_INDEX = "model.safetensors.index.json"
+
+
+def _published(version: int) -> dict[str, bytes]:
+    name = f"old/updates/weight_v{version:06d}/{_INDEX}"
+    return {name: b'{"metadata": {"version": "%06d"}}' % version}
 
 
 class _Volume:
@@ -62,15 +69,9 @@ class _Config:
     no_save_optim = False
 
 
-@pytest.mark.parametrize(
-    ("rollout_id", "resumed", "version"),
-    [
-        (19, False, 20),
-        (120, True, 120),
-    ],
-)
-def test_saved_checkpoint_version(rollout_id: int, resumed: bool, version: int) -> None:
-    assert saved_checkpoint_version(rollout_id, resumed=resumed) == version
+@pytest.mark.parametrize(("iteration", "version"), [(0, 1), (19, 20), (119, 120)])
+def test_export_version(iteration: int, version: int) -> None:
+    assert export_version(iteration) == version
 
 
 def test_resolve_resume_point_pairs_megatron_and_hf_checkpoints() -> None:
@@ -79,13 +80,15 @@ def test_resolve_resume_point_pairs_megatron_and_hf_checkpoints() -> None:
             "old/checkpoints/latest_checkpointed_iteration.txt": b"119\n",
             "old/checkpoints/iter_0000119/state": b"checkpoint",
             "old/hf_checkpoints/weight_v000119/.complete": b"",
+            **_published(120),
         }
     )
 
     assert resolve_resume_point(
         volume, source_run_id="old", save_hf=_Config.save_hf
     ) == ResumePoint(
-        version=119,
+        version=120,
+        iteration=119,
         source_run_id="old",
         trainer_checkpoint="/stitch/old/checkpoints",
         rollout_checkpoint="/stitch/old/hf_checkpoints/weight_v000119",
@@ -99,17 +102,69 @@ def test_resolve_resume_point_falls_back_to_previous_complete_pair() -> None:
             "old/checkpoints/iter_0000099/state": b"checkpoint",
             "old/checkpoints/iter_0000119/state": b"checkpoint",
             "old/hf_checkpoints/weight_v000099/.complete": b"",
+            **_published(100),
         }
     )
 
     assert resolve_resume_point(
         volume, source_run_id="old", save_hf=_Config.save_hf
     ) == ResumePoint(
-        version=99,
+        version=100,
+        iteration=99,
         source_run_id="old",
         trainer_checkpoint="/stitch/old/checkpoints",
         rollout_checkpoint="/stitch/old/hf_checkpoints/weight_v000099",
     )
+
+
+def test_resolve_resume_point_requires_the_exports_publication() -> None:
+    # A crash between save and publish leaves the export without its published
+    # version; the resume point falls back one save interval.
+    volume = _Volume(
+        {
+            "old/checkpoints/latest_checkpointed_iteration.txt": b"119\n",
+            "old/checkpoints/iter_0000099/state": b"checkpoint",
+            "old/checkpoints/iter_0000119/state": b"checkpoint",
+            "old/hf_checkpoints/weight_v000099/.complete": b"",
+            "old/hf_checkpoints/weight_v000119/.complete": b"",
+            **_published(100),
+        }
+    )
+
+    resolved = resolve_resume_point(
+        volume, source_run_id="old", save_hf=_Config.save_hf
+    )
+
+    assert (resolved.version, resolved.iteration) == (100, 99)
+
+
+def test_resolve_resume_point_rejects_a_mislabeled_publication() -> None:
+    volume = _Volume(
+        {
+            "old/checkpoints/latest_checkpointed_iteration.txt": b"119\n",
+            "old/checkpoints/iter_0000119/state": b"checkpoint",
+            "old/hf_checkpoints/weight_v000119/.complete": b"",
+            f"old/updates/weight_v000120/{_INDEX}": b'{"metadata": {"version": "0007"}}',
+        }
+    )
+
+    with pytest.raises(ValueError, match="identifies v7, not v120"):
+        resolve_resume_point(volume, source_run_id="old", save_hf=_Config.save_hf)
+
+
+def test_resolve_resume_point_skips_iteration_zero() -> None:
+    # A fresh actor also reports iteration 0, so iteration 0 never resumes.
+    volume = _Volume(
+        {
+            "old/checkpoints/latest_checkpointed_iteration.txt": b"0\n",
+            "old/checkpoints/iter_0000000/state": b"checkpoint",
+            "old/hf_checkpoints/weight_v000000/.complete": b"",
+            **_published(1),
+        }
+    )
+
+    with pytest.raises(ValueError, match="no complete Megatron/HF checkpoint pair"):
+        resolve_resume_point(volume, source_run_id="old", save_hf=_Config.save_hf)
 
 
 def test_resolve_resume_point_requires_a_complete_checkpoint_pair() -> None:
@@ -173,7 +228,7 @@ def test_validate_resume_requires_per_step_weight_updates() -> None:
 
 
 def test_resume_point_json_round_trip() -> None:
-    point = ResumePoint(7, "run", "/trainer", "/rollout")
+    point = ResumePoint(7, 6, "run", "/trainer", "/rollout")
 
     assert ResumePoint.from_json(point.to_json()) == point
 
@@ -186,19 +241,19 @@ def test_restore_resume_point_overwrites_trackers_but_preserves_updates() -> Non
             "run/updates/weight_v000009/old": b"preserved",
         }
     )
-    point = ResumePoint(8, "run", "/trainer", "/rollout")
+    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
 
     restored = restore_resume_point(volume, point)
 
     assert restored.identity == "run/weight_v000008"
     assert volume.files["run/latest"] == b"run/weight_v000008"
-    assert volume.files["run/checkpoints/latest_checkpointed_iteration.txt"] == b"8"
+    assert volume.files["run/checkpoints/latest_checkpointed_iteration.txt"] == b"7"
     assert volume.files["run/updates/weight_v000009/old"] == b"preserved"
 
 
 def test_restore_resume_point_rejects_a_checkpoint_ahead_of_latest() -> None:
     volume = _Volume({"run/latest": b"run/weight_v000007"})
-    point = ResumePoint(8, "run", "/trainer", "/rollout")
+    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
 
     with pytest.raises(ValueError, match="newer than latest"):
         restore_resume_point(volume, point)
@@ -206,7 +261,7 @@ def test_restore_resume_point_rejects_a_checkpoint_ahead_of_latest() -> None:
 
 def test_engine_startup_waits_for_exact_restored_pointer() -> None:
     volume = _Volume({"run/latest": b"run/weight_v000008"})
-    point = ResumePoint(8, "run", "/trainer", "/rollout")
+    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
 
     restored = wait_for_restored_pointer(volume, point, timeout=1)
 
@@ -215,7 +270,7 @@ def test_engine_startup_waits_for_exact_restored_pointer() -> None:
 
 def test_engine_startup_does_not_accept_abandoned_suffix(monkeypatch) -> None:
     volume = _Volume({"run/latest": b"run/weight_v000012"})
-    point = ResumePoint(8, "run", "/trainer", "/rollout")
+    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
     reloads = 0
 
     def reload() -> None:

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -7,7 +7,11 @@ import pytest
 from cookbook.miles_disagg.resume import (
     ResumePoint,
     export_version,
+    prepare_attempt,
+    read_trainer_call,
+    record_trainer_call,
     resolve_resume_point,
+    restore_boot_pointer,
     restore_resume_point,
     validate_auto_resume_config,
     validate_resume_config,
@@ -251,12 +255,71 @@ def test_restore_resume_point_overwrites_trackers_but_preserves_updates() -> Non
     assert volume.files["run/updates/weight_v000009/old"] == b"preserved"
 
 
-def test_restore_resume_point_rejects_a_checkpoint_ahead_of_latest() -> None:
+def test_restore_resume_point_completes_an_interrupted_publish() -> None:
+    # A crash between a publish's verified files and its pointer advance leaves
+    # latest one behind the resume point; restoring forward by one completes it.
     volume = _Volume({"run/latest": b"run/weight_v000007"})
+    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
+
+    assert restore_resume_point(volume, point).identity == "run/weight_v000008"
+    assert volume.files["run/latest"] == b"run/weight_v000008"
+
+
+def test_restore_resume_point_rejects_a_checkpoint_ahead_of_latest() -> None:
+    volume = _Volume({"run/latest": b"run/weight_v000006"})
     point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
 
     with pytest.raises(ValueError, match="newer than latest"):
         restore_resume_point(volume, point)
+
+
+def test_prepare_attempt_restores_the_newest_pair() -> None:
+    volume = _Volume(
+        {
+            "old/latest": b"old/weight_v000012",
+            "old/checkpoints/latest_checkpointed_iteration.txt": b"7",
+            "old/checkpoints/iter_0000007/state": b"checkpoint",
+            "old/hf_checkpoints/weight_v000007/.complete": b"",
+            **_published(8),
+        }
+    )
+
+    point = prepare_attempt(volume, run_id="old", save_hf=_Config.save_hf)
+
+    assert point is not None and (point.version, point.iteration) == (8, 7)
+    assert volume.files["old/latest"] == b"old/weight_v000008"
+    assert volume.files["old/checkpoints/latest_checkpointed_iteration.txt"] == b"7"
+
+
+def test_prepare_attempt_restarts_from_scratch_before_the_first_pair() -> None:
+    volume = _Volume({"old/latest": b"old/weight_v000003"})
+
+    assert prepare_attempt(volume, run_id="old", save_hf=_Config.save_hf) is None
+    assert volume.files["old/latest"] == b"old/weight_v000000"
+
+
+def test_prepare_attempt_is_a_noop_on_a_fresh_run() -> None:
+    volume = _Volume({})
+
+    assert prepare_attempt(volume, run_id="old", save_hf=_Config.save_hf) is None
+    assert volume.files == {}
+
+
+def test_restore_boot_pointer_rejects_a_foreign_run() -> None:
+    volume = _Volume({"old/latest": b"other/weight_v000003"})
+
+    with pytest.raises(ValueError, match="belongs to run"):
+        restore_boot_pointer(volume, "old")
+
+
+def test_trainer_call_fence_round_trip() -> None:
+    volume = _Volume({})
+
+    assert read_trainer_call(volume, "old") is None
+    record_trainer_call(volume, "old", "fc-123")
+    assert read_trainer_call(volume, "old") == "fc-123"
+    record_trainer_call(volume, "old", "fc-456")  # a newer spawn supersedes
+    assert read_trainer_call(volume, "old") == "fc-456"
 
 
 def test_engine_startup_waits_for_exact_restored_pointer() -> None:

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -13,7 +13,7 @@ from cookbook.miles_disagg.resume import (
     resolve_resume_point,
     restore_boot_pointer,
     restore_resume_point,
-    validate_auto_resume_config,
+    validate_resumable_config,
     validate_resume_config,
 )
 
@@ -199,12 +199,12 @@ def test_resolve_resume_point_rejects_path_like_run_id() -> None:
         ("no_save_rng", True, "RNG checkpointing"),
     ],
 )
-def test_validate_auto_resume_config(field: str, value: object, message: str) -> None:
+def test_validate_resumable_config(field: str, value: object, message: str) -> None:
     cfg = _Config()
     setattr(cfg, field, value)
 
     with pytest.raises(ValueError, match=message):
-        validate_auto_resume_config(cfg)
+        validate_resumable_config(cfg)
 
 
 @pytest.mark.parametrize(
@@ -228,12 +228,6 @@ def test_validate_resume_requires_per_step_weight_updates() -> None:
 
     with pytest.raises(ValueError, match="update_weights_interval == 1"):
         validate_resume_config(cfg)
-
-
-def test_resume_point_json_round_trip() -> None:
-    point = ResumePoint(7, 6, "run", "/trainer", "/rollout")
-
-    assert ResumePoint.from_json(point.to_json()) == point
 
 
 def test_restore_resume_point_overwrites_trackers_but_preserves_updates() -> None:

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -15,7 +15,6 @@ from cookbook.miles_disagg.resume import (
     restore_resume_point,
     validate_auto_resume_config,
     validate_resume_config,
-    wait_for_restored_pointer,
 )
 
 _INDEX = "model.safetensors.index.json"
@@ -320,32 +319,3 @@ def test_trainer_call_fence_round_trip() -> None:
     assert read_trainer_call(volume, "old") == "fc-123"
     record_trainer_call(volume, "old", "fc-456")  # a newer spawn supersedes
     assert read_trainer_call(volume, "old") == "fc-456"
-
-
-def test_engine_startup_waits_for_exact_restored_pointer() -> None:
-    volume = _Volume({"run/latest": b"run/weight_v000008"})
-    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
-
-    restored = wait_for_restored_pointer(volume, point, timeout=1)
-
-    assert restored.identity == "run/weight_v000008"
-
-
-def test_engine_startup_does_not_accept_abandoned_suffix(monkeypatch) -> None:
-    volume = _Volume({"run/latest": b"run/weight_v000012"})
-    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
-    reloads = 0
-
-    def reload() -> None:
-        nonlocal reloads
-        reloads += 1
-        if reloads == 2:
-            volume.files["run/latest"] = b"run/weight_v000008"
-
-    volume.reload = reload
-    monkeypatch.setattr("cookbook.miles_disagg.resume.time.sleep", lambda _delay: None)
-
-    restored = wait_for_restored_pointer(volume, point, timeout=1)
-
-    assert restored.identity == "run/weight_v000008"
-    assert reloads == 2

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -24,6 +24,11 @@ MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
 MILES_REPO_REF = "778a13786471777f81c587557f68cdf03903059a"
 
 MILES_ROOT = "/root/miles"
+# Applied to the checkout at container start (after any dev overlay), so the fix
+# also covers MILES_LOCAL_DIR; move to the fork and drop when the pin advances.
+MILES_RUNTIME_PATCHES = (
+    "/root/cookbook/miles_disagg/patches/miles-stable-weight-versions.patch",
+)
 # Source-only megatron.training must be on PYTHONPATH.
 MEGATRON_PATH = "/root/Megatron-LM"
 TORCH_DIST_CONVERT_WRAPPER = "/root/convert_hf_to_torch_dist_modal.py"

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -31,6 +31,8 @@ MILES_RUNTIME_PATCHES = (
     "/root/cookbook/miles_disagg/patches/miles-stable-weight-versions.patch",
     # resumed_external baseline capture tolerates 0-dim tensors (qwen3moe).
     "/root/cookbook/miles_disagg/patches/miles-seed-baseline-scalars.patch",
+    # single_turn generate honors an external rollout endpoint.
+    "/root/cookbook/miles_disagg/patches/miles-single-turn-external-endpoint.patch",
 )
 # Source-only megatron.training must be on PYTHONPATH.
 MEGATRON_PATH = "/root/Megatron-LM"

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -24,10 +24,13 @@ MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
 MILES_REPO_REF = "778a13786471777f81c587557f68cdf03903059a"
 
 MILES_ROOT = "/root/miles"
-# Applied to the checkout at container start (after any dev overlay), so the fix
-# also covers MILES_LOCAL_DIR; move to the fork and drop when the pin advances.
+# Applied to the checkout at container start (after any dev overlay), so the fixes
+# also cover MILES_LOCAL_DIR; each moves to the fork and drops when the pin advances.
 MILES_RUNTIME_PATCHES = (
+    # A resumed counter continues at iteration+1, so versions never relabel.
     "/root/cookbook/miles_disagg/patches/miles-stable-weight-versions.patch",
+    # resumed_external baseline capture tolerates 0-dim tensors (qwen3moe).
+    "/root/cookbook/miles_disagg/patches/miles-seed-baseline-scalars.patch",
 )
 # Source-only megatron.training must be on PYTHONPATH.
 MEGATRON_PATH = "/root/Megatron-LM"

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -5,11 +5,12 @@ Server (sglang + stitch sidecar) is the shared common one; the Trainer runs slim
 and publishes XOR deltas through the configured checkpoint store.
 
 Prepare the model + dataset once first (a separate app, so prep never spins up the rollout
-Server floor — see ``cookbook.slime_disagg.prep_app``), then launch a run with one command — it
-mints a unique run id, stands up that run's pool, and starts training. Each launch is its own run,
-isolated even from an identical-config relaunch (see ``cookbook.slime_disagg.launch``):
+Server floor — see ``cookbook.slime_disagg.prep_app``), then deploy the run's pool and launch
+its trainer under one run id. Each run id is its own run, isolated even from an
+identical-config run (see ``cookbook.slime_disagg.launch``):
 
-    EXPERIMENT_CONFIG=kimi_k2_6_int4 uv run --extra modal python -m cookbook.slime_disagg.launch
+    EXPERIMENT_CONFIG=kimi_k2_6_int4 RUN_ID=myrun01 uv run --extra modal modal deploy -m cookbook.slime_disagg.app
+    EXPERIMENT_CONFIG=kimi_k2_6_int4 RUN_ID=myrun01 uv run --extra modal python -m cookbook.slime_disagg.launch
 
 Config access is uniform: the experiment module ``exp`` is the single source of truth —
 its ``exp.modal`` (infra), ``exp.slime`` (training), and ``exp.<CONST>`` are read directly;

--- a/cookbook/slime_disagg/launch.py
+++ b/cookbook/slime_disagg/launch.py
@@ -1,16 +1,15 @@
-"""One-command launch: mint a unique run id, stand up that run's pool, start training.
+"""Launch a Slime run's trainer on its deployed pool.
 
-A run's pool is a deployed Flash app the trainer reaches by name, so the run id has to be in the
-app name before either half runs — which is why deploy and launch can't be one CLI call. This
-closes that: mint the id, deploy ``app.py``'s pool under it, wait for it to be ready, then spawn
-the trainer. Each launch is its own run — two launches of an identical config are two isolated
-runs (distinct ids), like commits.
+Mint the run id, wait for the pool's floor, then spawn the trainer. The pool's
+lifecycle belongs to explicit deploys of ``app.py`` under the same run id; a
+missing pool fails fast with that instruction. Each launch is its own run — two
+launches of an identical config are two isolated runs (distinct ids), like
+commits.
 
     EXPERIMENT_CONFIG=kimi_k2_6_int4 uv run --extra modal python -m cookbook.slime_disagg.launch
 
-A plain script, not a ``modal run`` entrypoint: ``App.deploy()`` only persists outside a ``modal
-run`` session (inside one the deployed app is torn down with the session). Minting the id here,
-before importing the pool module, also lets the pool's app name resolve from ``RUN_ID`` at import.
+Minting the id here, before importing the pool module, lets the pool's app name
+resolve from ``RUN_ID`` at import.
 """
 
 from __future__ import annotations
@@ -20,11 +19,11 @@ import uuid
 
 
 def main() -> None:
-    os.environ["RUN_ID"] = uuid.uuid4().hex[:8]
+    os.environ["RUN_ID"] = os.environ.get("RUN_ID") or uuid.uuid4().hex[:8]
     from cookbook.common import launch
     from cookbook.slime_disagg import app as run
 
-    launch.deploy_pool_and_spawn(run)
+    launch.spawn_on_pool(run)
     print(
         f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; "
         f"stop it with: modal app stop {run.APP_NAME}"

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -23,7 +23,13 @@ from typing import Any, Protocol
 from stitch.engines.base import Engine
 from stitch.pools.base import Pool
 from stitch.stores.base import Store
-from stitch.sync import AdmissionGate, CommitMode, ConstraintUnmet, Reconciler
+from stitch.sync import (
+    AdmissionClosed,
+    AdmissionGate,
+    CommitMode,
+    ConstraintUnmet,
+    Reconciler,
+)
 from stitch.types import PoolState, ReplicaState, VersionConstraint
 from stitch.watchdog import (
     EngineWatchdog,
@@ -256,6 +262,14 @@ def create_app(
                 )  # capture while still pinned, before a commit advances it
         except ConstraintUnmet as exc:
             return JSONResponse(exc.error, status_code=409)
+        except AdmissionClosed as exc:
+            # A restaging replica sheds: a 503 makes the router evict it and retry
+            # the session elsewhere, where a 409 would re-pin it via affinity.
+            return JSONResponse(
+                {"error": exc.error},
+                status_code=503,
+                headers={"Retry-After": "1"},
+            )
 
         if (
             is_versioned

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -267,6 +267,40 @@ def test_metrics_bypasses_weight_admission_before_first_pointer(monkeypatch):
     asyncio.run(go())
 
 
+def test_shedding_commit_returns_retryable_503():
+    # A rewind restage sheds versioned traffic with a 503 so the pool router
+    # evicts this replica and retries the session elsewhere (a 409 would bounce
+    # back through session affinity).
+    async def go():
+        gate_sidecar = _GateSidecar(applied=VersionRef("r1", 5))
+        app = create_app(gate_sidecar.gate, gate_sidecar, _ProxyEngine())
+        applying = asyncio.Event()
+        finish = asyncio.Event()
+
+        async def apply() -> None:
+            applying.set()
+            await finish.wait()
+
+        commit = asyncio.create_task(
+            gate_sidecar.gate.commit(
+                apply=apply, on_applied=lambda: None, drain_all=True, shed=True
+            )
+        )
+        await applying.wait()
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://sidecar"
+        ) as sidecar:
+            response = await sidecar.post("/generate", json={"text": "hi"})
+        assert response.status_code == 503
+        assert response.headers["retry-after"] == "1"
+        assert response.json()["error"]["retryable"] is True
+
+        finish.set()
+        await commit
+
+    asyncio.run(go())
+
+
 def test_await_pool_ready_waits_for_replica_threshold(monkeypatch) -> None:
     states = iter(
         [

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -471,6 +471,8 @@ class Reconciler:
             return True
         if self.applied is None or pointer.run_id != self.applied.run_id:
             await self._switch_run(pointer.run_id)
+        if self.applied is not None and pointer.version < self.applied.version:
+            await self._rewind(pointer, m)
         if not self._behind(pointer):
             return True
 
@@ -575,6 +577,64 @@ class Reconciler:
 
     async def _commit_noop(self) -> None:
         self.sync_state = SyncState.COMMITTING
+
+    async def _rewind(self, pointer: VersionRef, m: dict[str, Any]) -> None:
+        """Converge to a pointer behind the applied version: the launcher restored
+        the run to an earlier checkpoint, so every later version this replica
+        applied left the run's lineage.
+
+        Unlike a forward update, the live weights are not a valid serving state
+        while this runs, so the whole restage happens under a closed, shedding
+        gate (arrivals 503 and the router re-routes them) instead of the
+        stage-while-serving overlap. ``_range_has_weight_changes`` has no meaning
+        across a lineage fork — the restored checkpoint always loads. A failure
+        is terminal: a replacement replica boots from the restored checkpoint
+        directly, which also covers a boot anchor above the restore point."""
+        assert self.applied is not None
+        m["rewound_from_version"] = self.applied.version
+        m["applied_version"] = self.applied.version
+        m["target_version"] = pointer.version
+        self.ready = False  # leave rotation until reconcile re-latches convergence
+        self.sync_state = SyncState.FETCHING
+        self.last_error = None
+        logger.info(
+            "pointer rewound: v%d -> v%d, restaging the restored lineage",
+            self.applied.version,
+            pointer.version,
+        )
+        target = await asyncio.to_thread(self.store.read_manifest, pointer)
+        source_dir = await asyncio.to_thread(self.store.materialize, pointer)
+
+        async def apply() -> None:
+            self.sync_state = SyncState.STAGING
+            with _timed(m, "rewind_stage_s"):
+                await self.engine.stage(target, source_dir)
+            self.sync_state = SyncState.COMMITTING
+            # The abandoned suffix gets republished with different bytes under
+            # the same version numbers, so version-keyed KV entries are poisoned:
+            # flush unconditionally, not by commit policy.
+            with _timed(m, "rewind_commit_s"):
+                await self.engine.commit(target, flush_cache=True)
+
+        def on_applied() -> None:
+            self.applied = pointer
+
+        try:
+            await self.gate.commit(
+                apply=apply,
+                on_applied=on_applied,
+                pause=self.engine.pause,
+                resume=self.engine.resume,
+                drain_all=True,
+                shed=True,
+            )
+        except UnrecoverableSidecarError:
+            raise
+        except Exception as exc:
+            raise UnrecoverableEngineError(
+                "rewind to the restored checkpoint failed; the replacement "
+                "replica boots from it directly"
+            ) from exc
 
     async def _switch_run(self, new_run: str | None) -> None:
         """Select a new run at its boot version, resetting patched weights to the

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -53,6 +53,19 @@ class ConstraintUnmet(Exception):
         self.error = error
 
 
+class AdmissionClosed(Exception):
+    """Admission is shed while this replica restages its weights (a retryable 503).
+
+    A 503 — unlike a 409 — makes the pool router evict this replica and retry the
+    session on another one, instead of session affinity re-pinning it here while
+    the restage runs.
+    """
+
+    def __init__(self, error: dict[str, Any]) -> None:
+        super().__init__(error["message"])
+        self.error = error
+
+
 class AdmissionGate:
     """Request admission + the commit gate.
 
@@ -84,6 +97,7 @@ class AdmissionGate:
         self._active = 0
         self._committing = False
         self._drain_all = False
+        self._shedding = False
         self._exact_inflight: dict[int, int] = defaultdict(int)
 
     @property
@@ -114,10 +128,21 @@ class AdmissionGate:
     @asynccontextmanager
     async def admit(self, constraint: VersionConstraint | None = None):
         """Admit one request under a single lock acquisition, yielding the version it
-        is served on. Raises :class:`ConstraintUnmet` if the constraint can't be met."""
+        is served on. Raises :class:`ConstraintUnmet` if the constraint can't be met,
+        or :class:`AdmissionClosed` while a shedding commit runs — a shed rejects
+        arrivals (and wakes waiters to reject them) rather than queueing them behind
+        a restage of unknown duration."""
         c = constraint or VersionConstraint()
         async with self._cond:
-            await self._cond.wait_for(lambda: not self._committing)
+            await self._cond.wait_for(lambda: not self._committing or self._shedding)
+            if self._shedding:
+                raise AdmissionClosed(
+                    {
+                        "type": "ReplicaRestaging",
+                        "message": "this replica is restaging its weights",
+                        "retryable": True,
+                    }
+                )
             error = self._rejection(c)
             if error is not None:
                 self._on_reject(error)
@@ -145,17 +170,22 @@ class AdmissionGate:
         pause: Callable[[], Awaitable[None]] | None = None,
         resume: Callable[[], Awaitable[None]] | None = None,
         drain_all: bool = False,
+        shed: bool = False,
     ) -> None:
         """Wait for the commit point, close the gate, apply, flip the served version
         (``on_applied``) while the gate is held, then reopen. ``on_applied`` runs only
         after a successful apply; in ``in_place`` the flip happens before ``resume``.
         ``drain_all`` marks an incompatible transition (a boot reset): drain and gate
         every request regardless of mode — rolling requests may cross a compatible
-        weight update, never a change of lineage (stitch#32)."""
+        weight update, never a change of lineage (stitch#32). ``shed`` additionally
+        rejects arrivals with :class:`AdmissionClosed` instead of queueing them —
+        for a commit whose apply may run long (a rewind restage), so the pool routes
+        around this replica rather than parking requests on it."""
         # Close admission before draining (stitch#32), else a new in_place request can straddle a boot reset.
         async with self._cond:
             self._committing = True
             self._drain_all = drain_all
+            self._shedding = shed
             self._cond.notify_all()
         try:
             async with self._cond:
@@ -175,6 +205,7 @@ class AdmissionGate:
             async with self._cond:
                 self._committing = False
                 self._drain_all = False
+                self._shedding = False
                 self._cond.notify_all()
 
 

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -14,7 +14,7 @@ import pytest
 from stitch.engines.base import Engine
 from stitch.errors import UnrecoverableEngineError
 from stitch.stores.base import Store
-from stitch.sync import ConstraintUnmet, Reconciler
+from stitch.sync import AdmissionClosed, ConstraintUnmet, Reconciler
 from stitch.types import (
     SyncState,
     VersionConstraint,
@@ -61,6 +61,7 @@ class FakeEngine(Engine):
         self.calls: list[str] = []
         self.staged: list[VersionRef] = []
         self.committed: list[VersionRef] = []
+        self.commit_flushes: list[bool] = []
         self.initialized_versions: list[int] = []
 
     async def stage(self, manifest: VersionManifest, source_dir: str) -> None:
@@ -74,6 +75,7 @@ class FakeEngine(Engine):
         flush_cache: bool = False,
     ) -> None:
         self.committed.append(manifest.ref)
+        self.commit_flushes.append(flush_cache)
         self.calls.append(f"commit:{manifest.ref.version}")
 
     async def flush_cache(self) -> None:
@@ -424,6 +426,122 @@ def test_run_switch_drains_rolling_requests() -> None:
         assert (
             late_served[0] is not None and late_served[0].run_id == "r2"
         )  # admitted post-wipe
+
+    _run(go())
+
+
+# ── rewind (a restored checkpoint moved the pointer backward) ─────────────────
+def test_pointer_rewind_restages_in_place() -> None:
+    async def go() -> None:
+        engine = FakeEngine()
+        r = _make_reconciler(
+            store=FakeStore(VersionRef("r1", 2), _full("r1", 2)),
+            engine=engine,
+            commit_mode="in_place",
+        )
+        r.applied = VersionRef("r1", 5)
+        r.ready = True
+        await r.reconcile()
+        assert r.applied == VersionRef("r1", 2)
+        assert engine.committed[-1] == VersionRef("r1", 2)
+        # Republished suffix versions carry different bytes under the same
+        # numbers, so version-keyed KV must flush regardless of commit policy.
+        assert engine.commit_flushes[-1] is True
+        assert r.ready  # re-latches once converged on the restored lineage
+        assert r.server_info()["terminal_error"] is None
+
+    _run(go())
+
+
+def test_rewind_commits_even_when_the_range_looks_empty() -> None:
+    # The forward path skips byte-identical ranges; across a lineage fork that
+    # check has no meaning, so a rewind always reloads the restored checkpoint.
+    async def go() -> None:
+        engine = FakeEngine()
+        r = _make_reconciler(
+            store=FakeStore(VersionRef("r1", 2), _delta("r1", 2, files=[])),
+            engine=engine,
+        )
+        r.applied = VersionRef("r1", 5)
+        await r.reconcile()
+        assert VersionRef("r1", 2) in engine.committed
+
+    _run(go())
+
+
+def test_rewind_sheds_arrivals_and_drains_rolling_requests() -> None:
+    async def go() -> None:
+        engine = FakeEngine()
+        stage_started = asyncio.Event()
+        finish_stage = asyncio.Event()
+
+        async def slow_stage(manifest: VersionManifest, _source_dir: str) -> None:
+            engine.calls.append(f"stage:{manifest.ref.version}")
+            stage_started.set()
+            await finish_stage.wait()
+
+        engine.stage = slow_stage  # type: ignore[method-assign]
+        r = _make_reconciler(
+            store=FakeStore(VersionRef("r1", 2), _full("r1", 2)),
+            engine=engine,
+            commit_mode="in_place",
+        )
+        r.applied = VersionRef("r1", 5)
+        release = asyncio.Event()
+
+        async def rolling() -> None:
+            async with r.gate.admit(None):
+                await release.wait()
+
+        req = asyncio.create_task(rolling())
+        await asyncio.sleep(0)  # admitted before the rewind begins
+        sync = asyncio.create_task(r.reconcile())
+        for _ in range(1000):
+            if r.gate._committing:
+                break
+            await asyncio.sleep(0.001)
+        # The wrong-lineage bytes are never restaged under a rolling request.
+        assert "stage:2" not in engine.calls
+        assert not r.ready
+        with pytest.raises(AdmissionClosed):  # arrivals shed instead of queueing
+            async with r.gate.admit(VersionConstraint()):
+                pass
+        release.set()
+        await stage_started.wait()
+        finish_stage.set()
+        await asyncio.gather(req, sync)
+        assert r.applied == VersionRef("r1", 2)
+        assert r.ready
+        async with r.gate.admit(VersionConstraint()) as served:  # gate reopens
+            assert served == VersionRef("r1", 2)
+
+    _run(go())
+
+
+def test_rewind_failure_is_terminal() -> None:
+    # A failed rewind (e.g. the restore point precedes this replica's boot
+    # anchor) replaces the replica; the replacement boots from the restored
+    # checkpoint directly.
+    async def go() -> None:
+        engine = FakeEngine()
+
+        async def fail_stage(_manifest: VersionManifest, _source_dir: str) -> None:
+            raise RuntimeError("target precedes the base checkpoint")
+
+        engine.stage = fail_stage  # type: ignore[method-assign]
+        r = _make_reconciler(
+            store=FakeStore(VersionRef("r1", 2), _full("r1", 2)),
+            engine=engine,
+            reconcile_interval=0,
+        )
+        r.applied = VersionRef("r1", 5)
+        await r.reconcile()
+        with pytest.raises(
+            UnrecoverableEngineError,
+            match="rewind to the restored checkpoint failed",
+        ):
+            await r.wait_for_terminal_error()
+        assert not r.ready
 
     _run(go())
 


### PR DESCRIPTION
## What changed

- make trainer attempts derive their restore point from durable run state and let Modal retries own recovery
- keep weight-version numbering stable across resumed attempts
- rewind already-running replicas safely when a restored checkpoint moves the run pointer backward
- reject new admission during restaging so requests retry on ready replicas
- boot new rollout replicas from complete volume state instead of attempt-specific image configuration
- keep three narrowly scoped Miles compatibility patches at runtime
- add a small Qwen3 kill-and-resume certification recipe

## Why

A trainer retry previously mixed attempt state into deployment configuration and could relabel weight versions after restoring a checkpoint. That made recovery require redeployment and could leave active replicas on an abandoned delta suffix. Durable run state now owns restoration, while the launcher and serving image remain attempt-invariant.

This work was separated from the GLM-5.2 DFlash preflight in #154.

## Validation

- `uv run ruff check cookbook src`
- `uv run pytest` (228 passed)