### PR TITLE
Fix rare DFlash zero-probability draft acceptance

### DIFF
--- a/cookbook/common/SGLANG_FORK.md
+++ b/cookbook/common/SGLANG_FORK.md
@@ -14,7 +14,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.17",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.17",
-    commit="6843e87bc627a40e0194081e2d8fa99137b5db50",
+    commit="d050d06437d96196fc68d5b4e5c246408790d537",
 )
 ```
 

--- a/cookbook/common/serving_image.py
+++ b/cookbook/common/serving_image.py
@@ -30,7 +30,7 @@ DEFAULT_SGLANG_RUNTIME = SGLangRuntime(
     image="lmsysorg/sglang:v0.5.17",
     repository="https://github.com/modal-projects/sglang.git",
     branch="stitch-sglang-v0.5.17",
-    commit="6843e87bc627a40e0194081e2d8fa99137b5db50",
+    commit="d050d06437d96196fc68d5b4e5c246408790d537",
 )
 
 _COOKBOOK_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary

- pin the Stitch serving image to the SGLang DFlash sampling-boundary fix
- keep the documented immutable SGLang runtime pin synchronized with the executable pin

## Root cause

The native target-only speculative sampler uses an inclusive CDF comparison. DFlash previously supplied float32 random variates from `[0, 1)`, so the rare exact-zero draw could accept a draft token with zero target probability. The resulting token was correctly absent from its positive-probability sampling support, and Miles rejected the inconsistent response.

The pinned SGLang change supplies the mathematically equivalent `(0, 1]` float32 grid expected by the inclusive comparison. This fixes the deployed Python-overlay path without rebuilding the stock native kernel or weakening Miles' sampling-support validation.

## Validation

- forced-zero DFlash GPU regression on B300
- existing DFlash sampling-mask unit tests: 4 passed
- `cookbook/common/serving_image_test.py`: passed
