### PR TITLE
cookbook: parallelize safetensors downloads

### DIFF
--- a/cookbook/common/hf_download.py
+++ b/cookbook/common/hf_download.py
@@ -1,0 +1,431 @@
+"""Parallel Hugging Face repository downloads onto Modal Volumes."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any, Protocol
+
+_MANIFEST_SUFFIX = ".stitch-hf-snapshot.json"
+DOWNLOAD_MAX_CONTAINERS = 32
+
+
+@dataclass(frozen=True)
+class CachedRepoFile:
+    """One immutable safetensors shard stored in the default HF cache."""
+
+    repo_id: str
+    revision: str
+    filename: str
+
+
+@dataclass(frozen=True)
+class LocalRepoFile:
+    """One immutable safetensors shard stored in an explicit local directory."""
+
+    repo_id: str
+    revision: str
+    filename: str
+    destination_dir: str
+
+
+@dataclass(frozen=True)
+class _SnapshotManifest:
+    repo_id: str
+    revision: str
+
+
+class _Volume(Protocol):
+    def reload(self) -> None: ...
+
+    def commit(self) -> None: ...
+
+
+class _DownloadFunction(Protocol):
+    def spawn(self, repo_file: Any) -> Any: ...
+
+
+def download_cached_safetensors_file(
+    repo_file: CachedRepoFile, *, commit: Callable[[], None]
+) -> str:
+    """Download one shard into Hugging Face's default cache and commit it."""
+
+    _require_safetensors(repo_file.filename)
+    with _isolated_xet_cache():
+        from huggingface_hub import hf_hub_download
+
+        # Deliberately omit cache_dir and local_dir. A Volume mounted at
+        # ~/.cache/huggingface therefore gets the standard hub cache layout.
+        hf_hub_download(
+            repo_id=repo_file.repo_id,
+            revision=repo_file.revision,
+            filename=repo_file.filename,
+        )
+    commit()
+    print(f"Downloaded {repo_file.filename}", flush=True)
+    return repo_file.filename
+
+
+def download_local_safetensors_file(
+    repo_file: LocalRepoFile, *, commit: Callable[[], None]
+) -> str:
+    """Download one shard into an explicit repository directory and commit it."""
+
+    _require_safetensors(repo_file.filename)
+    destination_dir = Path(repo_file.destination_dir)
+    scratch_root = destination_dir.with_name(f".{destination_dir.name}.hf-downloads")
+    scratch = scratch_root / sha256(repo_file.filename.encode()).hexdigest()
+    shutil.rmtree(scratch, ignore_errors=True)
+    try:
+        with _isolated_xet_cache():
+            from huggingface_hub import hf_hub_download
+
+            downloaded = Path(
+                hf_hub_download(
+                    repo_id=repo_file.repo_id,
+                    revision=repo_file.revision,
+                    filename=repo_file.filename,
+                    cache_dir=scratch / "hub",
+                    local_dir=scratch / "repository",
+                )
+            )
+        destination = _repo_path(destination_dir, repo_file.filename)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        partial = destination.with_name(f".{destination.name}.partial")
+        shutil.copy2(downloaded, partial, follow_symlinks=True)
+        os.replace(partial, destination)
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+    commit()
+    print(f"Downloaded {repo_file.filename}", flush=True)
+    return repo_file.filename
+
+
+def download_cached_snapshot(
+    download_file: _DownloadFunction,
+    repo_id: str,
+    revision: str | None,
+    *,
+    volume: _Volume,
+) -> str:
+    """Populate the default HF cache, spawning one call per safetensors shard.
+
+    Neither this coordinator nor its shard workers pass ``cache_dir`` or
+    ``local_dir``. Mounting a Volume at ``~/.cache/huggingface`` is therefore
+    sufficient for ordinary Hugging Face clients to reuse the result.
+    """
+
+    resolved_revision, filenames = _repo_manifest(repo_id, revision)
+    volume.reload()
+    if revision != resolved_revision:
+        _cache_requested_revision(repo_id, revision, resolved_revision, filenames)
+        volume.commit()
+    missing = _missing_cached_files(repo_id, resolved_revision, filenames)
+
+    other_files = tuple(name for name in missing if not name.endswith(".safetensors"))
+    if other_files:
+        print(
+            f"Downloading {len(other_files)} non-safetensors files for "
+            f"{repo_id}@{resolved_revision} in one batch",
+            flush=True,
+        )
+        _download_cached_files(repo_id, resolved_revision, other_files)
+        volume.commit()
+
+    safetensors = tuple(name for name in missing if name.endswith(".safetensors"))
+    if safetensors:
+        print(
+            f"Spawning {len(safetensors)} safetensors downloads for "
+            f"{repo_id}@{resolved_revision}",
+            flush=True,
+        )
+        calls = [
+            download_file.spawn(CachedRepoFile(repo_id, resolved_revision, filename))
+            for filename in safetensors
+        ]
+        _verify_results(_gather_calls(calls), safetensors)
+        volume.reload()
+
+    snapshot = Path(local_cached_snapshot(repo_id, revision))
+    missing = [name for name in filenames if not _repo_path(snapshot, name).is_file()]
+    if missing:
+        preview = ", ".join(missing[:5])
+        raise RuntimeError(
+            f"Hugging Face download finished with {len(missing)} missing files: {preview}"
+        )
+
+    print(
+        f"HF_DOWNLOAD_VERDICT status=complete repo_id={repo_id!r} "
+        f"revision={resolved_revision} files={len(filenames)} destination={snapshot}",
+        flush=True,
+    )
+    return str(snapshot)
+
+
+def local_cached_snapshot(repo_id: str, revision: str | None) -> str:
+    """Resolve a snapshot using Hugging Face's unconfigured, local-only client."""
+
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(
+        repo_id=repo_id,
+        revision=revision,
+        local_files_only=True,
+    )
+
+
+def download_local_snapshot(
+    download_file: _DownloadFunction,
+    repo_id: str,
+    revision: str | None,
+    destination: str | Path,
+    *,
+    volume: _Volume,
+) -> str:
+    """Populate an explicit directory, spawning one call per safetensors shard."""
+
+    resolved_revision, filenames = _repo_manifest(repo_id, revision)
+    manifest = _SnapshotManifest(repo_id, resolved_revision)
+    destination = Path(destination)
+    staging = destination.with_name(f"{destination.name}.partial")
+
+    volume.reload()
+    if _is_complete(destination, filenames, manifest):
+        if not _has_manifest(destination, manifest):
+            _write_manifest(destination, manifest)
+            volume.commit()
+        print(f"Reusing {repo_id}@{resolved_revision} at {destination}", flush=True)
+        return str(destination)
+
+    if not _has_manifest(staging, manifest):
+        shutil.rmtree(staging, ignore_errors=True)
+    staging.mkdir(parents=True, exist_ok=True)
+    _write_manifest(staging, manifest)
+    missing = [name for name in filenames if not _repo_path(staging, name).is_file()]
+    other_files = tuple(name for name in missing if not name.endswith(".safetensors"))
+    if other_files:
+        print(
+            f"Downloading {len(other_files)} non-safetensors files for "
+            f"{repo_id}@{resolved_revision} in one batch",
+            flush=True,
+        )
+        _download_local_files(repo_id, resolved_revision, other_files, staging)
+    volume.commit()
+
+    safetensors = tuple(
+        name
+        for name in filenames
+        if name.endswith(".safetensors") and not _repo_path(staging, name).is_file()
+    )
+    if safetensors:
+        print(
+            f"Spawning {len(safetensors)} safetensors downloads for "
+            f"{repo_id}@{resolved_revision}",
+            flush=True,
+        )
+        calls = [
+            download_file.spawn(
+                LocalRepoFile(repo_id, resolved_revision, filename, str(staging))
+            )
+            for filename in safetensors
+        ]
+        _verify_results(_gather_calls(calls), safetensors)
+        volume.reload()
+
+    missing = [name for name in filenames if not _repo_path(staging, name).is_file()]
+    if missing:
+        preview = ", ".join(missing[:5])
+        raise RuntimeError(
+            f"Hugging Face download finished with {len(missing)} missing files: {preview}"
+        )
+
+    if destination.exists():
+        shutil.rmtree(destination)
+    os.replace(staging, destination)
+    _manifest_path(staging).unlink(missing_ok=True)
+    _write_manifest(destination, manifest)
+    volume.commit()
+    print(
+        f"HF_DOWNLOAD_VERDICT status=complete repo_id={repo_id!r} "
+        f"revision={resolved_revision} files={len(filenames)} destination={destination}",
+        flush=True,
+    )
+    return str(destination)
+
+
+def _repo_manifest(repo_id: str, revision: str | None) -> tuple[str, tuple[str, ...]]:
+    from huggingface_hub import HfApi
+
+    info = HfApi().repo_info(repo_id=repo_id, revision=revision, files_metadata=False)
+    if not info.sha:
+        raise RuntimeError(f"Hugging Face did not resolve a commit for {repo_id!r}")
+    filenames = tuple(sorted(sibling.rfilename for sibling in info.siblings))
+    return info.sha, filenames
+
+
+def _missing_cached_files(
+    repo_id: str, revision: str, filenames: Sequence[str]
+) -> tuple[str, ...]:
+    from huggingface_hub import try_to_load_from_cache
+
+    missing = []
+    for filename in filenames:
+        cached = try_to_load_from_cache(
+            repo_id=repo_id,
+            revision=revision,
+            filename=filename,
+        )
+        if not isinstance(cached, str) or not Path(cached).is_file():
+            missing.append(filename)
+    return tuple(missing)
+
+
+def _cache_requested_revision(
+    repo_id: str,
+    requested_revision: str | None,
+    resolved_revision: str,
+    filenames: Sequence[str],
+) -> None:
+    """Create the standard HF ref for a branch or tag without custom metadata."""
+
+    filename = next(
+        (name for name in filenames if not name.endswith(".safetensors")),
+        filenames[0],
+    )
+    with _isolated_xet_cache():
+        from huggingface_hub import hf_hub_download
+
+        hf_hub_download(
+            repo_id=repo_id,
+            revision=requested_revision,
+            filename=filename,
+        )
+    cached_revision = Path(local_cached_snapshot(repo_id, requested_revision)).name
+    if cached_revision != resolved_revision:
+        raise RuntimeError(
+            f"{repo_id}@{requested_revision or 'main'} changed from "
+            f"{resolved_revision} to {cached_revision} during download; retry"
+        )
+
+
+def _download_cached_files(
+    repo_id: str,
+    revision: str,
+    filenames: Sequence[str],
+) -> None:
+    with _isolated_xet_cache():
+        from huggingface_hub import snapshot_download
+
+        snapshot_download(
+            repo_id=repo_id,
+            revision=revision,
+            allow_patterns=list(filenames),
+            max_workers=4,
+        )
+
+
+def _download_local_files(
+    repo_id: str,
+    revision: str,
+    filenames: Sequence[str],
+    destination: Path,
+) -> None:
+    with tempfile.TemporaryDirectory(prefix="stitch-hf-") as cache_dir:
+        with _isolated_xet_cache():
+            from huggingface_hub import snapshot_download
+
+            snapshot_download(
+                repo_id=repo_id,
+                revision=revision,
+                cache_dir=Path(cache_dir) / "hub",
+                local_dir=destination,
+                allow_patterns=list(filenames),
+                max_workers=4,
+            )
+    shutil.rmtree(destination / ".cache", ignore_errors=True)
+
+
+@contextmanager
+def _isolated_xet_cache() -> Iterator[None]:
+    """Keep Xet's long-lived log handle off a mounted Modal Volume."""
+
+    from huggingface_hub import constants
+
+    previous_constant = constants.HF_XET_CACHE
+    previous_environment = os.environ.get("HF_XET_CACHE")
+    with tempfile.TemporaryDirectory(prefix="stitch-hf-xet-") as cache_dir:
+        constants.HF_XET_CACHE = cache_dir
+        os.environ["HF_XET_CACHE"] = cache_dir
+        try:
+            yield
+        finally:
+            constants.HF_XET_CACHE = previous_constant
+            if previous_environment is None:
+                os.environ.pop("HF_XET_CACHE", None)
+            else:
+                os.environ["HF_XET_CACHE"] = previous_environment
+
+
+def _gather_calls(calls: Sequence[Any]) -> Sequence[str]:
+    from modal import FunctionCall
+
+    return FunctionCall.gather(*calls)
+
+
+def _verify_results(results: Sequence[str], expected: tuple[str, ...]) -> None:
+    if tuple(results) != expected:
+        raise RuntimeError(
+            f"safetensors downloads returned unexpected files: {results!r}"
+        )
+
+
+def _require_safetensors(filename: str) -> None:
+    if not filename.endswith(".safetensors"):
+        raise ValueError(f"expected a safetensors file, got {filename!r}")
+
+
+def _is_complete(
+    destination: Path,
+    filenames: tuple[str, ...],
+    manifest: _SnapshotManifest,
+) -> bool:
+    if not destination.is_dir():
+        return False
+    if not all(_repo_path(destination, name).is_file() for name in filenames):
+        return False
+    marker = _manifest_path(destination)
+    # Adopt complete snapshots created by the former snapshot_download helpers.
+    return not marker.exists() or _has_manifest(destination, manifest)
+
+
+def _has_manifest(directory: Path, expected: _SnapshotManifest) -> bool:
+    try:
+        values = json.loads(_manifest_path(directory).read_text())
+        return values == asdict(expected)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return False
+
+
+def _write_manifest(directory: Path, manifest: _SnapshotManifest) -> None:
+    _manifest_path(directory).write_text(
+        json.dumps(asdict(manifest), sort_keys=True) + "\n"
+    )
+
+
+def _manifest_path(directory: Path) -> Path:
+    return directory.with_name(f".{directory.name}{_MANIFEST_SUFFIX}")
+
+
+def _repo_path(directory: Path, filename: str) -> Path:
+    relative = Path(filename)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(f"repository filename escapes its destination: {filename!r}")
+    return directory / relative

--- a/cookbook/miles_disagg/prep.py
+++ b/cookbook/miles_disagg/prep.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import json
 import os
 import shlex
-import shutil
 import subprocess
 import threading
 import time
@@ -22,7 +21,7 @@ from cookbook.miles_disagg.trainer_image import (
 )
 
 
-def _apply_prep_environment(exp) -> None:
+def apply_prep_environment(exp) -> None:
     """Apply download toggles and the experiment's checkpoint quantizer contract."""
     if getattr(exp, "DISABLE_HF_XET", False):
         os.environ["HF_HUB_DISABLE_XET"] = "1"
@@ -33,25 +32,22 @@ def _apply_prep_environment(exp) -> None:
     os.environ.update(getattr(exp, "PREP_ENV", {}))
 
 
-def _source_snapshot(exp) -> str:
-    _apply_prep_environment(exp)
-    from huggingface_hub import snapshot_download
-
-    return snapshot_download(
-        exp.SOURCE_MODEL,
-        revision=getattr(exp, "SOURCE_REVISION", None),
-    )
-
-
-def _bf16_masters(exp) -> str:
+def _bf16_masters(exp, source_snapshot: str) -> str:
     """Resolve the immutable BF16 source used by both checkpoint converters."""
-    src = _source_snapshot(exp)
-    if _is_int4(src) or getattr(exp, "MATERIALIZE_BF16_MASTERS", True):
+    if _is_int4(source_snapshot) or getattr(
+        exp, "MATERIALIZE_BF16_MASTERS", True
+    ):
         return str(exp.BF16_CHECKPOINT_PATH)
-    return src
+    return source_snapshot
 
 
-def prepare_checkpoints(exp, checkpoint_volume) -> None:
+def prepare_checkpoints(
+    exp,
+    checkpoint_volume,
+    *,
+    source_snapshot: str,
+    rollout_snapshot: str | None,
+) -> None:
     """Build the bf16 masters (trainer arch source) + the served base on a GPU.
 
     masters (bf16): a quantized source (Kimi INT4) is dequantized; a bf16 source IS the
@@ -66,7 +62,7 @@ def prepare_checkpoints(exp, checkpoint_volume) -> None:
         raise SystemExit(f"unsupported SERVED_CHECKPOINT_FORMAT={served_format!r}")
     tools = f"{MILES_ROOT}/tools"
 
-    src = _source_snapshot(exp)
+    src = source_snapshot
     is_int4 = _is_int4(src)  # read the source's quant scheme, not its repo name
 
     def _build_bf16(out: str) -> None:
@@ -106,20 +102,11 @@ def prepare_checkpoints(exp, checkpoint_volume) -> None:
 
     rollout_source = getattr(exp, "ROLLOUT_SOURCE_MODEL", None)
     if rollout_source:
-        rollout_revision = getattr(exp, "ROLLOUT_SOURCE_REVISION", None)
-
-        def _download_rollout_checkpoint(out: str) -> None:
-            from huggingface_hub import snapshot_download
-
-            snapshot_download(
-                rollout_source,
-                revision=rollout_revision,
-                local_dir=out,
+        if rollout_snapshot != served_dir:
+            raise ValueError(
+                "rollout snapshot must be downloaded directly to the served path: "
+                f"{rollout_snapshot!r} != {served_dir!r}"
             )
-            shutil.rmtree(os.path.join(out, ".cache"), ignore_errors=True)
-
-        _staged(served_dir, _download_rollout_checkpoint, resume=True)
-        checkpoint_volume.commit()
         print(f"Prepared masters={bf16_dir} served_base={served_dir}")
         return
 
@@ -159,13 +146,20 @@ def prepare_checkpoints(exp, checkpoint_volume) -> None:
     print(f"Prepared masters={bf16_dir} served_base={served_dir}")
 
 
-def prepare_torch_dist(exp, checkpoint_volume, *, rank: int, master_addr: str) -> None:
+def prepare_torch_dist(
+    exp,
+    checkpoint_volume,
+    *,
+    rank: int,
+    master_addr: str,
+    source_snapshot: str,
+) -> None:
     """Build the raw-mode torch_dist reference checkpoint from the BF16 source."""
     torch_dist_path = getattr(exp, "TORCH_DIST_CHECKPOINT_PATH", None)
     if torch_dist_path is None:
         raise SystemExit("this config does not use a torch_dist trainer checkpoint")
     checkpoint_volume.reload()
-    bf16_dir = _bf16_masters(exp)
+    bf16_dir = _bf16_masters(exp, source_snapshot)
     torch_dist_dir = str(torch_dist_path)
     if os.path.exists(
         os.path.join(torch_dist_dir, "latest_checkpointed_iteration.txt")

--- a/cookbook/miles_disagg/prep_app.py
+++ b/cookbook/miles_disagg/prep_app.py
@@ -26,6 +26,16 @@ from cookbook.common.constants import (
     HF_CACHE_PATH,
     MINUTES,
 )
+from cookbook.common.hf_download import (
+    DOWNLOAD_MAX_CONTAINERS,
+    CachedRepoFile,
+    LocalRepoFile,
+    download_cached_safetensors_file,
+    download_cached_snapshot,
+    download_local_safetensors_file,
+    download_local_snapshot,
+    local_cached_snapshot,
+)
 from cookbook.miles_disagg import prep, trainer_image
 
 EXPERIMENT = os.environ[
@@ -66,6 +76,36 @@ checkpoint_gpu = (
 
 @app.function(
     image=image,
+    cpu=4,
+    memory=4096,
+    max_containers=DOWNLOAD_MAX_CONTAINERS,
+    volumes={str(HF_CACHE_PATH): hf_cache_volume},
+    timeout=6 * 60 * MINUTES,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
+)
+def _download_source_file(repo_file: CachedRepoFile) -> str:
+    prep.apply_prep_environment(exp)
+    return download_cached_safetensors_file(repo_file, commit=hf_cache_volume.commit)
+
+
+@app.function(
+    image=image,
+    cpu=4,
+    memory=4096,
+    max_containers=DOWNLOAD_MAX_CONTAINERS,
+    volumes={str(CHECKPOINTS_PATH): checkpoint_volume},
+    timeout=6 * 60 * MINUTES,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
+)
+def _download_rollout_file(repo_file: LocalRepoFile) -> str:
+    prep.apply_prep_environment(exp)
+    return download_local_safetensors_file(repo_file, commit=checkpoint_volume.commit)
+
+
+@app.function(
+    image=image,
     gpu=checkpoint_gpu,
     volumes={
         str(HF_CACHE_PATH): hf_cache_volume,
@@ -77,7 +117,27 @@ checkpoint_gpu = (
     include_source=False,
 )
 def prepare_checkpoints() -> None:
-    prep.prepare_checkpoints(exp, checkpoint_volume)
+    source_snapshot = download_cached_snapshot(
+        _download_source_file,
+        exp.SOURCE_MODEL,
+        getattr(exp, "SOURCE_REVISION", None),
+        volume=hf_cache_volume,
+    )
+    rollout_snapshot = None
+    if rollout_source := getattr(exp, "ROLLOUT_SOURCE_MODEL", None):
+        rollout_snapshot = download_local_snapshot(
+            _download_rollout_file,
+            rollout_source,
+            getattr(exp, "ROLLOUT_SOURCE_REVISION", None),
+            miles_cfg.hf_checkpoint,
+            volume=checkpoint_volume,
+        )
+    prep.prepare_checkpoints(
+        exp,
+        checkpoint_volume,
+        source_snapshot=source_snapshot,
+        rollout_snapshot=rollout_snapshot,
+    )
 
 
 # torch_dist conversion is clustered across nodes (a large MoE won't fit an 8-way split).
@@ -109,10 +169,20 @@ _TORCH_DIST_MULTINODE = modal_cfg.torch_dist_prep_nodes > 1
     else lambda fn: fn
 )
 def prepare_torch_dist() -> None:
+    hf_cache_volume.reload()
     rank, master_addr, _ = ray_cluster.get_modal_cluster_context(
         modal_cfg.torch_dist_prep_nodes
     )
-    prep.prepare_torch_dist(exp, checkpoint_volume, rank=rank, master_addr=master_addr)
+    prep.prepare_torch_dist(
+        exp,
+        checkpoint_volume,
+        rank=rank,
+        master_addr=master_addr,
+        source_snapshot=local_cached_snapshot(
+            exp.SOURCE_MODEL,
+            getattr(exp, "SOURCE_REVISION", None),
+        ),
+    )
 
 
 @app.function(

--- a/cookbook/slime_disagg/prep_app.py
+++ b/cookbook/slime_disagg/prep_app.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import importlib
 import os
-import shutil
 from pathlib import Path
 
 import modal
@@ -24,6 +23,12 @@ from cookbook.common.constants import (
     DATA_PATH,
     HF_CACHE_PATH,
     MINUTES,
+)
+from cookbook.common.hf_download import (
+    DOWNLOAD_MAX_CONTAINERS,
+    LocalRepoFile,
+    download_local_safetensors_file,
+    download_local_snapshot,
 )
 from cookbook.slime_disagg import trainer_image
 
@@ -41,9 +46,6 @@ image = trainer_image.build_trainer_image(
     hf_cache_path=str(HF_CACHE_PATH), experiment=EXPERIMENT, slime_local=SLIME_LOCAL_DIR
 )
 
-hf_cache_volume = modal.Volume.from_name(
-    "huggingface-cache", create_if_missing=True, version=2
-)
 data_volume = modal.Volume.from_name("slime-data", create_if_missing=True, version=2)
 checkpoint_volume = modal.Volume.from_name(
     "slime-checkpoints",
@@ -56,35 +58,34 @@ app = modal.App(f"{exp.APP_NAME}-prep")
 
 @app.function(
     image=image,
-    volumes={
-        str(HF_CACHE_PATH): hf_cache_volume,
-        str(CHECKPOINTS_PATH): checkpoint_volume,
-    },
+    cpu=4,
+    memory=4096,
+    max_containers=DOWNLOAD_MAX_CONTAINERS,
+    volumes={str(CHECKPOINTS_PATH): checkpoint_volume},
     timeout=2 * 60 * MINUTES,
     secrets=[modal.Secret.from_name("huggingface-secret")],
     include_source=False,
 )
-def download_model() -> None:
-    """Materialize the configured model artifact in the checkpoint Volume."""
-    from huggingface_hub import snapshot_download
+def _download_model_file(repo_file: LocalRepoFile) -> str:
+    return download_local_safetensors_file(repo_file, commit=checkpoint_volume.commit)
 
-    checkpoint_volume.reload()
-    target = Path(slime_cfg.hf_checkpoint)
-    if (target / "config.json").is_file():
-        print(f"reusing model checkpoint {target}")
-        return
-    if target.exists():
-        raise RuntimeError(f"incomplete model checkpoint: {target}")
-    partial = target.with_name(f"{target.name}.partial")
-    shutil.rmtree(partial, ignore_errors=True)
-    snapshot_download(
-        repo_id=exp.SOURCE_MODEL,
-        revision=getattr(exp, "SOURCE_REVISION", None),
-        local_dir=partial,
+
+@app.function(
+    image=image,
+    volumes={str(CHECKPOINTS_PATH): checkpoint_volume},
+    timeout=2 * 60 * MINUTES,
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    include_source=False,
+)
+def download_model() -> str:
+    """Materialize the configured model artifact with one input per repo file."""
+    return download_local_snapshot(
+        _download_model_file,
+        exp.SOURCE_MODEL,
+        getattr(exp, "SOURCE_REVISION", None),
+        Path(slime_cfg.hf_checkpoint),
+        volume=checkpoint_volume,
     )
-    shutil.rmtree(partial / ".cache", ignore_errors=True)
-    partial.rename(target)
-    checkpoint_volume.commit()
 
 
 @app.function(

--- a/tools/profiling/_hf_checkpoint.py
+++ b/tools/profiling/_hf_checkpoint.py
@@ -3,44 +3,27 @@
 from __future__ import annotations
 
 import shutil
-from collections.abc import Callable
 from pathlib import Path
+from typing import Any
+
+from cookbook.common.hf_download import download_cached_snapshot
 
 
 def download_snapshot(
+    download_file: Any,
     repo_id: str,
     revision: str,
-    cache_dir: str,
     *,
-    commit: Callable[[], None],
+    volume: Any,
 ) -> str:
-    """Download and durably commit a model-sized snapshot in bounded batches."""
+    """Download and durably commit a profiling snapshot across Modal workers."""
 
-    from huggingface_hub import HfApi, snapshot_download
-
-    files = HfApi().list_repo_files(repo_id=repo_id, revision=revision)
-    weights = sorted(path for path in files if path.endswith(".safetensors"))
-    batches = [sorted(set(files) - set(weights))]
-    batches.extend(weights[offset : offset + 4] for offset in range(0, len(weights), 4))
-    for index, batch in enumerate(batches, start=1):
-        snapshot_download(
-            repo_id=repo_id,
-            revision=revision,
-            cache_dir=cache_dir,
-            allow_patterns=batch,
-            max_workers=4,
-        )
-        commit()
-        print(f"Committed checkpoint download batch {index}/{len(batches)}")
-
-    path = snapshot_download(
-        repo_id=repo_id,
-        revision=revision,
-        cache_dir=cache_dir,
-        local_files_only=True,
+    return download_cached_snapshot(
+        download_file,
+        repo_id,
+        revision,
+        volume=volume,
     )
-    print(f"Downloaded {repo_id}@{revision} to {path}")
-    return path
 
 
 def materialize_checkpoint_view(source_dir: str, target_dir: str) -> None:

--- a/tools/profiling/glm45_air_fp8_delta_weight_update.py
+++ b/tools/profiling/glm45_air_fp8_delta_weight_update.py
@@ -10,14 +10,17 @@ element-wise synthetic delta, and runs one verified update.
 
 from __future__ import annotations
 
-import json
-import os
-import shutil
 from pathlib import Path
 
 import modal
 
 from cookbook.common.constants import CHECKPOINTS_PATH
+from cookbook.common.hf_download import (
+    DOWNLOAD_MAX_CONTAINERS,
+    LocalRepoFile,
+    download_local_safetensors_file,
+    download_local_snapshot,
+)
 from cookbook.common.serving_image import build_serving_image
 from cookbook.miles_disagg.configs import glm45_air_fp8 as model
 from tools.profiling._delta_weight_update import (
@@ -53,7 +56,6 @@ BASE_CHECKPOINT_DIR = str(model.ROLLOUT_CHECKPOINT_PATH)
 LOCAL_TARGET_CHECKPOINT_DIR = "/local-checkpoint/glm45-air-fp8/target"
 LOCAL_CANONICAL_CHECKPOINT_DIR = "/local-checkpoint/glm45-air-fp8/canonical"
 SGLANG_CACHE_PATH = "/root/.cache/sglang"
-SOURCE_MARKER = ".stitch-source.json"
 
 SGLANG_SERVER_ARGS = {
     "--served-model-name": model.ROLLOUT_SOURCE_MODEL,
@@ -97,58 +99,32 @@ serving_image = build_serving_image(
 
 @app.function(
     image=serving_image,
-    cpu=32,
-    memory=(16 * 1024, 256 * 1024),
+    cpu=4,
+    memory=4096,
+    max_containers=DOWNLOAD_MAX_CONTAINERS,
+    volumes={str(CHECKPOINTS_PATH): checkpoint_volume},
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    timeout=6 * 60 * 60,
+)
+def _download_base_file(repo_file: LocalRepoFile) -> str:
+    return download_local_safetensors_file(repo_file, commit=checkpoint_volume.commit)
+
+
+@app.function(
+    image=serving_image,
     volumes={str(CHECKPOINTS_PATH): checkpoint_volume},
     secrets=[modal.Secret.from_name("huggingface-secret")],
     timeout=6 * 60 * 60,
 )
 def prepare_base() -> str:
     """Materialize the pinned public FP8 checkpoint as one immutable artifact."""
-
-    from huggingface_hub import HfApi, snapshot_download
-
-    checkpoint_volume.reload()
-    destination = Path(BASE_CHECKPOINT_DIR)
-    expected = {
-        "repo_id": model.ROLLOUT_SOURCE_MODEL,
-        "revision": model.ROLLOUT_SOURCE_REVISION,
-    }
-    marker = destination / SOURCE_MARKER
-    index = destination / "model.safetensors.index.json"
-    if marker.is_file() and index.is_file():
-        if json.loads(marker.read_text()) == expected:
-            print(f"Reusing pinned checkpoint at {destination}")
-            return str(destination)
-
-    staging = destination.with_name(f"{destination.name}.partial")
-    staging.mkdir(parents=True, exist_ok=True)
-    files = HfApi().list_repo_files(
-        repo_id=model.ROLLOUT_SOURCE_MODEL,
-        revision=model.ROLLOUT_SOURCE_REVISION,
+    return download_local_snapshot(
+        _download_base_file,
+        model.ROLLOUT_SOURCE_MODEL,
+        model.ROLLOUT_SOURCE_REVISION,
+        BASE_CHECKPOINT_DIR,
+        volume=checkpoint_volume,
     )
-    weights = sorted(name for name in files if name.endswith(".safetensors"))
-    batches = [sorted(set(files) - set(weights))]
-    batches.extend(weights[offset : offset + 4] for offset in range(0, len(weights), 4))
-    for batch_index, batch in enumerate(batches, start=1):
-        snapshot_download(
-            repo_id=model.ROLLOUT_SOURCE_MODEL,
-            revision=model.ROLLOUT_SOURCE_REVISION,
-            local_dir=staging,
-            allow_patterns=batch,
-            max_workers=4,
-        )
-        checkpoint_volume.commit()
-        print(f"Committed checkpoint batch {batch_index}/{len(batches)}")
-
-    shutil.rmtree(staging / ".cache", ignore_errors=True)
-    (staging / SOURCE_MARKER).write_text(json.dumps(expected, sort_keys=True) + "\n")
-    if destination.exists():
-        shutil.rmtree(destination)
-    os.replace(staging, destination)
-    checkpoint_volume.commit()
-    print(f"Prepared pinned checkpoint at {destination}")
-    return str(destination)
 
 
 @app.function(

--- a/tools/profiling/glm5_2_fp8_delta_weight_update.py
+++ b/tools/profiling/glm5_2_fp8_delta_weight_update.py
@@ -15,6 +15,12 @@ from pathlib import Path
 import modal
 
 from cookbook.common.constants import HF_CACHE_PATH
+from cookbook.common.hf_download import (
+    DOWNLOAD_MAX_CONTAINERS,
+    CachedRepoFile,
+    download_cached_safetensors_file,
+    local_cached_snapshot,
+)
 from cookbook.common.serving_image import build_serving_image
 from tools.profiling._delta_weight_update import (
     WeightUpdateSpec,
@@ -51,9 +57,6 @@ DELTA_SPEC = SyntheticDeltaSpec(
 )
 DELTA_ID = f"glm5-2-fp8/{ROLLOUT_REVISION}/{synthetic_delta_profile_id(DELTA_SPEC)}"
 DELTA_SOURCE_DIR = f"{DELTA_MOUNT}/{DELTA_ID}"
-HF_SNAPSHOT_DIR = (
-    f"{HF_CACHE_PATH}/models--zai-org--GLM-5.2-FP8/snapshots/{ROLLOUT_REVISION}"
-)
 LOCAL_CHECKPOINT_ROOT = "/local-checkpoint/glm5-2-fp8"
 BASE_CHECKPOINT_DIR = f"{LOCAL_CHECKPOINT_ROOT}/base"
 LOCAL_TARGET_CHECKPOINT_DIR = f"{LOCAL_CHECKPOINT_ROOT}/target"
@@ -147,18 +150,29 @@ def _pipeline_shard_for_tensor(name: str) -> int:
 
 @app.function(
     image=download_image,
-    cpu=32,
-    memory=(16 * 1024, 256 * 1024),
+    cpu=4,
+    memory=4096,
+    max_containers=DOWNLOAD_MAX_CONTAINERS,
+    volumes={str(HF_CACHE_PATH): hf_cache_volume},
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    timeout=6 * 60 * 60,
+)
+def _download_model_file(repo_file: CachedRepoFile) -> str:
+    return download_cached_safetensors_file(repo_file, commit=hf_cache_volume.commit)
+
+
+@app.function(
+    image=download_image,
     volumes={str(HF_CACHE_PATH): hf_cache_volume},
     secrets=[modal.Secret.from_name("huggingface-secret")],
     timeout=6 * 60 * 60,
 )
 def download_model() -> str:
     return download_snapshot(
+        _download_model_file,
         ROLLOUT_MODEL,
         ROLLOUT_REVISION,
-        str(HF_CACHE_PATH),
-        commit=hf_cache_volume.commit,
+        volume=hf_cache_volume,
     )
 
 
@@ -174,7 +188,7 @@ def download_model() -> str:
 )
 def prepare_delta() -> dict:
     return prepare_standard_delta(
-        HF_SNAPSHOT_DIR,
+        local_cached_snapshot(ROLLOUT_MODEL, ROLLOUT_REVISION),
         DELTA_SOURCE_DIR,
         spec=DELTA_SPEC,
         commit=delta_volume.commit,
@@ -202,7 +216,10 @@ def benchmark(
     runtime: str,
     sample_id: str,
 ) -> dict:
-    materialize_checkpoint_view(HF_SNAPSHOT_DIR, BASE_CHECKPOINT_DIR)
+    materialize_checkpoint_view(
+        local_cached_snapshot(ROLLOUT_MODEL, ROLLOUT_REVISION),
+        BASE_CHECKPOINT_DIR,
+    )
     return run_delta_weight_update(
         WeightUpdateSpec(
             model_name="GLM-5.2 FP8",

--- a/tools/profiling/glm5_2_nvfp4_delta_weight_update.py
+++ b/tools/profiling/glm5_2_nvfp4_delta_weight_update.py
@@ -20,6 +20,12 @@ from pathlib import Path
 import modal
 
 from cookbook.common.constants import CHECKPOINTS_PATH, HF_CACHE_PATH
+from cookbook.common.hf_download import (
+    DOWNLOAD_MAX_CONTAINERS,
+    CachedRepoFile,
+    download_cached_safetensors_file,
+    download_cached_snapshot,
+)
 from cookbook.common.serving_image import build_serving_image
 from cookbook.miles_disagg import prep, trainer_image
 from cookbook.miles_disagg.configs import glm5_2_nvfp4 as model
@@ -139,6 +145,20 @@ def _pipeline_shard_for_tensor(name: str) -> int:
 
 @app.function(
     image=prep_image,
+    cpu=4,
+    memory=4096,
+    max_containers=DOWNLOAD_MAX_CONTAINERS,
+    volumes={str(HF_CACHE_PATH): hf_cache_volume},
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    timeout=6 * 60 * 60,
+)
+def _download_source_file(repo_file: CachedRepoFile) -> str:
+    prep.apply_prep_environment(model)
+    return download_cached_safetensors_file(repo_file, commit=hf_cache_volume.commit)
+
+
+@app.function(
+    image=prep_image,
     gpu=f"{model.modal.gpu}:1",
     memory=model.modal.trainer_memory_mib,
     volumes={
@@ -149,7 +169,18 @@ def _pipeline_shard_for_tensor(name: str) -> int:
     timeout=6 * 60 * 60,
 )
 def prepare_base() -> None:
-    prep.prepare_checkpoints(model, checkpoint_volume)
+    source_snapshot = download_cached_snapshot(
+        _download_source_file,
+        model.SOURCE_MODEL,
+        getattr(model, "SOURCE_REVISION", None),
+        volume=hf_cache_volume,
+    )
+    prep.prepare_checkpoints(
+        model,
+        checkpoint_volume,
+        source_snapshot=source_snapshot,
+        rollout_snapshot=None,
+    )
 
 
 @app.function(

--- a/tools/profiling/kimi_k2_6_nvfp4_delta_weight_update.py
+++ b/tools/profiling/kimi_k2_6_nvfp4_delta_weight_update.py
@@ -15,6 +15,12 @@ from pathlib import Path
 import modal
 
 from cookbook.common.constants import HF_CACHE_PATH
+from cookbook.common.hf_download import (
+    DOWNLOAD_MAX_CONTAINERS,
+    CachedRepoFile,
+    download_cached_safetensors_file,
+    local_cached_snapshot,
+)
 from cookbook.common.serving_image import build_serving_image
 from tools.profiling._delta_weight_update import (
     WeightUpdateSpec,
@@ -48,9 +54,6 @@ DELTA_SPEC = SyntheticDeltaSpec(
 )
 DELTA_ID = f"kimi-k2-6/{ROLLOUT_REVISION}/{synthetic_delta_profile_id(DELTA_SPEC)}"
 DELTA_SOURCE_DIR = f"{DELTA_MOUNT}/{DELTA_ID}"
-HF_SNAPSHOT_DIR = (
-    f"{HF_CACHE_PATH}/models--nvidia--Kimi-K2.6-NVFP4/snapshots/{ROLLOUT_REVISION}"
-)
 LOCAL_CHECKPOINT_ROOT = "/local-checkpoint/kimi-k2-6-nvfp4"
 BASE_CHECKPOINT_DIR = f"{LOCAL_CHECKPOINT_ROOT}/base"
 LOCAL_TARGET_CHECKPOINT_DIR = f"{LOCAL_CHECKPOINT_ROOT}/target"
@@ -105,6 +108,11 @@ download_image = (
         remote_path="/root/tools",
         ignore=["**/__pycache__", "**/*.pyc"],
     )
+    .add_local_dir(
+        str(Path(__file__).resolve().parents[2] / "cookbook"),
+        remote_path="/root/cookbook",
+        ignore=["**/__pycache__", "**/*.pyc"],
+    )
 )
 serving_image = build_serving_image(
     hf_cache_path=str(HF_CACHE_PATH),
@@ -118,18 +126,29 @@ serving_image = build_serving_image(
 
 @app.function(
     image=download_image,
-    cpu=32,
-    memory=(16 * 1024, 256 * 1024),
+    cpu=4,
+    memory=4096,
+    max_containers=DOWNLOAD_MAX_CONTAINERS,
+    volumes={str(HF_CACHE_PATH): hf_cache_volume},
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    timeout=6 * 60 * 60,
+)
+def _download_model_file(repo_file: CachedRepoFile) -> str:
+    return download_cached_safetensors_file(repo_file, commit=hf_cache_volume.commit)
+
+
+@app.function(
+    image=download_image,
     volumes={str(HF_CACHE_PATH): hf_cache_volume},
     secrets=[modal.Secret.from_name("huggingface-secret")],
     timeout=6 * 60 * 60,
 )
 def download_model() -> str:
     return download_snapshot(
+        _download_model_file,
         ROLLOUT_MODEL,
         ROLLOUT_REVISION,
-        str(HF_CACHE_PATH),
-        commit=hf_cache_volume.commit,
+        volume=hf_cache_volume,
     )
 
 
@@ -145,7 +164,7 @@ def download_model() -> str:
 )
 def prepare_delta() -> dict:
     return prepare_standard_delta(
-        HF_SNAPSHOT_DIR,
+        local_cached_snapshot(ROLLOUT_MODEL, ROLLOUT_REVISION),
         DELTA_SOURCE_DIR,
         spec=DELTA_SPEC,
         commit=delta_volume.commit,
@@ -172,7 +191,10 @@ def benchmark(
     runtime: str,
     sample_id: str,
 ) -> dict:
-    materialize_checkpoint_view(HF_SNAPSHOT_DIR, BASE_CHECKPOINT_DIR)
+    materialize_checkpoint_view(
+        local_cached_snapshot(ROLLOUT_MODEL, ROLLOUT_REVISION),
+        BASE_CHECKPOINT_DIR,
+    )
     return run_delta_weight_update(
         WeightUpdateSpec(
             model_name="Kimi K2.6 NVFP4",

--- a/tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
+++ b/tools/profiling/kimi_k3_mxfp4_delta_weight_update.py
@@ -24,6 +24,12 @@ from pathlib import Path
 
 import modal
 
+from cookbook.common.hf_download import (
+    DOWNLOAD_MAX_CONTAINERS,
+    CachedRepoFile,
+    download_cached_safetensors_file,
+    local_cached_snapshot,
+)
 from cookbook.common.serving_image import build_serving_image
 from cookbook.miles_disagg.configs import kimi_k3_mxfp4 as model
 from tools.profiling._delta_weight_update import (
@@ -47,10 +53,6 @@ from tools.profiling._synthetic_delta import (
 APP_NAME = "profile-kimi-k3-mxfp4-delta-weight-update"
 EXPERIMENT = "kimi_k3_mxfp4"
 HF_CACHE_PATH = "/root/.cache/huggingface"
-HF_SNAPSHOT_DIR = (
-    f"{HF_CACHE_PATH}/models--moonshotai--Kimi-K3/snapshots/"
-    f"{model.ROLLOUT_SOURCE_REVISION}"
-)
 DELTA_MOUNT = "/synthetic-delta"
 DELTA_SPEC = SyntheticDeltaSpec(
     checkpoint_format="mxfp4",
@@ -120,18 +122,29 @@ serving_image = build_serving_image(
 
 @app.function(
     image=download_image,
-    cpu=32,
-    memory=(16 * 1024, 256 * 1024),
+    cpu=4,
+    memory=4096,
+    max_containers=DOWNLOAD_MAX_CONTAINERS,
+    volumes={HF_CACHE_PATH: hf_cache_volume},
+    secrets=[modal.Secret.from_name("huggingface-secret")],
+    timeout=6 * 60 * 60,
+)
+def _download_model_file(repo_file: CachedRepoFile) -> str:
+    return download_cached_safetensors_file(repo_file, commit=hf_cache_volume.commit)
+
+
+@app.function(
+    image=download_image,
     volumes={HF_CACHE_PATH: hf_cache_volume},
     secrets=[modal.Secret.from_name("huggingface-secret")],
     timeout=6 * 60 * 60,
 )
 def download_model() -> str:
     return download_snapshot(
+        _download_model_file,
         model.ROLLOUT_SOURCE_MODEL,
         model.ROLLOUT_SOURCE_REVISION,
-        HF_CACHE_PATH,
-        commit=hf_cache_volume.commit,
+        volume=hf_cache_volume,
     )
 
 
@@ -147,7 +160,10 @@ def download_model() -> str:
 )
 def prepare_delta() -> dict:
     return prepare_standard_delta(
-        HF_SNAPSHOT_DIR,
+        local_cached_snapshot(
+            model.ROLLOUT_SOURCE_MODEL,
+            model.ROLLOUT_SOURCE_REVISION,
+        ),
         DELTA_SOURCE_DIR,
         spec=DELTA_SPEC,
         commit=delta_volume.commit,
@@ -173,7 +189,13 @@ def benchmark(
     runtime: str,
     sample_id: str,
 ) -> dict:
-    materialize_checkpoint_view(HF_SNAPSHOT_DIR, BASE_CHECKPOINT_DIR)
+    materialize_checkpoint_view(
+        local_cached_snapshot(
+            model.ROLLOUT_SOURCE_MODEL,
+            model.ROLLOUT_SOURCE_REVISION,
+        ),
+        BASE_CHECKPOINT_DIR,
+    )
     server_args = dict(model.SGLANG_SERVER_ARGS)
     server_args["--cpu-weight-cache-max-compile-group-gb"] = CPU_CACHE_GROUP_GB
     return run_delta_weight_update(


### PR DESCRIPTION
## Summary

- populate the standard Hugging Face hub cache under ~/.cache/huggingface without cache_dir or local_dir overrides
- resolve each repository to an immutable commit, preserve ordinary branch/tag refs, and batch non-safetensors through snapshot_download
- spawn one Modal call per missing safetensors shard and join the FunctionCall handles with gather
- keep explicit Slime, Miles rollout, and profiling checkpoint directories at their existing locations
- route the cache-backed Miles source and profiling downloads through the shared parallel helper

## Verification

- UV_CACHE_DIR=/tmp/uv-cache uv run --frozen pytest (174 passed, 49 sandbox-only skips)
- UV_CACHE_DIR=/tmp/uv-cache uv run --frozen ruff check .
- clean CPU-only Modal probe in stitch-dev using hf-internal-testing/tiny-hidream-i1-pipe: 27 remaining non-safetensors batched once, 6 safetensors spawned concurrently, and a fresh container resolved both main and the pinned commit with local_files_only=True from /root/.cache/huggingface/hub
- temporary probe Volumes deleted