### PR TITLE
stitch: staging watchdog gating and generation pause for cpu delta stages

### DIFF
--- a/src/stitch/engines/sglang.py
+++ b/src/stitch/engines/sglang.py
@@ -84,12 +84,26 @@ class SGLangEngine(Engine):
         )
 
     async def stage(self, manifest: VersionManifest, source_dir: str) -> None:
-        await self._stage_weight_update(
-            checkpoint_source_dir=str(Path(source_dir).parent),
-            target_version=manifest.ref.version,
-            base_version=self._boot_version,
-            destination=self._destination_for(manifest),
-        )
+        destination = self._destination_for(manifest)
+        # The fork serializes nothing between the cpu-image compile and
+        # generation forwards: the engine recompiles the FULL image on
+        # each delta (minutes at large-model scale), and concurrent
+        # forwards contend with the compile. Pause the scheduler around
+        # the stage RPC — the same pause the commit path uses. Requests
+        # queued during the pause resume automatically afterward.
+        # Disk-destination stages are pure file I/O and stay un-paused.
+        if destination == "cpu":
+            await self.pause()
+        try:
+            await self._stage_weight_update(
+                checkpoint_source_dir=str(Path(source_dir).parent),
+                target_version=manifest.ref.version,
+                base_version=self._boot_version,
+                destination=destination,
+            )
+        finally:
+            if destination == "cpu":
+                await self.resume()
 
     async def initialize_update_destination(self, boot_version: int = 0) -> None:
         await self._stage_weight_update(

--- a/src/stitch/engines/sglang_test.py
+++ b/src/stitch/engines/sglang_test.py
@@ -195,6 +195,7 @@ def test_cpu_mode_stages_deltas_in_cpu() -> None:
     engine._post = fake_post  # type: ignore[method-assign]
     asyncio.run(engine.stage(_manifest(VersionKind.DELTA), "/source/weight_v000005"))
     assert requests == [
+        ("/pause_generation", {"mode": "in_place"}),
         (
             "/stage_weight_update",
             {
@@ -204,8 +205,45 @@ def test_cpu_mode_stages_deltas_in_cpu() -> None:
                 "target_version": 5,
                 "destination": "cpu",
             },
-        )
+        ),
+        ("/continue_generation", {}),
     ]
+
+
+def test_cpu_stage_resumes_generation_after_stage_failure() -> None:
+    engine = SGLangEngine(
+        "http://engine",
+        "/base",
+        "/ckpt",
+        delta_update_mode="cpu",
+    )
+    requests = []
+
+    async def fake_post(path, payload, *, timeout=None, action=None):
+        requests.append(path)
+        if path == "/stage_weight_update":
+            raise RuntimeError("compile OOM")
+
+    engine._post = fake_post  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="compile OOM"):
+        asyncio.run(engine.stage(_manifest(VersionKind.DELTA), "/source/weight_v000005"))
+    assert requests == [
+        "/pause_generation",
+        "/stage_weight_update",
+        "/continue_generation",
+    ]
+
+
+def test_disk_stage_does_not_pause_generation() -> None:
+    engine = SGLangEngine("http://engine", "/base", "/ckpt")
+    requests = []
+
+    async def fake_post(path, payload, *, timeout=None, action=None):
+        requests.append(path)
+
+    engine._post = fake_post  # type: ignore[method-assign]
+    asyncio.run(engine.stage(_manifest(VersionKind.DELTA), "/source/weight_v000005"))
+    assert requests == ["/stage_weight_update"]
 
 
 def test_cpu_mode_rejects_full_checkpoint_staging() -> None:
@@ -289,7 +327,14 @@ def test_resumed_destination_preserves_boot_version(mode: str) -> None:
     }
     if mode == "disk":
         staged["local_checkpoint_dir"] = "/ckpt"
-    assert requests == [("/stage_weight_update", staged)]
+    expected = [("/stage_weight_update", staged)]
+    if mode == "cpu":
+        expected = [
+            ("/pause_generation", {"mode": "in_place"}),
+            *expected,
+            ("/continue_generation", {}),
+        ]
+    assert requests == expected
 
 
 def test_staging_and_commit_have_independent_timeouts() -> None:

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -23,7 +23,12 @@ from typing import Any, Protocol
 from stitch.engines.base import Engine
 from stitch.pools.base import Pool
 from stitch.stores.base import Store
-from stitch.sync import AdmissionGate, CommitMode, ConstraintUnmet, Reconciler
+from stitch.sync import (
+    AdmissionGate,
+    CommitMode,
+    ConstraintUnmet,
+    Reconciler,
+)
 from stitch.types import PoolState, ReplicaState, VersionConstraint
 from stitch.watchdog import (
     EngineWatchdog,
@@ -77,7 +82,8 @@ def create_app(
     """The versioned rollout proxy. Versioned routes are admitted through the gate
     (constraint enforced, serving version captured), stamped by the engine, forwarded,
     and the response stamped with the served version. A rejected constraint returns a
-    retryable 409; a client disconnect aborts the upstream generation. A local-engine
+    retryable 409; admission during a generation-pausing stage returns a retryable
+    503; a client disconnect aborts the upstream generation. A local-engine
     transport failure returns a retryable 503 instead of escaping as a sidecar 500.
     An admitted exact-pin carrying ``lease_header`` acquires or renews a
     version lease in the gate."""

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -442,3 +442,31 @@ def test_await_pool_ready_fails_closed_below_threshold(monkeypatch) -> None:
         )
 
 
+def test_staging_pause_holds_admission_until_cleared(monkeypatch):
+    # During a generation-pausing stage the proxy holds new work (no error
+    # surfaces); once the pause clears the held request is admitted and
+    # forwarded normally.
+    async def go():
+        upstream = _HangingUpstream()
+        allow_disconnect = asyncio.Event()
+        sidecar = _GateSidecar(VersionRef("run", 3))
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: upstream)
+        app = create_app(sidecar.gate, sidecar, _ProxyEngine())
+
+        sidecar.gate.staging_pause = True
+        request = asyncio.create_task(
+            _asgi_post(app, {"rid": "rollout-3"}, disconnect_on=allow_disconnect)
+        )
+        await asyncio.sleep(0.02)
+        assert not request.done(), "the request holds behind the staging pause"
+        assert not upstream.started.is_set()  # nothing enqueued behind the pause
+        assert sidecar.gate.active_requests == 0
+
+        await sidecar.gate.clear_staging_pause()
+        await asyncio.wait_for(upstream.started.wait(), 2.0)  # admitted + forwarded
+        assert sidecar.gate.active_requests == 1
+        allow_disconnect.set()
+        status, _, _ = await request
+        assert status == 499, "released by the disconnect — never a pause rejection"
+
+    asyncio.run(go())

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -66,7 +66,8 @@ class AdmissionGate:
     Version leases (``version_lease_ttl > 0``) hold a replica on its applied
     version while pinned sessions are active. An ``in_place`` commit waits,
     admission still open, until no unexpired lease names a version below the
-    target.
+    target; the reconciler runs that wait *before* staging, because a
+    cpu-destination stage pauses generation for minutes.
 
     The gate does not own the served version: it reads it through the injected
     ``served_version`` reader, always under its condition lock, and reports every
@@ -96,12 +97,31 @@ class AdmissionGate:
         self._committing = False
         self._drain_all = False
         self._exact_inflight: dict[int, int] = defaultdict(int)
+        # Set by the reconciler while a generation-pausing (cpu-destination)
+        # stage occupies the engine: admit holds new work until the stage
+        # clears; nothing queues behind the pause.
+        self._staging_pause = False
         # lease_key -> (exact version, monotonic expiry). Pruned lazily.
         self._leases: dict[str, tuple[int, float]] = {}
 
     @property
     def active_requests(self) -> int:
         return self._active
+
+    @property
+    def staging_pause(self) -> bool:
+        return self._staging_pause
+
+    @staging_pause.setter
+    def staging_pause(self, active: bool) -> None:
+        self._staging_pause = active
+
+    async def clear_staging_pause(self) -> None:
+        """Clear the staging hold and wake held admissions — under the cond
+        lock, matching how commit clears ``_committing``."""
+        async with self._cond:
+            self._staging_pause = False
+            self._cond.notify_all()
 
     def _rejection(self, c: VersionConstraint) -> dict[str, Any] | None:
         served = self._served_version()
@@ -182,7 +202,11 @@ class AdmissionGate:
         think-time still holds the replica on its version."""
         c = constraint or VersionConstraint()
         async with self._cond:
-            await self._cond.wait_for(lambda: not self._committing)
+            # Stock-shaped hold: wait out a running commit and a
+            # generation-pausing stage alike; no error surfaces.
+            await self._cond.wait_for(
+                lambda: not self._committing and not self._staging_pause
+            )
             error = self._rejection(c)
             if error is not None:
                 self._on_reject(error)
@@ -303,6 +327,12 @@ class Reconciler:
             raise ValueError("boot_version must be non-negative")
         self.store = store
         self.engine = engine
+        # Only a cpu-destination stage pauses generation (the engine pauses its
+        # scheduler around the stage RPC); disk-destination stages are pure file
+        # I/O. An engine that declares no mode keeps stock behavior: no pause.
+        self._stage_pauses_generation = (
+            getattr(engine, "delta_update_mode", "disk") == "cpu"
+        )
         self.flush_cache_on_commit = flush_cache_on_commit
         self.run_id = run_id
         self.boot_version = boot_version
@@ -321,6 +351,7 @@ class Reconciler:
         self.sync_state = SyncState.IDLE
         self._hold_prior = SyncState.IDLE
         self.last_error: str | None = None
+        self._target_version: int | None = None
         # Latches after first catch-up unless the replica becomes terminal.
         self.ready = False
         self.metrics: dict[str, Any] = {}
@@ -389,6 +420,8 @@ class Reconciler:
             "applied_version": self.applied.version if self.applied else None,
             "leases": self.gate.leases_snapshot(),
             "sync_state": self.sync_state.value,
+            "staging_pause": self.gate.staging_pause,
+            "target_version": self._target_version,
             "reason": self.last_error,
             "run_id": self.run_id,
             "commit_mode": self.gate.commit_mode,
@@ -417,7 +450,18 @@ class Reconciler:
 
     def expects_engine_progress(self) -> bool:
         """Whether this replica should currently make inference progress."""
-        return self.ready and self.sync_state is not SyncState.COMMITTING
+        # A cpu-destination stage or a commit RPC can occupy the engine's HTTP
+        # loop for minutes (a first cpu-mode delta compiles the full weight
+        # image), so a health probe timing out then is not an independent
+        # engine-health signal. Disk-destination stages are pure file I/O: the
+        # engine keeps serving, and the watchdog keeps probing.
+        if not self.ready:
+            return False
+        if self.sync_state is SyncState.COMMITTING:
+            return False
+        return not (
+            self.sync_state is SyncState.STAGING and self._stage_pauses_generation
+        )
 
     def _on_hold_start(self) -> None:
         """Surface a gate-internal lease hold as HOLDING so drain selection
@@ -427,6 +471,12 @@ class Reconciler:
 
     def _on_hold_end(self) -> None:
         self.sync_state = self._hold_prior
+
+    def _clear_live_target(self) -> None:
+        # No live target: a stale metrics.target_version must not advertise
+        # one through /server_info.
+        self._target_version = None
+        self.metrics.pop("target_version", None)
 
     async def wait_for_terminal_error(self) -> None:
         """Raise once reconciliation proves this replica must be replaced."""
@@ -466,12 +516,14 @@ class Reconciler:
             except UnrecoverableSidecarError as exc:
                 self.last_error = str(exc)
                 self.sync_state = SyncState.ERROR
+                self._clear_live_target()
                 self._record_terminal_error(exc)
                 logger.exception("reconcile failed terminally")
                 return
             except Exception as exc:  # noqa: BLE001
                 self.last_error = str(exc)
                 self.sync_state = SyncState.ERROR
+                self._clear_live_target()
                 logger.exception("reconcile failed")
                 if self._wake_pending:
                     continue
@@ -480,6 +532,7 @@ class Reconciler:
                 if self._wake_pending:
                     continue
                 self.sync_state = SyncState.IDLE
+                self._clear_live_target()
                 if not self.ready:
                     logger.info(
                         "caught up to v%d in %d pass(es), %.0fs — entering rotation",
@@ -521,6 +574,38 @@ class Reconciler:
             if m.kind is not VersionKind.DELTA or m.files:
                 return True
         return False
+
+    async def _advance_to_newer_head(
+        self,
+        pointer: VersionRef,
+        target: VersionManifest,
+        source_dir: str,
+        m: dict[str, Any],
+        *,
+        error_key: str,
+        warning: str,
+        info: str,
+    ) -> tuple[VersionRef, VersionManifest, str]:
+        """Re-read the head after a long hold/stage; if it advanced within the
+        same run (never across — a run change is a reset, not a coalesce),
+        adopt the newer target so the wait never commits an obsolete version."""
+        try:
+            await asyncio.to_thread(self.store.refresh)
+            latest = await asyncio.to_thread(self.store.read_pointer)
+            if (
+                latest is None
+                or latest.run_id != pointer.run_id
+                or latest.version <= pointer.version
+            ):
+                return pointer, target, source_dir
+            latest_target = await asyncio.to_thread(self.store.read_manifest, latest)
+            latest_source_dir = await asyncio.to_thread(self.store.materialize, latest)
+        except Exception as exc:  # noqa: BLE001
+            m[error_key] = str(exc)
+            logger.warning(warning, pointer.version, exc_info=True)
+            return pointer, target, source_dir
+        logger.info(info, pointer.version, latest.version)
+        return latest, latest_target, latest_source_dir
 
     async def _reconcile_once(self) -> bool:
         async with self._lock:
@@ -586,48 +671,58 @@ class Reconciler:
             )
             m["skipped_weight_update"] = True
         else:
+            initial_pointer = pointer
+            self._target_version = pointer.version
+            if (
+                self.gate.commit_mode == "in_place"
+                and self.gate.leases_blocking(pointer.version)
+            ):
+                # A cpu-destination stage pauses generation for minutes, so wait
+                # out live leases first — admission open, engine serving.
+                # HOLDING is not a stage/commit: the watchdog stays fully live.
+                self.sync_state = SyncState.HOLDING
+                with _timed(m, "hold_s"):
+                    await self.gate.hold_for_leases(pointer.version)
+                # The hold can last minutes; re-read the head so coalescing
+                # stages the newest target, never a stale one.
+                pointer, target, source_dir = await self._advance_to_newer_head(
+                    pointer,
+                    target,
+                    source_dir,
+                    m,
+                    error_key="hold_coalesce_error",
+                    warning="could not inspect a newer target after the lease hold; "
+                    "staging v%d",
+                    info="catch-up: lease hold advanced head v%d -> v%d before staging",
+                )
+                self._target_version = pointer.version
             # Preparation runs while serving. Re-read the head once before the
             # commit so a slow stage does not force an avoidable GPU update to an
             # already-obsolete version. One re-check bounds the work when the
             # trainer publishes continuously.
             self.sync_state = SyncState.STAGING
-            initial_pointer = pointer
-            with _timed(m, "stage_s"):
-                await self.engine.stage(target, source_dir)
-                try:
-                    await asyncio.to_thread(self.store.refresh)
-                    latest = await asyncio.to_thread(self.store.read_pointer)
-                    if (
-                        latest is not None
-                        and latest.run_id == pointer.run_id
-                        and latest.version > pointer.version
-                    ):
-                        latest_target = await asyncio.to_thread(
-                            self.store.read_manifest, latest
-                        )
-                        latest_source_dir = await asyncio.to_thread(
-                            self.store.materialize, latest
-                        )
-                    else:
-                        latest = None
-                except Exception as exc:  # noqa: BLE001
-                    latest = None
-                    m["coalesce_error"] = str(exc)
-                    logger.warning(
-                        "could not inspect a newer target; committing staged v%d",
-                        pointer.version,
-                        exc_info=True,
+            # A cpu-destination stage pauses generation, possibly for minutes:
+            # hold new admissions for the pause rather than enqueue abandoned
+            # requests behind the paused engine. Disk-destination stages serve
+            # throughout.
+            self.gate.staging_pause = self._stage_pauses_generation
+            try:
+                with _timed(m, "stage_s"):
+                    await self.engine.stage(target, source_dir)
+                    staged_pointer = pointer
+                    pointer, target, source_dir = await self._advance_to_newer_head(
+                        pointer,
+                        target,
+                        source_dir,
+                        m,
+                        error_key="coalesce_error",
+                        warning="could not inspect a newer target; committing staged v%d",
+                        info="catch-up: staging advanced head v%d -> v%d before commit",
                     )
-
-                if latest is not None:
-                    logger.info(
-                        "catch-up: staging advanced head v%d -> v%d before commit",
-                        pointer.version,
-                        latest.version,
-                    )
-                    await self.engine.stage(latest_target, latest_source_dir)
-                    pointer = latest
-                    target = latest_target
+                    if pointer is not staged_pointer:
+                        await self.engine.stage(target, source_dir)
+            finally:
+                await self.gate.clear_staging_pause()
 
             if pointer != initial_pointer:
                 m["initial_target_version"] = initial_pointer.version

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -27,6 +27,14 @@ from stitch.types import (
 _make_reconciler = partial(Reconciler, run_id="r1")
 
 
+async def _admit_served(
+    gate: AdmissionGate, constraint: VersionConstraint | None
+) -> VersionRef | None:
+    """One admission returning the version it was served on."""
+    async with gate.admit(constraint) as served:
+        return served
+
+
 class FakeStore(Store):
     def __init__(
         self, pointer: VersionRef | None = None, *manifests: VersionManifest
@@ -178,6 +186,9 @@ def test_startup_initializes_update_destination() -> None:
         (True, SyncState.IDLE, True),
         (True, SyncState.FETCHING, True),
         (True, SyncState.HOLDING, True),
+        # A mode-less engine keeps stock behavior (no staging pause): STAGING
+        # expects progress. The cpu-mode pause case lives in
+        # test_staging_pause_cpu_vs_disk.
         (True, SyncState.STAGING, True),
         (True, SyncState.COMMITTING, False),
         (True, SyncState.ERROR, True),
@@ -240,7 +251,7 @@ def test_latest_advance_during_stage_coalesces_before_commit() -> None:
         assert engine.committed == [VersionRef("r1", 10)]
         assert r.applied == VersionRef("r1", 10)
         assert r.metrics["initial_target_version"] == 7
-        assert r.metrics["target_version"] == 10
+        assert "target_version" not in r.metrics  # cleared once IDLE
         assert r.metrics["coalesced_versions"] == 3
 
     _run(go())
@@ -1061,6 +1072,313 @@ def test_lease_lifecycle() -> None:
         info = r.server_info()
         assert info["applied_version"] == 0
         assert info["leases"] == {}
+
+    _run(go())
+
+
+def _reconciler_v4(engine: FakeEngine, **kwargs) -> Reconciler:
+    """Reconciler targeting v4 with v3 applied, in-place commits."""
+    kwargs.setdefault("store", FakeStore(VersionRef("r1", 4), _full("r1", 4)))
+    r = _make_reconciler(engine=engine, commit_mode="in_place", **kwargs)
+    r.applied = VersionRef("r1", 3)
+    return r
+
+
+def test_reconcile_holds_before_stage() -> None:
+    """Hold blocks stage/commit with admission open; renew extends; pointer
+    re-read after the hold; in-flight pins block commit, not stage."""
+
+    async def go() -> None:
+        engine = FakeEngine()
+        r = _reconciler_v4(engine, version_lease_ttl=0.15)
+        pin = VersionConstraint(exact_version=3)
+
+        async def pinned() -> None:
+            async with r.gate.admit(pin, lease_key="sess-1"):
+                pass
+
+        await pinned()
+        assert r.gate.leases_snapshot() == {3: 1}
+        r.ready = True
+        sync = asyncio.create_task(r.reconcile())
+        await asyncio.sleep(0.05)
+        assert "stage:4" not in engine.calls
+        assert "commit:4" not in engine.calls
+        assert not r.gate._committing
+        assert engine.staged == []
+        assert r.sync_state is SyncState.HOLDING
+        assert r.expects_engine_progress()
+        info = r.server_info()
+        assert info["sync_state"] == "HOLDING"
+        assert info["target_version"] == 4
+
+        rolling_served: list[VersionRef | None] = []
+        async with r.gate.admit(None) as served:
+            rolling_served.append(served)
+        assert rolling_served == [VersionRef("r1", 3)]
+
+        await pinned()  # renew extends the hold
+        await asyncio.sleep(0.1)
+        assert "stage:4" not in engine.calls
+        assert "commit:4" not in engine.calls
+
+        await asyncio.wait_for(sync, 2.0)
+        assert engine.calls.index("stage:4") < engine.calls.index("commit:4")
+        assert engine.staged == [VersionRef("r1", 4)]
+        assert engine.committed == [VersionRef("r1", 4)]
+        assert r.applied == VersionRef("r1", 4)
+        assert r.gate.leases_snapshot() == {}
+        assert "hold_s" in r.metrics
+        info = r.server_info()
+        assert info["sync_state"] == "IDLE"
+        assert info["target_version"] is None
+
+        engine = FakeEngine()
+        manifests = [_delta("r1", v, files=[f"v{v}"]) for v in (4, 5)]
+        store = FakeStore(VersionRef("r1", 4), *manifests)
+        r = _reconciler_v4(engine, store=store, version_lease_ttl=0.1)
+        async with r.gate.admit(VersionConstraint(exact_version=3), lease_key="sess"):
+            pass
+        sync = asyncio.create_task(r.reconcile())
+        await asyncio.sleep(0.03)
+        assert r.sync_state is SyncState.HOLDING
+        store.advance_pointer(VersionRef("r1", 5))
+        await asyncio.wait_for(sync, 2.0)
+        assert engine.staged == [VersionRef("r1", 5)]
+        assert engine.committed == [VersionRef("r1", 5)]
+        assert r.applied == VersionRef("r1", 5)
+        assert r.metrics["initial_target_version"] == 4
+        assert "target_version" not in r.metrics
+        assert r.metrics["coalesced_versions"] == 1
+
+        engine = FakeEngine()
+        r = _reconciler_v4(engine)
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def inflight() -> None:
+            async with r.gate.admit(
+                VersionConstraint(exact_version=3), lease_key="sess"
+            ):
+                entered.set()
+                await release.wait()
+
+        pin_task = asyncio.create_task(inflight())
+        await entered.wait()
+        assert r.gate.leases_snapshot() == {}
+        sync = asyncio.create_task(r.reconcile())
+        await asyncio.sleep(0.05)
+        assert engine.staged == [VersionRef("r1", 4)]
+        assert "commit:4" not in engine.calls
+        release.set()
+        await asyncio.wait_for(sync, 2.0)
+        assert engine.committed == [VersionRef("r1", 4)]
+        assert "hold_s" not in r.metrics
+        await pin_task
+
+        engine = FakeEngine()
+        engine.delta_update_mode = "disk"  # type: ignore[attr-defined]
+        r = _reconciler_v4(engine, version_lease_ttl=0.2)
+        r.ready = True
+        base_stage = engine.stage
+        staged = asyncio.Event()
+
+        async def stage_then_pin(manifest: VersionManifest, source_dir: str) -> None:
+            await base_stage(manifest, source_dir)
+            async with r.gate.admit(VersionConstraint(exact_version=3), lease_key="sess"):
+                pass
+            staged.set()
+
+        engine.stage = stage_then_pin  # type: ignore[method-assign]
+        sync = asyncio.create_task(r.reconcile())
+        await staged.wait()
+        await asyncio.sleep(0.05)
+        assert "commit:4" not in engine.calls
+        assert not r.gate._committing
+        assert r.sync_state is SyncState.HOLDING
+        assert r.expects_engine_progress()
+        assert r.server_info()["sync_state"] == "HOLDING"
+        await asyncio.wait_for(sync, 2.0)
+        assert engine.committed == [VersionRef("r1", 4)]
+        assert r.applied == VersionRef("r1", 4)
+        assert r.sync_state is SyncState.IDLE
+
+    _run(go())
+
+
+def test_ttl_positive_without_live_leases_stages_immediately() -> None:
+    """ttl>0 but zero live leases: the pre-stage hold never engages — a
+    pointer move stages at once, in stock order."""
+
+    async def go() -> None:
+        engine = FakeEngine()
+        r = _reconciler_v4(engine, version_lease_ttl=30.0)
+        r.ready = True
+        stage_started = asyncio.Event()
+        finish_stage = asyncio.Event()
+        base_stage = engine.stage
+
+        async def slow_stage(manifest: VersionManifest, source_dir: str) -> None:
+            await base_stage(manifest, source_dir)
+            stage_started.set()
+            await finish_stage.wait()
+
+        engine.stage = slow_stage  # type: ignore[method-assign]
+        sync = asyncio.create_task(r.reconcile())
+        await asyncio.wait_for(stage_started.wait(), 0.5)  # no hold detour
+        assert r.sync_state is SyncState.STAGING
+        finish_stage.set()
+        await asyncio.wait_for(sync, 2.0)
+        assert engine.calls == ["stage:4", "pause", "commit:4", "resume"]
+        assert r.applied == VersionRef("r1", 4)
+        assert "hold_s" not in r.metrics
+        assert r.gate.leases_snapshot() == {}
+
+    _run(go())
+
+
+def test_staging_pause_cpu_vs_disk() -> None:
+    """cpu vs disk staging-pause asymmetry: a cpu stage holds admission, a
+    disk stage keeps it open; the watchdog expects progress on disk STAGING,
+    not cpu STAGING."""
+
+    async def go() -> None:
+        engine = FakeEngine()
+        engine.delta_update_mode = "cpu"  # type: ignore[attr-defined]
+        r = _make_reconciler(
+            store=FakeStore(VersionRef("r1", 4), _full("r1", 4)), engine=engine
+        )
+        r.applied = VersionRef("r1", 3)
+        stage_started = asyncio.Event()
+        finish_stage = asyncio.Event()
+        base_stage = engine.stage
+
+        async def slow_stage(manifest: VersionManifest, source_dir: str) -> None:
+            await base_stage(manifest, source_dir)
+            stage_started.set()
+            await finish_stage.wait()
+
+        engine.stage = slow_stage  # type: ignore[method-assign]
+        sync = asyncio.create_task(r.reconcile())
+        await stage_started.wait()
+        assert r.sync_state is SyncState.STAGING
+        assert r.gate.staging_pause
+        assert r.server_info()["staging_pause"] is True
+        held_open = asyncio.create_task(_admit_served(r.gate, None))
+        held_pinned = asyncio.create_task(
+            _admit_served(r.gate, VersionConstraint(exact_version=3))
+        )
+        await asyncio.sleep(0.02)
+        assert not held_open.done() and not held_pinned.done(), (
+            "admissions hold behind the cpu staging pause"
+        )
+        finish_stage.set()
+        await asyncio.wait_for(sync, 2.0)
+        assert not r.gate.staging_pause
+        assert r.server_info()["staging_pause"] is False
+        assert r.applied == VersionRef("r1", 4)
+        assert await asyncio.wait_for(held_open, 2.0) == VersionRef("r1", 4), (
+            "an unconstrained request held through the pause is admitted after"
+        )
+        with pytest.raises(ConstraintUnmet):
+            await held_pinned  # v4 applied: the stale pin 409s as usual
+
+        engine = FakeEngine()
+        engine.delta_update_mode = "disk"  # type: ignore[attr-defined]
+        r = _make_reconciler(
+            store=FakeStore(VersionRef("r1", 4), _full("r1", 4)), engine=engine
+        )
+        r.applied = VersionRef("r1", 3)
+        stage_started = asyncio.Event()
+        finish_stage = asyncio.Event()
+        base_stage = engine.stage
+
+        async def slow_disk(manifest: VersionManifest, source_dir: str) -> None:
+            await base_stage(manifest, source_dir)
+            stage_started.set()
+            await finish_stage.wait()
+
+        engine.stage = slow_disk  # type: ignore[method-assign]
+        sync = asyncio.create_task(r.reconcile())
+        await stage_started.wait()
+        assert r.sync_state is SyncState.STAGING
+        assert not r.gate.staging_pause
+        async with r.gate.admit(None) as served:
+            assert served == VersionRef("r1", 3)
+        finish_stage.set()
+        await asyncio.wait_for(sync, 2.0)
+        assert r.applied == VersionRef("r1", 4)
+
+        engine = FakeEngine()
+        engine.delta_update_mode = "disk"  # type: ignore[attr-defined]
+        r = _make_reconciler(store=FakeStore(), engine=engine)
+        r.ready = True
+        r.sync_state = SyncState.STAGING
+        assert r.expects_engine_progress() is True
+        r.sync_state = SyncState.COMMITTING
+        assert r.expects_engine_progress() is False
+        engine = FakeEngine()
+        engine.delta_update_mode = "cpu"  # type: ignore[attr-defined]
+        r = _make_reconciler(store=FakeStore(), engine=engine)
+        r.ready = True
+        r.sync_state = SyncState.STAGING
+        assert r.expects_engine_progress() is False
+
+    _run(go())
+
+
+def test_staging_pause_default_mode_is_stock() -> None:
+    """An engine that declares no ``delta_update_mode`` keeps stock behavior:
+    the staging pause is disabled."""
+    engine = FakeEngine()
+    assert not hasattr(engine, "delta_update_mode")
+    r = _make_reconciler(store=FakeStore(), engine=engine)
+    assert r._stage_pauses_generation is False
+    assert not r.gate.staging_pause
+
+
+def test_stage_failure_releases_pause_and_recovers() -> None:
+    """A stage that raises lands the reconciler in ERROR with the admission
+    hold released (the finally clears it); a later pass reconciles cleanly."""
+
+    async def go() -> None:
+        engine = FakeEngine()
+        engine.delta_update_mode = "cpu"  # type: ignore[attr-defined]
+        r = _make_reconciler(
+            store=FakeStore(VersionRef("r1", 4), _full("r1", 4)), engine=engine
+        )
+        r.applied = VersionRef("r1", 3)
+        base_stage = engine.stage
+        stage_entered = asyncio.Event()
+        release_stage = asyncio.Event()
+
+        async def fail_stage(manifest: VersionManifest, source_dir: str) -> None:
+            stage_entered.set()
+            await release_stage.wait()
+            raise RuntimeError("stage boom")
+
+        engine.stage = fail_stage  # type: ignore[method-assign]
+        sync = asyncio.create_task(r.reconcile())
+        await stage_entered.wait()
+        assert r.gate.staging_pause  # the cpu-mode pause brackets the stage
+        held = asyncio.create_task(_admit_served(r.gate, None))
+        await asyncio.sleep(0.02)
+        assert not held.done(), "admission holds behind the staging pause"
+        release_stage.set()
+        await asyncio.wait_for(sync, 2.0)
+        assert r.sync_state is SyncState.ERROR
+        assert "stage boom" in (r.last_error or "")
+        assert not r.gate.staging_pause
+        assert r.server_info()["staging_pause"] is False
+        assert await asyncio.wait_for(held, 2.0) == VersionRef("r1", 3), (
+            "the finally-cleared pause releases the held admission"
+        )
+
+        engine.stage = base_stage  # type: ignore[method-assign]
+        await r.reconcile()
+        assert r.applied == VersionRef("r1", 4)
+        assert r.sync_state is SyncState.IDLE
+        assert not r.gate.staging_pause
 
     _run(go())
 

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -1237,6 +1237,68 @@ def test_ttl_positive_without_live_leases_stages_immediately() -> None:
     _run(go())
 
 
+def test_ttl_zero_reconcile_path_is_legacy_identical() -> None:
+    """ttl 0 (the default) is byte-for-byte stock across the FULL reconcile
+    path: no lease table writes, no HOLDING state (pre-stage hold included),
+    no hold metrics — stage and commit run in the stock order, with only
+    the cpu-mode staging hold applied."""
+
+    async def go() -> None:
+        engine = FakeEngine()
+        engine.delta_update_mode = "cpu"  # type: ignore[attr-defined]
+        r = _make_reconciler(
+            store=FakeStore(VersionRef("r1", 4), _full("r1", 4)),
+            engine=engine,
+            commit_mode="in_place",
+        )  # version_lease_ttl defaults to 0
+        r.applied = VersionRef("r1", 3)
+        r.ready = True
+
+        # A pinned admit carrying a lease key writes nothing without ttl.
+        async with r.gate.admit(VersionConstraint(exact_version=3), lease_key="sess"):
+            pass
+        assert r.gate.leases_snapshot() == {}
+
+        stage_started = asyncio.Event()
+        finish_stage = asyncio.Event()
+        base_stage = engine.stage
+
+        async def slow_stage(manifest: VersionManifest, source_dir: str) -> None:
+            await base_stage(manifest, source_dir)
+            stage_started.set()
+            await finish_stage.wait()
+
+        engine.stage = slow_stage  # type: ignore[method-assign]
+        sync = asyncio.create_task(r.reconcile())
+        await stage_started.wait()
+        # Staging begins immediately: the pre-stage hold never engages without
+        # ttl, so the state is STAGING, never HOLDING.
+        assert r.sync_state is SyncState.STAGING
+        assert r.gate.staging_pause  # the cpu-mode pause is ttl-independent
+        held = asyncio.create_task(_admit_served(r.gate, None))
+        await asyncio.sleep(0.02)
+        assert not held.done(), "admission holds behind the staging pause"
+        assert r.gate.leases_snapshot() == {}, "a held admission writes no leases"
+        finish_stage.set()
+        await asyncio.wait_for(sync, 2.0)
+        assert await asyncio.wait_for(held, 2.0) == VersionRef("r1", 4), (
+            "the held request is admitted after the pause clears"
+        )
+
+        # Stock staging order: stage fully precedes the commit, and the
+        # pause/resume pair brackets the commit exactly.
+        assert engine.calls == ["stage:4", "pause", "commit:4", "resume"]
+        assert engine.staged == [VersionRef("r1", 4)]
+        assert engine.committed == [VersionRef("r1", 4)]
+        assert r.applied == VersionRef("r1", 4)
+        assert r.sync_state is SyncState.IDLE
+        assert not r.gate.staging_pause
+        assert "hold_s" not in r.metrics
+        assert r.gate.leases_snapshot() == {}
+
+    _run(go())
+
+
 def test_staging_pause_cpu_vs_disk() -> None:
     """cpu vs disk staging-pause asymmetry: a cpu stage holds admission, a
     disk stage keeps it open; the watchdog expects progress on disk STAGING,

--- a/src/stitch/watchdog.py
+++ b/src/stitch/watchdog.py
@@ -67,9 +67,9 @@ class EngineWatchdog:
     """Turn repeated engine-health failures into one terminal sidecar error.
 
     Probe only while the reconciler promises inference progress. Destination
-    initialization and commits supervise their own engine RPCs and may occupy the
-    engine's HTTP loop, so a concurrent health request is not an independent signal.
-    Staging runs alongside inference and remains functionally monitored.
+    initialization, staging, and commits supervise their own engine RPCs and may
+    occupy the engine's HTTP loop, so a concurrent health request is not an
+    independent signal then.
     """
 
     def __init__(

--- a/src/stitch/watchdog_test.py
+++ b/src/stitch/watchdog_test.py
@@ -78,11 +78,42 @@ def test_watchdog_does_not_probe_when_progress_is_not_expected() -> None:
     asyncio.run(go())
 
 
-def test_probe_timeouts_during_lease_hold_count_toward_watchdog() -> None:
-    """HOLDING is not a stage/commit: the engine still serves, so probe
-    failures count toward the unrecoverable verdict."""
+def test_probe_timeouts_and_watchdog_states() -> None:
+    """Probe-timeout accounting depends on sync state. A stage RPC can occupy
+    the engine's HTTP loop for minutes (a first cpu-mode delta compiles the
+    full weight image), so probe timeouts during STAGING must not count toward
+    the unrecoverable verdict; HOLDING is not a stage/commit — the engine still
+    serves — so there probe failures do count."""
 
     async def go() -> None:
+        # The STAGING probe exemption is cpu-mode specific (a mode-less engine
+        # keeps stock behavior: progress expected, probes count).
+        class _CpuEngine:
+            delta_update_mode = "cpu"
+
+        reconciler = Reconciler(store=None, engine=_CpuEngine(), run_id="r1")  # type: ignore[arg-type]
+        reconciler.ready = True
+        reconciler.sync_state = SyncState.STAGING
+        engine = _HealthSequence(
+            EngineHealthStatus.UNRESPONSIVE,
+            EngineHealthStatus.UNRESPONSIVE,
+            EngineHealthStatus.UNRESPONSIVE,
+        )
+        task = asyncio.create_task(
+            _watchdog(
+                engine,
+                expects_engine_progress=reconciler.expects_engine_progress,
+            ).run()
+        )
+        await asyncio.sleep(0.05)
+        assert not task.done(), "probe timeouts during staging must not trip the watchdog"
+        assert engine.checks == 0, "no probes are sent while a stage occupies the engine"
+
+        reconciler.sync_state = SyncState.IDLE
+        with pytest.raises(UnrecoverableEngineError, match="unresponsive"):
+            await asyncio.wait_for(task, timeout=1)
+        # (stage finished, engine still unresponsive -> the watchdog trips)
+
         reconciler = Reconciler(store=None, engine=None, run_id="r1")  # type: ignore[arg-type]
         reconciler.ready = True
         reconciler.sync_state = SyncState.HOLDING
@@ -95,7 +126,9 @@ def test_probe_timeouts_during_lease_hold_count_toward_watchdog() -> None:
                 engine,
                 expects_engine_progress=reconciler.expects_engine_progress,
             ).run()
-        assert engine.checks == 2
+        assert engine.checks == 2, (
+            "HOLDING still serves, so probe timeouts count toward the verdict"
+        )
 
     asyncio.run(go())
 


### PR DESCRIPTION
Production series 3/7, stacked on #197.

## Summary

- pause generation around cpu-destination delta stages (the image compile contends with concurrent forwards); disk stages stay un-paused
- gate the health watchdog only for generation-pausing stages; disk stages keep full probing
- hold new admissions during a pausing stage on the same gate that already holds them during commits; no error surfaces, requests proceed through normal admission once the stage clears; the pause is advertised in `/server_info` as `staging_pause`
- engines that do not declare a delta update mode default to disk (no pause)
- run staging after the lease hold, re-reading the pointer once post-hold to coalesce to the newest version

## Validation

- `pytest src/ cookbook/ -q` at branch head (266 passed)
- cpu-vs-disk watchdog asymmetry, hold-through-stage admission, hold-then-stage ordering, coalesce tests
- boundary behavior exercised in the live GLM delta runs
