### PR TITLE
cookbook: router lease packing and active consolidation

### DIFF
--- a/cookbook/common/consolidation.py
+++ b/cookbook/common/consolidation.py
@@ -1,0 +1,187 @@
+"""Active consolidation: the router's drain-victim policy.
+
+Victim selection/eligibility, the drain condition math, hysteresis counters,
+and the shared-Dict victim record. The registry (``cookbook.common.router``)
+keeps polling and drives the policy through ``DrainPolicy.update``.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import modal
+
+if TYPE_CHECKING:
+    from cookbook.common.router import ContainerInfo
+
+logger = logging.getLogger(__name__)
+
+# Consolidation: a victim is marked draining only after the drain condition
+# holds for this many consecutive registry polls (hysteresis against blips).
+DRAIN_HYSTERESIS_POLLS = 5
+# ...and a persisted victim is cleared only after this many consecutive polls
+# where the keep-condition fails: a single /server_info blip (the victim's
+# poll failed and dropped it from one snapshot) must not flap the drain.
+DRAIN_CLEAR_HYSTERESIS_POLLS = 3
+# Drain only when the old version's leases fit on the remaining k-1 replicas
+# with this safety margin below the engine overload threshold.
+DRAIN_SAFETY_FACTOR = 0.7
+# sync_states that mean "new-version capacity is imminent" — draining then is
+# premature. HOLDING is deliberately absent: holders are the starved
+# lease-holders the drain exists to free.
+_DRAIN_BLOCKING_STATES = frozenset({"FETCHING", "STAGING", "COMMITTING"})
+
+
+def consolidation_dict(app_name: str) -> modal.Dict:
+    """The run's consolidation record (single fleet-wide drain victim), namespaced
+    to the run app. Persisted outside /loads so a registry restart or a victim's
+    poll blip cannot silently clear or duplicate the victim."""
+    return modal.Dict.from_name(f"{app_name}-consolidation", create_if_missing=True)
+
+
+class _LocalDict:
+    """In-memory stand-in for the consolidation modal.Dict (tests, single-process)."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, Any] = {}
+        self.get = SimpleNamespace(aio=self._get)
+        self.put = SimpleNamespace(aio=self._put)
+
+    async def _get(self, key: str, default: Any = None) -> Any:
+        return self._store.get(key, default)
+
+    async def _put(self, key: str, value: Any) -> None:
+        self._store[key] = value
+
+
+def select_drain_victim(
+    containers: list[ContainerInfo],
+    rollout_concurrency: int,
+    *,
+    safety_factor: float = DRAIN_SAFETY_FACTOR,
+) -> tuple[int, str] | None:
+    """The consolidation candidate: ``(version, task_id)`` to drain, or None.
+
+    Oldest applied version V with k>=2 lease-holders and some replica targeting
+    newer than V (a k=1 group is skipped, not fatal). Drain when leases at V
+    fit on k-1 survivors under ``rollout_concurrency * DRAIN_SAFETY_FACTOR``
+    and every survivor's load is below ``rollout_concurrency``. None while any
+    replica is FETCHING/STAGING/COMMITTING. Victim is min(task_id).
+    """
+    targets = [c.target_version for c in containers if c.target_version is not None]
+    if not targets:
+        return None
+    max_target = max(targets)
+    if any(
+        (c.sync_state or "").upper() in _DRAIN_BLOCKING_STATES for c in containers
+    ):
+        return None
+
+    by_version: dict[int, list[ContainerInfo]] = {}
+    for container in containers:
+        if container.applied_version is None or container.draining:
+            continue
+        if container.leases.get(str(container.applied_version), 0) > 0:
+            by_version.setdefault(container.applied_version, []).append(container)
+
+    for version in sorted(by_version):
+        if version >= max_target:
+            continue
+        group = by_version[version]
+        k = len(group)
+        if k < 2:
+            continue
+        victim = min(group, key=lambda c: c.task_id)
+        survivors = [c for c in group if c.task_id != victim.task_id]
+        total_leases = sum(c.leases.get(str(version), 0) for c in group)
+        if total_leases > (k - 1) * rollout_concurrency * safety_factor:
+            continue
+        if any(c.load_stale for c in survivors):
+            # A stale survivor load is unverifiable spare capacity — never
+            # approve a drain on a frozen (possibly zero) reading.
+            continue
+        if any(c.load >= rollout_concurrency for c in survivors):
+            continue
+        return version, victim.task_id
+    return None
+
+
+class DrainPolicy:
+    """The drain policy's mutable state: hysteresis counters + the shared record."""
+
+    def __init__(self, rollout_concurrency: int | None, consolidation: Any) -> None:
+        self.rollout_concurrency = rollout_concurrency
+        self.consolidation = consolidation
+        self._drain_pending: tuple[int, str] | None = None
+        self._drain_pending_polls = 0
+        self._drain_clear_polls = 0
+
+    async def update(self, containers: list[ContainerInfo]) -> None:
+        """Mark/unmark the single fleet-wide drain victim.
+
+        The record lives in the shared consolidation dict (survives registry
+        restart). Unmarked when applied_version changes, no replica targets
+        newer, or the victim left — each only after DRAIN_CLEAR_HYSTERESIS_POLLS
+        consecutive failing polls. A new victim requires
+        DRAIN_HYSTERESIS_POLLS consecutive polls of the same candidate.
+        """
+        if self.rollout_concurrency is None:
+            # Drain policy disabled: no victim selection, no record mutation.
+            return
+        record = await self.consolidation.get.aio("victim", None) or {}
+        victim_id, version = record.get("victim_task_id"), record.get("version")
+        if victim_id is not None and version is not None:
+            victim = next((c for c in containers if c.task_id == victim_id), None)
+            newer_target = any(
+                c.target_version is not None and c.target_version > version
+                for c in containers
+            )
+            if victim is not None and victim.applied_version == version and newer_target:
+                victim.draining = True
+                self._drain_clear_polls = 0
+                return
+            # The keep-condition failed on this poll. A single blip (the
+            # victim's /server_info poll failed and dropped it from this
+            # snapshot, or a stale read mid-flip) must not flap the drain:
+            # clear the record only after DRAIN_CLEAR_HYSTERESIS_POLLS
+            # consecutive failing polls.
+            self._drain_clear_polls += 1
+            if self._drain_clear_polls < DRAIN_CLEAR_HYSTERESIS_POLLS:
+                if victim is not None and victim.applied_version == version:
+                    victim.draining = True  # status quo across the blip
+                return
+            await self.consolidation.put.aio(
+                "victim", {"victim_task_id": None, "version": None}
+            )
+            if victim is not None:
+                victim.draining = False
+            self._drain_pending = None
+            self._drain_pending_polls = 0
+            self._drain_clear_polls = 0
+
+        candidate = select_drain_victim(containers, self.rollout_concurrency)
+        if candidate is None:
+            self._drain_pending = None
+            self._drain_pending_polls = 0
+            return
+        if candidate == self._drain_pending:
+            self._drain_pending_polls += 1
+        else:
+            self._drain_pending = candidate
+            self._drain_pending_polls = 1
+        if self._drain_pending_polls >= DRAIN_HYSTERESIS_POLLS:
+            victim_version, victim_id = candidate
+            await self.consolidation.put.aio(
+                "victim", {"victim_task_id": victim_id, "version": victim_version}
+            )
+            self._drain_clear_polls = 0
+            for container in containers:
+                if container.task_id == victim_id:
+                    container.draining = True
+            logger.info(
+                "consolidation: marking replica %s draining at version %d",
+                victim_id,
+                victim_version,
+            )

--- a/cookbook/common/consolidation_test.py
+++ b/cookbook/common/consolidation_test.py
@@ -1,0 +1,164 @@
+"""Drain-victim policy: eligibility/condition math, hysteresis, shared-Dict record."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from cookbook.common.consolidation import (
+    DRAIN_CLEAR_HYSTERESIS_POLLS,
+    DRAIN_HYSTERESIS_POLLS,
+    _LocalDict,
+    select_drain_victim,
+)
+from cookbook.common.router import ContainerInfo, _RegistryApp
+
+
+def _member(
+    task_id: str,
+    *,
+    load: int = 0,
+    applied: int | None = 1,
+    leases: dict[str, int] | None = None,
+    sync_state: str | None = "IDLE",
+    target: int | None = 2,
+    draining: bool = False,
+) -> ContainerInfo:
+    return ContainerInfo(
+        task_id=task_id,
+        upstream=f"{task_id}:8000",
+        load=load,
+        applied_version=applied,
+        leases=leases or {},
+        sync_state=sync_state,
+        target_version=target,
+        draining=draining,
+    )
+
+
+def _starving_fleet() -> list[ContainerInfo]:
+    return [
+        _member("ta-0", leases={"1": 2}),
+        _member("ta-1", leases={"1": 2}),
+        _member("ta-2", applied=1, leases={}, sync_state="HOLDING"),
+    ]
+
+
+def _drain_registry(
+    consolidation: Any | None = None, victim: dict | None = None
+) -> tuple[_RegistryApp, Any]:
+    consolidation = consolidation if consolidation is not None else _LocalDict()
+    if victim is not None:
+        asyncio.run(consolidation.put.aio("victim", victim))
+    registry = _RegistryApp(
+        app_name="app",
+        upstream_cls="Server",
+        rollout_concurrency=10,
+        consolidation=consolidation,
+    )
+    return registry, consolidation
+
+
+def test_drain_disabled_without_rollout_concurrency() -> None:
+    # Default opt-out: no rollout_concurrency, no victim selection — even with
+    # a fleet that would otherwise drain, and no consolidation record written.
+    registry = _RegistryApp(app_name="app", upstream_cls="Server")
+    fleet = _starving_fleet()
+    for _ in range(DRAIN_HYSTERESIS_POLLS + 1):
+        asyncio.run(registry._update_drain(fleet))
+    assert not any(c.draining for c in fleet)
+    assert asyncio.run(registry.consolidation.get.aio("victim")) is None
+
+
+def test_drain_lifecycle() -> None:
+    # drain-victim policy gates: drain bar, transitioning blocks, survivor load.
+    holders = lambda a, b: [  # noqa: E731
+        _member("ta-0", leases={"1": a}),
+        _member("ta-1", leases={"1": b}),
+    ]
+    assert select_drain_victim(holders(3, 4), 10) == (1, "ta-0"), (
+        "k=2 concurrency=10 drain bar is 7 leases"
+    )
+    assert select_drain_victim(holders(3, 5), 10) is None
+    for state in ("STAGING", "COMMITTING", "FETCHING"):
+        blocked = holders(1, 1) + [_member("ta-2", applied=1, sync_state=state)]
+        assert select_drain_victim(blocked, 10) is None, state
+    allowed = holders(1, 1) + [_member("ta-2", applied=1, sync_state="HOLDING")]
+    assert select_drain_victim(allowed, 10) == (1, "ta-0"), (
+        "HOLDING must not block draining"
+    )
+    overloaded = [_member("ta-0", load=0, leases={"1": 1}), _member("ta-1", load=10, leases={"1": 1})]
+    assert select_drain_victim(overloaded, 10) is None, "survivor at overload bar"
+    stale = [_member("ta-0", load=0, leases={"1": 1}), _member("ta-1", load=0, leases={"1": 1})]
+    stale[1].load_stale = True
+    assert select_drain_victim(stale, 10) is None, "stale survivor load blocks drain"
+
+    registry, consolidation = _drain_registry()
+    fleet = _starving_fleet()
+    for i in range(DRAIN_HYSTERESIS_POLLS - 1):
+        asyncio.run(registry._update_drain(fleet))
+        assert not any(c.draining for c in fleet), f"marked early at poll {i + 1}"
+    asyncio.run(registry._update_drain(fleet))
+    assert [c.task_id for c in fleet if c.draining] == ["ta-0"]
+    assert asyncio.run(consolidation.get.aio("victim")) == {
+        "victim_task_id": "ta-0",
+        "version": 1,
+    }
+
+    first, consolidation = _drain_registry()
+    fleet = _starving_fleet()
+    for _ in range(DRAIN_HYSTERESIS_POLLS):
+        asyncio.run(first._update_drain(fleet))
+    restarted, _ = _drain_registry(consolidation)
+    fleet = _starving_fleet()
+    asyncio.run(restarted._update_drain(fleet))
+    assert [c.task_id for c in fleet if c.draining] == ["ta-0"]
+
+    registry, _ = _drain_registry(victim={"victim_task_id": "ta-c", "version": 2})
+    fleet = [
+        _member("ta-a", applied=1, leases={"1": 1}, target=3),
+        _member("ta-b", applied=1, leases={"1": 1}, target=3),
+        _member("ta-c", applied=2, leases={"2": 1}, target=3),
+        _member("ta-d", applied=2, leases={"2": 1}, target=3),
+    ]
+    for _ in range(DRAIN_HYSTERESIS_POLLS + 1):
+        asyncio.run(registry._update_drain(fleet))
+    assert [c.task_id for c in fleet if c.draining] == ["ta-c"]
+
+    def _advanced(fleet: list[ContainerInfo]) -> list[ContainerInfo]:
+        fleet[0].applied_version = 2
+        return fleet
+
+    def _no_target(fleet: list[ContainerInfo]) -> list[ContainerInfo]:
+        for c in fleet:
+            c.target_version = None
+        return fleet
+
+    cleared = {"victim_task_id": None, "version": None}
+    for record, mutate in [
+        ({"victim_task_id": "ta-0", "version": 1}, _advanced),
+        ({"victim_task_id": "ta-0", "version": 1}, _no_target),
+        ({"victim_task_id": "ta-dead", "version": 1}, lambda fleet: fleet),
+    ]:
+        registry, consolidation = _drain_registry(victim=record)
+        fleet = mutate(_starving_fleet())
+        for _ in range(DRAIN_CLEAR_HYSTERESIS_POLLS):
+            asyncio.run(registry._update_drain(fleet))
+        assert not any(c.draining for c in fleet)
+        assert asyncio.run(consolidation.get.aio("victim")) == cleared
+
+    registry, consolidation = _drain_registry(
+        victim={"victim_task_id": "ta-0", "version": 1}
+    )
+    fleet = _starving_fleet()
+    for _ in range(DRAIN_CLEAR_HYSTERESIS_POLLS - 1):
+        asyncio.run(registry._update_drain(fleet[1:]))
+        got = asyncio.run(consolidation.get.aio("victim"))
+        assert got["victim_task_id"] == "ta-0"
+    asyncio.run(registry._update_drain(fleet))
+    assert [c.task_id for c in fleet if c.draining] == ["ta-0"]
+    for _ in range(DRAIN_CLEAR_HYSTERESIS_POLLS - 1):
+        asyncio.run(registry._update_drain(fleet[1:]))
+    assert (asyncio.run(consolidation.get.aio("victim")))["victim_task_id"] == "ta-0"
+    asyncio.run(registry._update_drain(fleet[1:]))
+    assert (asyncio.run(consolidation.get.aio("victim")))["victim_task_id"] is None

--- a/cookbook/common/process.py
+++ b/cookbook/common/process.py
@@ -41,6 +41,8 @@ def start_sidecar(
     commit_mode: str,
     flush_cache_on_commit: bool = False,
     debug_requests: bool = False,
+    version_lease_ttl: float | None = None,
+    lease_header: str | None = None,
 ) -> subprocess.Popen:
     """Launch the versioned rollout proxy (the shared sidecar) beside sglang."""
     # Empty settings normalize to unset: only set options reach the factory.
@@ -67,6 +69,8 @@ def start_sidecar(
         run_id=run_id,
         boot_version=boot_version,
         debug_requests=debug_requests,
+        version_lease_ttl=0.0 if version_lease_ttl is None else float(version_lease_ttl),
+        lease_header="Modal-Session-ID" if lease_header is None else lease_header,
     )
     cmd = [
         "python3",

--- a/cookbook/common/router.py
+++ b/cookbook/common/router.py
@@ -13,7 +13,9 @@ polls every replica's ``/server_info`` (authoritative membership: applied_versio
 sync_state, target_version) and ``/v1/loads`` (live queue depth only); the router pins each
 session to a replica with spare capacity via the ``modal-flash-upstream`` header, and a 503
 from a pinned replica evicts it from rotation and retries on a healthier one, so load
-spreads across the pool.
+spreads across the pool. When a newer version starves, the registry marks one
+old-version replica ``draining`` at a time; draining replicas are excluded from
+every proxy selection path until their applied_version flips.
 
 Deltas from the upstream router: no proxy-auth/api-key secret plumbing (cookbook pools are
 ``unauthenticated``), replica discovery reuses Stitch's ``ModalFlashPool`` adapter, stdlib
@@ -42,6 +44,11 @@ from fastapi import FastAPI, Request, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, TypeAdapter
 
+from cookbook.common.consolidation import (
+    DrainPolicy,
+    _LocalDict,
+    consolidation_dict,  # noqa: F401  # re-exported for inference_only.app
+)
 from stitch.pools.modal_flash import list_flash_containers_async
 
 from .constants import (
@@ -109,6 +116,10 @@ class ContainerInfo(BaseModel):
     sync_state: str | None = None
     target_version: int | None = None  # None when idle
     draining: bool = False  # excluded from every proxy selection path
+    # Transiently occupied by a generation-pausing weight stage: excluded from
+    # fresh placements only. Unlike draining, sticky routes survive — a sticky
+    # arrival parks at the sidecar's admission hold, the correctness backstop.
+    staging_pause: bool = False
 
 
 ContainerInfoList = TypeAdapter(list[ContainerInfo])
@@ -190,6 +201,24 @@ def select_underloaded_container(
     return random.choice(pool)
 
 
+def select_packed_container(
+    candidates: list[ContainerInfo], exact_version: int
+) -> ContainerInfo:
+    """Among replicas applied at ``exact_version``, pick the lowest-load
+    lease-holder (all candidates if none hold leases). Packing onto the
+    most-leased replica stampedes it past the engine overload threshold."""
+    holders = [c for c in candidates if c.leases.get(str(exact_version), 0) > 0]
+    pool = holders or list(candidates)
+    if not pool:
+        raise ValueError("select_packed_container: no candidates to select from")
+    # A stale load is last-known, not live (a paused replica can sit at a
+    # frozen zero): when any candidate reports fresh load, pack only across
+    # those.
+    pool = [c for c in pool if not c.load_stale] or pool
+    min_load = min(c.load for c in pool)
+    return random.choice([c for c in pool if c.load == min_load])
+
+
 async def route_session(
     session_routes: modal.Dict,
     session_id: str,
@@ -198,9 +227,10 @@ async def route_session(
     exact_version: int | None = None,
 ) -> ContainerInfo | None:
     """Pick the replica for one session: sticky if healthy and (when set)
-    applied_version == exact_version, else the lowest-load same-version replica.
+    applied_version == exact_version, else a packed same-version replica.
+    Draining replicas are excluded; sticky routes to them are deleted.
     Returns None — and does not persist a route — when exact_version is set
-    but no ready replica matches it."""
+    but no non-draining replica matches it."""
     current_time = time.time()
 
     routes: list[RouteEntry] = RouteEntryList.validate_python(
@@ -224,6 +254,11 @@ async def route_session(
             ),
         )
 
+    def _in_rotation(c: ContainerInfo) -> bool:
+        # A pause is transient, so it bars fresh placements without evicting
+        # sticky routes; draining is terminal for the version, so it does both.
+        return c.ready and not c.draining and not c.staging_pause
+
     for entry in list(routes):
         # Re-lookup defensively: a concurrent 503-evict can pop the shared map
         # while this coroutine is suspended in save_routes() — indexing would
@@ -231,13 +266,15 @@ async def route_session(
         container = containers.get(entry.task_id)
         if container is None:
             continue
-        if not container.ready:
-            # Booting (stale boot weights) or dead-engine replica: evict so the
-            # session migrates off stale weights.
+        if container.draining or not container.ready:
+            # Delete, don't skip: a kept sticky route would re-admit the victim
+            # on a blip. A booting (stale boot weights) or dead-engine replica
+            # is evicted like draining so the session migrates off stale weights.
             logger.info(
-                "session %s: sticky route %s is not ready; evicting",
+                "session %s: sticky route %s is %s; evicting",
                 session_id,
                 container.task_id,
+                "draining" if container.draining else "not ready",
             )
             routes.remove(entry)
             await save_routes()
@@ -260,12 +297,10 @@ async def route_session(
     candidates = [
         container
         for container in containers.values()
-        if container.load < overload_threshold and container.ready
+        if container.load < overload_threshold and _in_rotation(container)
     ]
-    # Unpinned fallback is overloaded-but-ready; an all-not-ready fleet yields None.
-    fallback = candidates or [
-        container for container in containers.values() if container.ready
-    ]
+    # Unpinned fallback is overloaded-but-not-draining; an all-draining fleet yields None.
+    fallback = candidates or [c for c in containers.values() if _in_rotation(c)]
 
     if exact_version is not None:
         version_matched = [c for c in candidates if c.applied_version == exact_version]
@@ -277,13 +312,14 @@ async def route_session(
             version_matched = [
                 container
                 for container in containers.values()
-                if container.applied_version == exact_version and container.ready
+                if container.applied_version == exact_version and _in_rotation(container)
             ]
         if version_matched:
-            selected = min(version_matched, key=lambda container: container.load)
+            selected = select_packed_container(version_matched, exact_version)
         else:
             # No healthy upstream at the pinned version: return None rather than
-            # landing on a wrong-version replica (which would 409).
+            # landing on a wrong-version or draining replica (which would 409
+            # and re-pin the session onto the victim).
             logger.info(
                 "session %s: no healthy upstream at exact_version=%d "
                 "(%d replicas known); not re-pinning",
@@ -295,7 +331,7 @@ async def route_session(
     else:
         if not fallback:
             logger.info(
-                "session %s: no ready replica available; no selection",
+                "session %s: no non-draining replica available; no selection",
                 session_id,
             )
             return None
@@ -377,9 +413,29 @@ class _RequestCancelledMiddleware:
             return None
 
 
-def serve_registry(replica: Any, *, app_name: str, upstream_cls: str) -> None:
-    """Start the load-registry server on a ``RouterRegistry`` container (@modal.enter)."""
-    registry = _RegistryApp(app_name=app_name, upstream_cls=upstream_cls)
+def serve_registry(
+    replica: Any,
+    *,
+    app_name: str,
+    upstream_cls: str,
+    rollout_concurrency: int | None = None,
+    consolidation: Any = None,
+) -> None:
+    """Start the load-registry server on a ``RouterRegistry`` container (@modal.enter).
+
+    ``rollout_concurrency`` is the engine's per-replica overload threshold and
+    the capacity unit of the consolidation drain policy. The default ``None``
+    disables the policy entirely: no drain victim is ever selected.
+    """
+    # Router containers default to WARNING; routing decisions ("pinning new
+    # upstream", "marking … draining") are INFO and must reach the log store.
+    logging.basicConfig(level=logging.INFO)
+    registry = _RegistryApp(
+        app_name=app_name,
+        upstream_cls=upstream_cls,
+        rollout_concurrency=rollout_concurrency,
+        consolidation=consolidation,
+    )
     registry.start()
     replica._router_server = registry
 
@@ -393,6 +449,7 @@ def serve_router(
     overload_threshold: int,
 ) -> None:
     """Start the session-routing proxy on a ``Router`` container (@modal.enter)."""
+    logging.basicConfig(level=logging.INFO)
     router = _ProxyApp(
         registry_url=registry_url,
         upstream_url=upstream_url,
@@ -422,16 +479,30 @@ class _ReplicaPoll:
     sync_state: str | None
     target_version: int | None
     ready: bool
+    staging_pause: bool
 
 
 class _RegistryApp(_UvicornApp):
     """Poll /server_info (membership) and /v1/loads (queue depth); serve ``/loads``."""
 
-    def __init__(self, *, app_name: str, upstream_cls: str) -> None:
+    def __init__(
+        self,
+        *,
+        app_name: str,
+        upstream_cls: str,
+        rollout_concurrency: int | None = None,
+        consolidation: Any = None,
+    ) -> None:
         self.app_name = app_name
         self.upstream_cls = upstream_cls
+        # Engine overload threshold (the recipe's rollout_target_inputs) — the
+        # capacity unit of the drain condition, NOT the router's own Flash
+        # target_concurrency. None disables the drain policy (no victim selection).
+        self.rollout_concurrency = rollout_concurrency
+        self.consolidation = consolidation if consolidation is not None else _LocalDict()
         self.containers: list[ContainerInfo] = []
         self._last_loads: dict[str, int] = {}
+        self._drain_policy = DrainPolicy(rollout_concurrency, self.consolidation)
 
     async def _poll_container(self, upstream: str) -> _ReplicaPoll:
         """/server_info is membership (failure drops the replica). /v1/loads is
@@ -474,6 +545,8 @@ class _RegistryApp(_UvicornApp):
             target_version=target_version,
             # Older sidecars don't expose `ready`; treat absence as ready.
             ready=bool(data.get("ready", True)),
+            # Older sidecars don't expose `staging_pause`; treat absence as unpaused.
+            staging_pause=bool(data.get("staging_pause", False)),
         )
 
     async def _poll_once(self) -> list[ContainerInfo]:
@@ -517,9 +590,15 @@ class _RegistryApp(_UvicornApp):
                     sync_state=result.sync_state,
                     target_version=result.target_version,
                     ready=result.ready,
+                    staging_pause=result.staging_pause,
                 )
             )
+        await self._update_drain(updated)
         return updated
+
+    async def _update_drain(self, containers: list[ContainerInfo]) -> None:
+        """Mark/unmark the drain victim — the policy lives in cookbook.common.consolidation."""
+        await self._drain_policy.update(containers)
 
     async def poll_containers(self) -> None:
         await asyncio.sleep(CONTAINER_POLL_INTERVAL_SECONDS)

--- a/cookbook/common/router_test.py
+++ b/cookbook/common/router_test.py
@@ -15,6 +15,7 @@ from cookbook.common import router
 from cookbook.common.router import (
     SESSION_ROUTE_TTL_SECONDS,
     ContainerInfo,
+    ContainerInfoList,
     RouteEntry,
     RouteEntryList,
     _container_addr,
@@ -23,6 +24,7 @@ from cookbook.common.router import (
     filter_headers,
     relay_lease_header,
     route_session,
+    select_packed_container,
     select_underloaded_container,
     session_id_from_headers,
 )
@@ -302,9 +304,23 @@ def _leased(
     )
 
 
+def _draining(task_id: str, applied_version: int, leases: dict[str, int]) -> ContainerInfo:
+    return _leased(task_id, 0, applied_version, leases).model_copy(
+        update={"draining": True}
+    )
+
+
+def _rollout_fleet() -> dict[str, ContainerInfo]:
+    return {
+        "ta-victim": _draining("ta-victim", 1, {"1": 3}),
+        "ta-s1": _leased("ta-s1", 0, 2, {"2": 4}),
+        "ta-s2": _leased("ta-s2", 0, 2, {"2": 2}),
+    }
+
+
 def test_route_session_version_boundary() -> None:
-    """Version preference, no-match no-repin, and saturation queuing — one
-    walk of the pinned-session boundary."""
+    """Version preference, saturation queuing, draining exclusion, and the
+    no-fallback boundary — one walk of the pinned-session boundary."""
     containers = {
         "ta-0": ContainerInfo(
             task_id="ta-0", upstream="h0:8000", load=0, applied_version=1
@@ -354,6 +370,106 @@ def test_route_session_version_boundary() -> None:
     )
     assert picked.task_id == "ta-0", "saturated matching replica queues rather than 409s"
     assert routes.store["s1"][0]["task_id"] == "ta-0"
+
+    routes = FakeRoutes()
+    _seeded(routes, "s1", [{"task_id": "ta-0", "last_sent": time.time()}])
+    drain = {
+        "ta-0": _draining("ta-0", 1, {"1": 3}),
+        "ta-1": _leased("ta-1", 0, 1, {"1": 1}),
+    }
+    picked = asyncio.run(route_session(routes, "s1", drain, 4, exact_version=1))
+    assert picked.task_id == "ta-1", "sticky draining route is deleted"
+    assert [entry["task_id"] for entry in routes.store["s1"]] == ["ta-1"]
+    picked = asyncio.run(
+        route_session(FakeRoutes(), "s1", drain, 4, exact_version=1)
+    )
+    assert picked.task_id == "ta-1", "draining excluded from version-matched candidates"
+
+    paused = {
+        "ta-0": _leased("ta-0", 0, 1, {"1": 1}).model_copy(
+            update={"staging_pause": True}
+        ),
+        "ta-1": _leased("ta-1", 0, 1, {"1": 1}),
+    }
+    routes = FakeRoutes()
+    picked = asyncio.run(route_session(routes, "s1", paused, 4, exact_version=1))
+    assert picked.task_id == "ta-1", (
+        "fresh placements route around a staging_pause replica"
+    )
+    routes = FakeRoutes()
+    _seeded(routes, "s1", [{"task_id": "ta-0", "last_sent": time.time()}])
+    picked = asyncio.run(route_session(routes, "s1", paused, 4, exact_version=1))
+    assert picked.task_id == "ta-0", (
+        "a sticky route to a paused replica survives; the arrival parks at the "
+        "sidecar hold"
+    )
+    assert [entry["task_id"] for entry in routes.store["s1"]] == ["ta-0"], (
+        "unlike draining, a pause never evicts the sticky route"
+    )
+
+    no_fallback_fleets = [
+        {
+            "ta-0": _draining("ta-0", 2, {"2": 3}),
+            "ta-1": _leased("ta-1", 0, 2, {}),
+        },
+        {"ta-0": _draining("ta-0", 1, {"1": 1})},
+        _rollout_fleet(),
+    ]
+    for fleet in no_fallback_fleets:
+        routes = FakeRoutes()
+        for i in range(5):
+            picked = asyncio.run(
+                route_session(routes, f"s{i}", fleet, 4, exact_version=1)
+            )
+            assert picked is None, (
+                "no match never falls back to draining or wrong version"
+            )
+        assert routes.store == {}, "pinned miss must not re-pin"
+
+    assert (
+        asyncio.run(
+            route_session(
+                FakeRoutes(), "s1", {"ta-0": _draining("ta-0", 1, {"1": 1})}, 4
+            )
+        )
+        is None
+    ), "all-draining fleet yields None"
+
+
+def test_select_packed_container_fresh_load_and_zero_leases() -> None:
+    candidates = [
+        _leased("ta-0", load=2, applied_version=3, leases={"1": 4}),
+        _leased("ta-1", load=1, applied_version=3, leases={}),
+    ]
+    assert select_packed_container(candidates, 3).task_id == "ta-1", (
+        "zero leases at the pin degenerates to lowest load"
+    )
+    candidates = [
+        _leased("ta-0", 0, 1, {"1": 1}).model_copy(update={"load_stale": True}),
+        _leased("ta-1", 3, 1, {"1": 1}),
+    ]
+    for _ in range(5):
+        assert select_packed_container(candidates, 1).task_id == "ta-1", (
+            "fresh load preferred over a stale zero"
+        )
+    candidates[1] = candidates[1].model_copy(update={"load_stale": True})
+    assert select_packed_container(candidates, 1).task_id in {"ta-0", "ta-1"}
+
+    original = [
+        _leased("ta-0", load=1, applied_version=2, leases={"2": 3, "1": 1}).model_copy(
+            update={"sync_state": "HOLDING", "target_version": 3, "draining": True}
+        )
+    ]
+    payload = ContainerInfoList.dump_python(original, mode="json")
+    assert payload[0]["leases"] == {"2": 3, "1": 1}
+    assert payload[0]["sync_state"] == "HOLDING"
+    assert payload[0]["target_version"] == 3
+    assert payload[0]["draining"] is True
+    parsed = ContainerInfoList.validate_python(payload)
+    assert parsed[0].leases == {"2": 3, "1": 1}
+    assert parsed[0].sync_state == "HOLDING"
+    assert parsed[0].target_version == 3
+    assert parsed[0].draining is True
 
 
 class _FakeResp:
@@ -506,32 +622,33 @@ async def _post(
         )
 
 
-def test_forward_409_passthrough_and_503_eviction() -> None:
-    """A 409 is passed through without eviction; only 503 evicts; a pin with no
-    matching version is a 409 that never touches an upstream."""
+def test_forward_pinned_vs_draining() -> None:
+    """A 409 is passed through without eviction; only 503 evicts; the victim
+    is never touched."""
 
     async def run() -> None:
-        fleet = {
-            "ta-s1": _leased("ta-s1", 0, 2, {"2": 4}),
-            "ta-s2": _leased("ta-s2", 0, 2, {"2": 2}),
-        }
-        proxy, app = _proxy(fleet)
+        proxy, app = _proxy(_rollout_fleet())
+        fake = _FakeUpstreamClient({"ta-victim:8000": 200})
+        proxy.client = fake
+        responses = await asyncio.gather(
+            *[_post(app, f"s{i}", 1) for i in range(6)]
+        )
+        assert all(r.status_code == 409 for r in responses), (
+            "pinned v1 with only a draining victim is 409, never a victim 200"
+        )
+        assert fake.requested_upstreams == []
+        assert set(proxy.containers) == {"ta-victim", "ta-s1", "ta-s2"}
+
+        proxy, app = _proxy(_rollout_fleet())
         fake = _FakeUpstreamClient({"ta-s1:8000": 409, "ta-s2:8000": 409})
         proxy.client = fake
         response = await _post(app, "s1", 2)
-        assert response.status_code == 409, "409 from a pinned replica is passed through"
+        assert response.status_code == 409, "409 from a pinned survivor is passed through"
         assert len(fake.requested_upstreams) == 1
         assert fake.requested_upstreams[0] in {"ta-s1:8000", "ta-s2:8000"}
-        assert set(proxy.containers) == {"ta-s1", "ta-s2"}, "409 does not evict"
-
-        proxy, app = _proxy({"ta-s1": _leased("ta-s1", 0, 2, {"2": 4})})
-        fake = _FakeUpstreamClient({})
-        proxy.client = fake
-        response = await _post(app, "s1", 1)
-        assert response.status_code == 409, (
-            "no v1 replica: 409, never a wrong-version upstream"
+        assert set(proxy.containers) == {"ta-victim", "ta-s1", "ta-s2"}, (
+            "409 does not evict"
         )
-        assert fake.requested_upstreams == []
 
         proxy, app = _proxy(
             {
@@ -549,20 +666,18 @@ def test_forward_409_passthrough_and_503_eviction() -> None:
         assert response.headers["retry-after"] == "1"
         assert fake.requested_upstreams == []
 
-        fleet = {
-            "ta-s1": _leased("ta-s1", 0, 2, {"2": 4}),
-            "ta-s2": _leased("ta-s2", 1, 2, {"2": 2}),
-        }
+        fleet = _rollout_fleet()
+        fleet["ta-s2"] = fleet["ta-s2"].model_copy(update={"load": 1})
         proxy, app = _proxy(fleet)
         fake = _FakeUpstreamClient({"ta-s1:8000": 503, "ta-s2:8000": 200})
         proxy.client = fake
         response = await _post(app, "s1", 2)
         assert response.status_code == 200
         assert fake.requested_upstreams == ["ta-s1:8000", "ta-s2:8000"], (
-            "ta-s1 is the lowest-load v2 match, so the 503-retry lands on ta-s2"
+            "ta-s1 is the least-loaded v2 lease-holder, so 503-retry lands on ta-s2"
         )
         assert "ta-s1" not in proxy.containers
-        assert set(proxy.containers) == {"ta-s2"}
+        assert set(proxy.containers) == {"ta-victim", "ta-s2"}
 
     asyncio.run(run())
 

--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -33,6 +33,8 @@ def serve_startup(
     commit_mode: str,
     flush_cache_on_commit: bool = False,
     startup_timeout: int,
+    version_lease_ttl: float | None = None,
+    lease_header: str | None = None,
 ) -> None:
     """Start sglang + the versioned-proxy sidecar on a Server replica (from ``@modal.enter``).
     SGLang starts directly from the immutable boot checkpoint. The sidecar enters
@@ -92,6 +94,8 @@ def serve_startup(
         boot_version=boot_version,
         commit_mode=commit_mode,
         flush_cache_on_commit=flush_cache_on_commit,
+        version_lease_ttl=version_lease_ttl,
+        lease_header=lease_header,
     )
     # Modal admits the container when @enter returns. The sidecar owns readiness:
     # /health stays 503 through destination initialization and first catch-up.

--- a/cookbook/inference_only/app.py
+++ b/cookbook/inference_only/app.py
@@ -222,6 +222,7 @@ router_image = router.build_router_image(
     extra_env=STORE_DEPLOYMENT.image_environment,
 )
 session_routes = router.session_routes_dict(APP_NAME)
+consolidation = router.consolidation_dict(APP_NAME)
 
 
 @app.server(
@@ -239,7 +240,13 @@ class RouterRegistry:
 
     @modal.enter()
     def enter(self) -> None:
-        router.serve_registry(self, app_name=APP_NAME, upstream_cls="Server")
+        router.serve_registry(
+            self,
+            app_name=APP_NAME,
+            upstream_cls="Server",
+            rollout_concurrency=ROLLOUT_CONCURRENCY,
+            consolidation=consolidation,
+        )
 
     @modal.exit()
     def exit(self) -> None:


### PR DESCRIPTION
Production series 4/7, stacked on #179.

## Summary

- pack old-version traffic onto the replicas already holding its leases (lowest load among them)
- add active consolidation: when a version's leases fit in one fewer replica, the registry (opt-in via `rollout_concurrency`; `None` disables it) drains one victim at a time (min task-id, persisted in a shared Dict, cleared after consecutive absent polls)
- keep fresh placements off replicas in a pausing stage (`staging_pause`; sticky routes survive, the sidecar hold is the backstop)
- exclude the victim from every selection path and delete its sticky routes until its applied version flips

## Validation

- `pytest src/ cookbook/ -q` at branch head (269 passed)
- drain lifecycle, packing, exclusion, and one-victim invariant tests
- packing exercised live (final POC run: all sessions concentrated on one replica from the first request)
