### PR TITLE
cookbook: mixed-fleet publish gate

### DIFF
--- a/cookbook/inference_only/publish_app.py
+++ b/cookbook/inference_only/publish_app.py
@@ -8,11 +8,12 @@ from the inference pool so it scales independently.
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import logging
 import os
 import threading
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 
@@ -96,6 +97,9 @@ class PublishRequest(BaseModel):
     # Accepted for API compat; full-vs-delta is derived from the index's
     # `delta_encoding` key by stitch.publish, not from this flag.
     delta: bool = False
+    # Skip the fleet-mixed gate (e.g. republish after the operator confirms the
+    # mixed state is expected). The gate is a safety rail, not a lock.
+    force: bool = False
 
 
 class StatusResponse(BaseModel):
@@ -291,6 +295,78 @@ def materialize_version(run_id: str, version: int, source: str, publish: bool) -
     return {"version": version, "path": str(version_dir), "published": publish}
 
 
+# ── Fleet-mixed publish gate ─────────────────────────────────────────────────
+
+# Sync states in which a replica is mid-transition toward a newer version;
+# publishing into that fleet would strand the in-flight rollout.
+# Lowercase because infos are compared via ``.lower()`` (sidecar casing varies).
+_FLEET_TRANSITION_STATES = frozenset({"holding", "staging", "committing"})
+
+
+def fleet_is_mixed(infos: list[dict[str, Any]]) -> tuple[bool, dict[str, Any]]:
+    """True when replicas disagree on applied_version, or any replica is
+    holding/staging/committing toward a newer target. Empty ``infos`` is
+    not mixed (publisher must work standalone).
+    """
+    applied_versions = sorted(
+        {info.get("applied_version") for info in infos},
+        key=lambda v: (v is None, v),
+    )
+    offenders: list[dict[str, Any]] = []
+    for info in infos:
+        sync_state = info.get("sync_state")
+        if not isinstance(sync_state, str):
+            continue
+        if sync_state.lower() not in _FLEET_TRANSITION_STATES:
+            continue
+        target = info.get("target_version")
+        if target is None:
+            continue
+        applied = info.get("applied_version")
+        if target > (applied if applied is not None else -1):
+            offenders.append(
+                {
+                    "sync_state": sync_state,
+                    "target_version": target,
+                    "applied_version": applied,
+                }
+            )
+    detail: dict[str, Any] = {
+        "applied_versions": applied_versions,
+        "transitioning_replicas": offenders,
+    }
+    return len(applied_versions) > 1 or bool(offenders), detail
+
+
+async def _default_server_info_provider() -> list[dict[str, Any]]:
+    """Discover pool replicas and GET each sidecar's /server_info (200s only)."""
+    import httpx
+
+    from stitch.pools.modal_flash import ModalFlashPool
+
+    try:
+        pool = ModalFlashPool(app_name=POOL_APP_NAME, cls_name=POOL_CLS_NAME)
+        urls = await pool.discover_replicas_async()
+    except Exception as exc:  # noqa: BLE001
+        # Pool down/undiscoverable == empty probe, and an empty probe is NOT
+        # mixed — the publisher must still work standalone (no 500 here).
+        logger.warning("replica discovery failed; treating as empty probe: %s", exc)
+        return []
+
+    async def fetch(client: Any, url: str) -> dict[str, Any] | None:
+        try:
+            resp = await client.get(f"{url}/server_info")
+            if resp.status_code == 200:
+                return resp.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("server_info probe failed for %s: %s", url, exc)
+        return None
+
+    async with httpx.AsyncClient(timeout=5.0, trust_env=False) as client:
+        results = await asyncio.gather(*(fetch(client, url) for url in urls))
+    return [info for info in results if info is not None]
+
+
 def _default_volume_reloader() -> None:
     """Reload the run volume's view (same guard as ``materialize_version``)."""
     if STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME:
@@ -306,12 +382,14 @@ class PublisherServer:
         store: Store,
         run_dir: Path,
         port: int = PUBLISHER_PORT,
+        server_info_provider: Callable[[], Awaitable[list[dict[str, Any]]]] | None = None,
         volume_reloader: Callable[[], None] | None = None,
     ) -> None:
         self.store = store
         self.run_dir = run_dir
         self.updates_dir = _updates_dir(run_dir)
         self.port = port
+        self._server_info_provider = server_info_provider or _default_server_info_provider
         self._volume_reloader = volume_reloader or _default_volume_reloader
         # In-memory single-writer guard. A Flash recycle resets it; the store
         # pointer's rewind guard is the durable backstop.
@@ -375,6 +453,25 @@ class PublisherServer:
                     "version": request.version,
                     "path": str(version_dir),
                 }
+
+            # force=True bypasses; an empty probe (pool down) is not mixed.
+            if not request.force:
+                infos = await self._server_info_provider()
+                mixed, detail = fleet_is_mixed(infos)
+                if mixed:
+                    logger.warning(
+                        "rejecting /publish for version %d: fleet mixed (%s)",
+                        request.version,
+                        detail,
+                    )
+                    return JSONResponse(
+                        status_code=409,
+                        content={
+                            "status": "retryable",
+                            "reason": "fleet mixed",
+                            "detail": detail,
+                        },
+                    )
 
             source_path = Path(request.source)
             if not source_path.exists():

--- a/cookbook/inference_only/publish_app_test.py
+++ b/cookbook/inference_only/publish_app_test.py
@@ -161,6 +161,7 @@ _server_seq = 0
 def _make_server(
     tmp_path: Path,
     pointer: VersionRef | None = None,
+    server_info_provider: object = _empty_server_infos,
     *,
     label: str | None = None,
     volume_reloader: Callable[[], None] | None = None,
@@ -175,10 +176,28 @@ def _make_server(
         store=_FakeStore(pointer),
         run_dir=run_dir,
         port=0,
+        server_info_provider=server_info_provider,  # type: ignore[arg-type]
         # Unit tests must never invoke the real run_volume.reload() (needs Modal auth).
         volume_reloader=volume_reloader or (lambda: None),
     )
 
+
+_MIXED_INFOS = [
+    {"applied_version": 3, "sync_state": "IDLE", "target_version": 3},
+    {"applied_version": 4, "sync_state": "HOLDING", "target_version": 5},
+]
+
+_UNMIXED_INFOS = [
+    {"applied_version": 3, "sync_state": "IDLE", "target_version": 3},
+    {"applied_version": 3, "sync_state": "IDLE", "target_version": 3},
+]
+
+
+def _provider_of(infos: list[dict]) -> object:
+    async def provider() -> list[dict]:
+        return infos
+
+    return provider
 
 
 def _make_publish_source(tmp_path: Path) -> Path:
@@ -364,6 +383,7 @@ def _make_recording_server(
         store=store,
         run_dir=run_dir,
         port=0,
+        server_info_provider=_empty_server_infos,  # type: ignore[arg-type]
         volume_reloader=reloader,
     )
     return server, store
@@ -532,6 +552,81 @@ def test_publisher_lifecycle(
     assert resp.status_code == 200
     assert resp.json()["status"] == "pending"
     assert store.calls == [], "/job never reloads the volume"
+
+    source = _make_publish_source(tmp_path)
+    fake_spawn = _FakeSpawn()
+    monkeypatch.setattr(publish_app, "materialize_version", fake_spawn)
+    server = _make_server(tmp_path, server_info_provider=_provider_of(_MIXED_INFOS))
+    client = TestClient(server.build_app())
+    resp = client.post(
+        "/publish",
+        json={"run_id": publish_app.RUN_ID, "version": 5, "source": str(source)},
+    )
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["status"] == "retryable"
+    assert body["reason"] == "fleet mixed"
+    assert body["detail"]["applied_versions"] == [3, 4]
+    assert body["detail"]["transitioning_replicas"] == [
+        {"sync_state": "HOLDING", "target_version": 5, "applied_version": 4}
+    ]
+    assert fake_spawn.calls == []
+
+    # fleet_is_mixed truth table: one applied version across the fleet is not
+    # mixed; two applied versions are; one applied version with a replica
+    # moving toward a newer target is; an empty/unreachable probe is not
+    # (the publisher must work standalone).
+    assert publish_app.fleet_is_mixed(_UNMIXED_INFOS)[0] is False
+    assert publish_app.fleet_is_mixed(_MIXED_INFOS)[0] is True
+    transitioning = [
+        {"applied_version": 3, "sync_state": "IDLE", "target_version": 3},
+        {"applied_version": 3, "sync_state": "STAGING", "target_version": 4},
+    ]
+    mixed, detail = publish_app.fleet_is_mixed(transitioning)
+    assert mixed is True
+    assert detail["applied_versions"] == [3]
+    assert detail["transitioning_replicas"] == [
+        {"sync_state": "STAGING", "target_version": 4, "applied_version": 3}
+    ]
+    assert publish_app.fleet_is_mixed([]) == (
+        False,
+        {"applied_versions": [], "transitioning_replicas": []},
+    )
+
+    fake_spawn = _FakeSpawn(job_id="fc-force-1")
+    monkeypatch.setattr(publish_app, "materialize_version", fake_spawn)
+    server = _make_server(tmp_path, server_info_provider=_provider_of(_MIXED_INFOS))
+    client = TestClient(server.build_app())
+    resp = client.post(
+        "/publish",
+        json={
+            "run_id": publish_app.RUN_ID,
+            "version": 5,
+            "source": str(source),
+            "force": True,
+        },
+    )
+    assert resp.status_code == 202
+    assert resp.json()["job_id"] == "fc-force-1"
+
+    fake_spawn = _FakeSpawn(job_id="fc-unmixed-1")
+    monkeypatch.setattr(publish_app, "materialize_version", fake_spawn)
+    server = _make_server(tmp_path, server_info_provider=_provider_of(_UNMIXED_INFOS))
+    client = TestClient(server.build_app())
+    resp = client.post(
+        "/publish",
+        json={"run_id": publish_app.RUN_ID, "version": 4, "source": str(source)},
+    )
+    assert resp.status_code == 202
+    assert fake_spawn.calls == [
+        {
+            "run_id": publish_app.RUN_ID,
+            "version": 4,
+            "source": str(source),
+            "publish": True,
+        }
+    ]
+
 
 def test_publisher_guards(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Production series 7/7, stacked on #183. The [POC] example series (#192-#195) follows.

## Summary

- reject a publish while the fleet is mixed (more than one applied version, or any replica moving toward a newer one); retryable response, `force` bypasses
- treat an unreachable pool as not-mixed rather than an error

## Validation

- `pytest src/ cookbook/ -q` at branch head (273 passed)
- `fleet_is_mixed` truth-table tests
