### PR TITLE
cookbook: version-aware router placement and session-id lease relay

### DIFF
--- a/cookbook/common/constants.py
+++ b/cookbook/common/constants.py
@@ -23,6 +23,12 @@ RAY_PORT = 6379
 # cookbook router when selecting a rollout replica.
 MODAL_SESSION_ID_HEADER = "Modal-Session-ID"
 
+# Internal lease-identity header. The platform hashes Modal-Session-ID for its
+# own session affinity, which takes precedence over an explicit ``modal-flash-upstream``
+# pin mid-path, so the router strips it and relays the session value upstream
+# as Stitch-Lease-Key instead.
+STITCH_LEASE_HEADER = "Stitch-Lease-Key"
+
 # Timeouts.
 MINUTES = 60
 SERVER_STARTUP_TIMEOUT = 60 * MINUTES

--- a/cookbook/common/router.py
+++ b/cookbook/common/router.py
@@ -9,15 +9,16 @@ deploy, one stop — the router scales and dies with the pool.
 Why it exists: with a per-container queue bound (sglang ``--max-queued-requests``), Flash's
 own sticky routing turns the first saturated replicas into 503 attractors — sessions stuck
 on a full replica keep retrying it while the rest of the pool starves. Here, the registry
-polls every replica's live queue depth (``/v1/loads`` + a ``/health`` zombie check); the
-router pins each ``modal-session-id`` to a healthy replica with spare capacity via the
-``modal-flash-upstream`` header, and a 503 from a pinned replica evicts it from rotation and
-retries on a healthier one, so load spreads instead of sticking.
+polls every replica's ``/server_info`` (authoritative membership: applied_version, leases,
+sync_state, target_version) and ``/v1/loads`` (live queue depth only); the router pins each
+session to a replica with spare capacity via the ``modal-flash-upstream`` header, and a 503
+from a pinned replica evicts it from rotation and retries on a healthier one, so load
+spreads across the pool.
 
 Deltas from the upstream router: no proxy-auth/api-key secret plumbing (cookbook pools are
 ``unauthenticated``), replica discovery reuses Stitch's ``ModalFlashPool`` adapter, stdlib
 logging, and startup tolerates the sibling classes still cold-booting (single-app deploys
-have no boot ordering) instead of dying on the first failed poll. The legacy-tuple
+have no boot ordering) and survives failed first polls. The legacy-tuple
 session-route migration is dropped — per-run route dicts start empty.
 """
 
@@ -31,6 +32,7 @@ import threading
 import time
 import uuid
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, AsyncGenerator, Generator
 
@@ -38,11 +40,14 @@ import httpx
 import modal
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, Field, TypeAdapter
 
 from stitch.pools.modal_flash import list_flash_containers_async
 
-from .constants import MODAL_SESSION_ID_HEADER
+from .constants import (
+    MODAL_SESSION_ID_HEADER,
+    STITCH_LEASE_HEADER,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +99,16 @@ def session_routes_dict(app_name: str) -> modal.Dict:
 class ContainerInfo(BaseModel):
     task_id: str
     upstream: str  # host:port of the replica
-    load: int  # queued + running requests, last successful poll
+    load: int  # queued + running requests, last successful /v1/loads poll
+    load_stale: bool = False  # True when load is last-known, not live
+    # False while booting or after a terminal engine error; excluded from every
+    # selection path. Older sidecars omit it (treated as ready).
+    ready: bool = True
+    applied_version: int | None = None
+    leases: dict[str, int] = Field(default_factory=dict)  # /server_info; JSON keys are strings
+    sync_state: str | None = None
+    target_version: int | None = None  # None when idle
+    draining: bool = False  # excluded from every proxy selection path
 
 
 ContainerInfoList = TypeAdapter(list[ContainerInfo])
@@ -132,6 +146,7 @@ def filter_headers(headers: dict[str, str]) -> dict[str, str]:
         "modal-key",
         "modal-secret",
         MODAL_SESSION_ID_HEADER.lower(),
+        STITCH_LEASE_HEADER.lower(),
         "x-forwarded-for",
         "x-forwarded-host",
         "x-forwarded-port",
@@ -140,6 +155,18 @@ def filter_headers(headers: dict[str, str]) -> dict[str, str]:
         "x-forwarded-server",
     }
     return {k: v for k, v in headers.items() if k.lower() not in removed}
+
+
+def session_id_from_headers(headers: Any) -> str | None:
+    """Session identity for stickiness: ``Modal-Session-ID``."""
+    return headers.get(MODAL_SESSION_ID_HEADER)
+
+
+def relay_lease_header(headers: dict[str, str], session_id: str | None) -> dict[str, str]:
+    """Copy the stickiness session id into ``Stitch-Lease-Key``. Mutates ``headers``."""
+    if session_id:
+        headers[STITCH_LEASE_HEADER] = session_id
+    return headers
 
 
 def select_underloaded_container(
@@ -157,7 +184,10 @@ def select_underloaded_container(
         for container in containers.values()
         if container.load < overload_threshold
     ]
-    return random.choice(candidates or list(containers.values()))
+    pool = candidates or list(containers.values())
+    if not pool:
+        raise ValueError("select_underloaded_container: no containers to select from")
+    return random.choice(pool)
 
 
 async def route_session(
@@ -165,10 +195,12 @@ async def route_session(
     session_id: str,
     containers: dict[str, ContainerInfo],
     overload_threshold: int,
-) -> ContainerInfo:
-    """Pick the replica for one session: the most-recently-used of its known replicas
-    that has room below the pool's configured soft capacity, else a random replica with
-    headroom. Mutates and persists the session's routes."""
+    exact_version: int | None = None,
+) -> ContainerInfo | None:
+    """Pick the replica for one session: sticky if healthy and (when set)
+    applied_version == exact_version, else the lowest-load same-version replica.
+    Returns None — and does not persist a route — when exact_version is set
+    but no ready replica matches it."""
     current_time = time.time()
 
     routes: list[RouteEntry] = RouteEntryList.validate_python(
@@ -192,26 +224,98 @@ async def route_session(
             ),
         )
 
-    for entry in routes:
-        container = containers[entry.task_id]
+    for entry in list(routes):
+        # Re-lookup defensively: a concurrent 503-evict can pop the shared map
+        # while this coroutine is suspended in save_routes() — indexing would
+        # turn that race into a KeyError 500.
+        container = containers.get(entry.task_id)
+        if container is None:
+            continue
+        if not container.ready:
+            # Booting (stale boot weights) or dead-engine replica: evict so the
+            # session migrates off stale weights.
+            logger.info(
+                "session %s: sticky route %s is not ready; evicting",
+                session_id,
+                container.task_id,
+            )
+            routes.remove(entry)
+            await save_routes()
+            continue
         if container.load < overload_threshold:
+            if exact_version is not None and container.applied_version != exact_version:
+                logger.info(
+                    "session %s: sticky route %s has applied_version %s, "
+                    "not matching exact_version %d; evicting",
+                    session_id,
+                    container.task_id,
+                    container.applied_version,
+                    exact_version,
+                )
+                continue
             entry.last_sent = current_time
             await save_routes()
             return container
 
-    selected = select_underloaded_container(containers, overload_threshold)
+    candidates = [
+        container
+        for container in containers.values()
+        if container.load < overload_threshold and container.ready
+    ]
+    # Unpinned fallback is overloaded-but-ready; an all-not-ready fleet yields None.
+    fallback = candidates or [
+        container for container in containers.values() if container.ready
+    ]
+
+    if exact_version is not None:
+        version_matched = [c for c in candidates if c.applied_version == exact_version]
+        if not version_matched:
+            # Overloaded-but-matching fallback: the threshold ranks versions,
+            # it never denies the only correct version. Saturated at-version
+            # replicas still take the pinned request (queue there) — a 409
+            # here stops lease renewals, the holds collapse, sessions die.
+            version_matched = [
+                container
+                for container in containers.values()
+                if container.applied_version == exact_version and container.ready
+            ]
+        if version_matched:
+            selected = min(version_matched, key=lambda container: container.load)
+        else:
+            # No healthy upstream at the pinned version: return None rather than
+            # landing on a wrong-version replica (which would 409).
+            logger.info(
+                "session %s: no healthy upstream at exact_version=%d "
+                "(%d replicas known); not re-pinning",
+                session_id,
+                exact_version,
+                len(containers),
+            )
+            return None
+    else:
+        if not fallback:
+            logger.info(
+                "session %s: no ready replica available; no selection",
+                session_id,
+            )
+            return None
+        selected = random.choice(fallback)
+
     reason = (
         f"previous upstreams [{', '.join(entry.task_id for entry in routes)}] overloaded"
         f" (load >= {overload_threshold})"
         if routes
         else "no previous upstream"
     )
+    log_suffix = f" (exact_version={exact_version})" if exact_version is not None else ""
     logger.info(
-        "session %s: %s; pinning new upstream %s (load %d)",
+        "session %s: %s; pinning new upstream %s (load %d, applied_version=%s)%s",
         session_id,
         reason,
         selected.task_id,
         selected.load,
+        selected.applied_version,
+        log_suffix,
     )
     routes.insert(0, RouteEntry(task_id=selected.task_id, last_sent=current_time))
     await save_routes()
@@ -306,26 +410,71 @@ def stop_server(replica: Any) -> None:
         server.stop()
 
 
+@dataclass
+class _ReplicaPoll:
+    """One replica's poll result. ``load=None`` means /v1/loads failed — the
+    replica stays a member (/server_info is the membership contract) with its
+    last-known load."""
+
+    load: int | None
+    applied_version: int | None
+    leases: dict[str, int]
+    sync_state: str | None
+    target_version: int | None
+    ready: bool
+
+
 class _RegistryApp(_UvicornApp):
-    """Polls upstream replicas for load and serves the snapshot at ``/loads``."""
+    """Poll /server_info (membership) and /v1/loads (queue depth); serve ``/loads``."""
 
     def __init__(self, *, app_name: str, upstream_cls: str) -> None:
         self.app_name = app_name
         self.upstream_cls = upstream_cls
         self.containers: list[ContainerInfo] = []
+        self._last_loads: dict[str, int] = {}
 
-    async def _container_load(self, upstream: str) -> int:
-        loads_response, health_response = await asyncio.gather(
+    async def _poll_container(self, upstream: str) -> _ReplicaPoll:
+        """/server_info is membership (failure drops the replica). /v1/loads is
+        the load number only: its failure never drops the replica — a
+        STAGING/COMMITTING sidecar blocks /v1/loads for minutes."""
+        server_info_response, loads_response = await asyncio.gather(
+            self.client.get(f"https://{upstream}/server_info"),
             self.client.get(f"https://{upstream}/v1/loads", params={"include": "core"}),
-            self.client.get(f"https://{upstream}/health"),
+            return_exceptions=True,
         )
-        loads_response.raise_for_status()
-        health_response.raise_for_status()
+        if isinstance(server_info_response, BaseException):
+            raise server_info_response
+        server_info_response.raise_for_status()
+        data = server_info_response.json()
+        raw_leases = data.get("leases") or {}
+        # JSON object keys arrive as strings.
+        leases = {str(version): int(count) for version, count in raw_leases.items()}
+        sync_state = data.get("sync_state")
+        target_version = data.get("target_version")
+        if (sync_state or "").upper() == "ERROR":
+            # An errored replica has no target; never trust a leftover value.
+            target_version = None
 
-        loads = loads_response.json()["loads"]
-        queued = sum(int(load["num_waiting_reqs"]) for load in loads)
-        running = sum(int(load["num_running_reqs"]) for load in loads)
-        return queued + running
+        load: int | None = None
+        if not isinstance(loads_response, BaseException):
+            try:
+                loads_response.raise_for_status()
+                loads = loads_response.json()["loads"]
+                queued = sum(int(load["num_waiting_reqs"]) for load in loads)
+                running = sum(int(load["num_running_reqs"]) for load in loads)
+                load = queued + running
+            except Exception as exc:
+                logger.debug("loads poll failed for %s: %r", upstream, exc)
+
+        return _ReplicaPoll(
+            load=load,
+            applied_version=data.get("applied_version"),
+            leases=leases,
+            sync_state=sync_state,
+            target_version=target_version,
+            # Older sidecars don't expose `ready`; treat absence as ready.
+            ready=bool(data.get("ready", True)),
+        )
 
     async def _poll_once(self) -> list[ContainerInfo]:
         discovered = await list_flash_containers_async(self.app_name, self.upstream_cls)
@@ -339,20 +488,36 @@ class _RegistryApp(_UvicornApp):
             if task_id and addr:
                 upstreams[task_id] = addr
         results = await asyncio.gather(
-            *(self._container_load(upstream) for upstream in upstreams.values()),
+            *(self._poll_container(upstream) for upstream in upstreams.values()),
             return_exceptions=True,
         )
         updated: list[ContainerInfo] = []
         for (task_id, upstream), result in zip(upstreams.items(), results, strict=True):
             if isinstance(result, BaseException):
                 logger.warning(
-                    "load poll failed for replica %s: %r; dropping from registry",
+                    "server_info poll failed for replica %s: %r; dropping from registry",
                     task_id,
                     result,
                 )
+                self._last_loads.pop(task_id, None)
                 continue
+            if result.load is None:
+                load, load_stale = self._last_loads.get(task_id, 0), True
+            else:
+                load, load_stale = result.load, False
+                self._last_loads[task_id] = load
             updated.append(
-                ContainerInfo(task_id=task_id, upstream=upstream, load=result)
+                ContainerInfo(
+                    task_id=task_id,
+                    upstream=upstream,
+                    load=load,
+                    load_stale=load_stale,
+                    applied_version=result.applied_version,
+                    leases=result.leases,
+                    sync_state=result.sync_state,
+                    target_version=result.target_version,
+                    ready=result.ready,
+                )
             )
         return updated
 
@@ -533,11 +698,24 @@ class _ProxyApp(_UvicornApp):
                 return Response(content=b"", status_code=200, media_type="text/plain")
 
             body = await request.body()
-            session_id = request.headers.get(MODAL_SESSION_ID_HEADER)
+            session_id = session_id_from_headers(request.headers)
             log_prefix = f"[request {uuid.uuid4()}, session {session_id}]"
+
+            exact_version: int | None = None
+            exact_version_header = request.headers.get("stitch-exact-version", "").strip()
+            if exact_version_header:
+                try:
+                    exact_version = int(exact_version_header)
+                except ValueError:
+                    logger.warning(
+                        "%s ignoring malformed stitch-exact-version header: %r",
+                        log_prefix,
+                        exact_version_header,
+                    )
 
             try:
                 headers = filter_headers(dict(request.headers))
+                relay_lease_header(headers, session_id)
 
                 for attempt in range(MAX_SESSION_RETRIES + 1):
                     container = None
@@ -547,14 +725,43 @@ class _ProxyApp(_UvicornApp):
                             session_id,
                             self.containers,
                             self.overload_threshold,
+                            exact_version=exact_version,
                         )
+                        if container is None:
+                            if exact_version is not None:
+                                # No healthy upstream at the pin: 409, do not re-pin.
+                                logger.info(
+                                    "%s no healthy upstream (exact_version=%s); "
+                                    "answering 409",
+                                    log_prefix,
+                                    exact_version,
+                                )
+                                return Response(
+                                    content=b"No healthy upstream",
+                                    status_code=409,
+                                    media_type="text/plain",
+                                )
+                            # Unpinned with zero replicas in rotation (all booting
+                            # or draining): stock main falls through to the Flash
+                            # LB here, which retries — answer a retryable 503.
+                            logger.info(
+                                "%s no replica in rotation; answering 503",
+                                log_prefix,
+                            )
+                            return Response(
+                                content=b"No replica in rotation",
+                                status_code=503,
+                                headers={"Retry-After": "1"},
+                                media_type="text/plain",
+                            )
                         headers["modal-flash-upstream"] = container.upstream
 
                     logger.info(
-                        "%s proxying to replica %s (attempt=%d)",
+                        "%s proxying to replica %s (attempt=%d, exact_version=%s)",
                         log_prefix,
                         container.task_id if container else None,
                         attempt,
+                        exact_version,
                     )
 
                     stream = self.upstream_stream(
@@ -562,14 +769,14 @@ class _ProxyApp(_UvicornApp):
                     )
                     response: httpx.Response = await anext(stream)
 
-                    # Resolve stale upstream state to avoid repeated 503s: a pinned
-                    # replica that refuses the request leaves rotation, and the
-                    # session re-routes instead of retrying its saturator.
+                    # Only 503 evicts. A 409 is a version mismatch; the client
+                    # retries and the next registry poll refreshes applied_version.
                     if response.status_code == 503 and container is not None:
                         logger.warning(
-                            "%s replica %s returned 503 on attempt %d/%d; evicting",
+                            "%s replica %s returned %d on attempt %d/%d; evicting",
                             log_prefix,
                             container.task_id,
+                            response.status_code,
                             attempt + 1,
                             MAX_SESSION_RETRIES + 1,
                         )

--- a/cookbook/common/router_test.py
+++ b/cookbook/common/router_test.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 import asyncio
 import time
 from types import SimpleNamespace
+from typing import Any
+
+import httpx
 
 from cookbook.common import router
 from cookbook.common.router import (
@@ -16,9 +19,12 @@ from cookbook.common.router import (
     RouteEntryList,
     _container_addr,
     _ProxyApp,
+    _RegistryApp,
     filter_headers,
+    relay_lease_header,
     route_session,
     select_underloaded_container,
+    session_id_from_headers,
 )
 
 
@@ -139,6 +145,46 @@ def test_route_session_drops_expired_and_undiscovered_routes() -> None:
     assert [entry["task_id"] for entry in routes.store["s1"]] == ["ta-0"]
 
 
+def test_route_session_survives_concurrent_container_pops() -> None:
+    """A container-map pop racing a selection suspended in save_routes degrades
+    to another replica or None, never a KeyError."""
+
+    async def run() -> None:
+        routes = FakeRoutes()
+
+        class _YieldingPut:
+            async def aio(self, key: str, value: list) -> None:
+                await asyncio.sleep(0)  # let the popper interleave mid-save
+                routes.store[key] = value
+
+        routes.put = _YieldingPut()  # type: ignore[assignment]
+        fleet = _containers(0, 0, 0)
+        _seeded(routes, "s", [{"task_id": "ta-1", "last_sent": time.time()}])
+        picks: list[str] = []
+
+        async def popper() -> None:
+            for _ in range(400):
+                popped = fleet.pop("ta-1", None)
+                await asyncio.sleep(0)
+                if popped is not None:
+                    fleet["ta-1"] = popped
+                await asyncio.sleep(0)
+
+        async def select_loop() -> None:
+            for _ in range(200):
+                picked = await route_session(routes, "s", fleet, 4)
+                if picked is not None:
+                    picks.append(picked.task_id)
+
+        await asyncio.gather(popper(), *(select_loop() for _ in range(8)))
+        assert picks, "selections kept succeeding around concurrent pops"
+        fleet.pop("ta-1", None)
+        final = await route_session(routes, "s", fleet, 4)
+        assert final is not None and final.task_id != "ta-1"
+
+    asyncio.run(run())
+
+
 def test_select_underloaded_container_spreads_across_headroom(monkeypatch) -> None:
     containers = _containers(7, 2, 3, 2)
     candidates = []
@@ -153,7 +199,7 @@ def test_select_underloaded_container_spreads_across_headroom(monkeypatch) -> No
     assert {container.task_id for container in candidates} == {"ta-1", "ta-2", "ta-3"}
 
 
-def test_filter_headers_drops_routing_and_hop_by_hop() -> None:
+def test_session_and_lease_headers() -> None:
     headers = {
         "Host": "example",
         "Content-Length": "10",
@@ -167,6 +213,20 @@ def test_filter_headers_drops_routing_and_hop_by_hop() -> None:
         "Authorization": "Bearer tok",
         "content-type": "application/json",
     }
+    assert filter_headers(
+        {
+            "stitch-exact-version": "3",
+            "modal-session-id": "s1",
+            "Stitch-Lease-Key": "forged",
+        }
+    ) == {"stitch-exact-version": "3"}
+    assert relay_lease_header({"content-type": "application/json"}, "s1") == {
+        "content-type": "application/json",
+        "Stitch-Lease-Key": "s1",
+    }
+    assert relay_lease_header({}, None) == {}
+    assert session_id_from_headers({"Modal-Session-ID": "modal-s"}) == "modal-s"
+    assert session_id_from_headers({}) is None
 
 
 def test_container_addr_normalizes_host_and_port() -> None:
@@ -226,6 +286,283 @@ def test_upstream_stream_reserves_capacity_before_connecting() -> None:
         assert container.load == 1
         assert [chunk async for chunk in stream] == [b"ok"]
         assert container.load == 0
+
+    asyncio.run(run())
+
+
+def _leased(
+    task_id: str, load: int, applied_version: int | None, leases: dict[str, int]
+) -> ContainerInfo:
+    return ContainerInfo(
+        task_id=task_id,
+        upstream=f"{task_id}:8000",
+        load=load,
+        applied_version=applied_version,
+        leases=leases,
+    )
+
+
+def test_route_session_version_boundary() -> None:
+    """Version preference, no-match no-repin, and saturation queuing — one
+    walk of the pinned-session boundary."""
+    containers = {
+        "ta-0": ContainerInfo(
+            task_id="ta-0", upstream="h0:8000", load=0, applied_version=1
+        ),
+        "ta-1": ContainerInfo(
+            task_id="ta-1", upstream="h1:8000", load=0, applied_version=2
+        ),
+    }
+    routes = FakeRoutes()
+    picked = asyncio.run(route_session(routes, "s1", containers, 4, exact_version=2))
+    assert picked.task_id == "ta-1", "version preference picks the matching replica"
+    assert picked.applied_version == 2
+
+    routes = FakeRoutes()
+    picked = asyncio.run(
+        route_session(routes, "s1", {"ta-0": containers["ta-0"]}, 4, exact_version=99)
+    )
+    assert picked is None, "no version match returns None"
+    assert "s1" not in routes.store, "no match must not re-pin"
+    picked = asyncio.run(
+        route_session(
+            FakeRoutes(),
+            "s1",
+            {
+                "ta-0": _leased("ta-0", load=0, applied_version=2, leases={"2": 7}),
+                "ta-1": _leased("ta-1", load=0, applied_version=None, leases={}),
+            },
+            4,
+            exact_version=1,
+        )
+    )
+    assert picked is None, "no applied_version match returns None"
+
+    routes = FakeRoutes()
+    picked = asyncio.run(
+        route_session(
+            routes,
+            "s1",
+            {
+                "ta-0": _leased("ta-0", load=9, applied_version=1, leases={"1": 3}),
+                "ta-1": _leased("ta-1", load=12, applied_version=1, leases={"1": 5}),
+                "ta-2": _leased("ta-2", load=0, applied_version=2, leases={"2": 1}),
+            },
+            4,
+            exact_version=1,
+        )
+    )
+    assert picked.task_id == "ta-0", "saturated matching replica queues rather than 409s"
+    assert routes.store["s1"][0]["task_id"] == "ta-0"
+
+
+class _FakeResp:
+    def __init__(self, payload: dict, *, ok: bool = True) -> None:
+        self._payload = payload
+        self._ok = ok
+
+    def raise_for_status(self) -> None:
+        if not self._ok:
+            raise RuntimeError("HTTP 503")
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _registry_client(
+    server_info: dict | Exception, loads: dict | Exception
+) -> object:
+    class FakeClient:
+        async def get(self, url: str, **_kwargs) -> _FakeResp:
+            if url.endswith("/server_info"):
+                if isinstance(server_info, Exception):
+                    raise server_info
+                return _FakeResp(server_info)
+            if url.endswith("/v1/loads"):
+                if isinstance(loads, Exception):
+                    raise loads
+                return _FakeResp(loads)
+            raise AssertionError(f"unexpected url: {url}")
+
+    return FakeClient()
+
+
+def _loads_payload(waiting: int, running: int) -> dict:
+    return {"loads": [{"num_waiting_reqs": waiting, "num_running_reqs": running}]}
+
+
+def _patch_discovery(monkeypatch, task_ids: list[str]) -> None:
+    async def discover(_app_name: str, _cls: str) -> list[dict]:
+        return [{"task_id": t, "host": f"h-{t}", "port": 8000} for t in task_ids]
+
+    monkeypatch.setattr(router, "list_flash_containers_async", discover)
+
+
+def test_registry_poll_membership_vs_load(monkeypatch) -> None:
+    """Happy-path load/version passthrough; server_info failure drops the replica."""
+    registry = _RegistryApp(app_name="app", upstream_cls="Server")
+    registry.client = _registry_client(
+        {
+            "applied_version": 3,
+            "leases": {"3": 2, "1": 1},
+            "sync_state": "HOLDING",
+            "target_version": 4,
+        },
+        _loads_payload(1, 2),
+    )
+    poll = asyncio.run(registry._poll_container("h0:8000"))
+    assert poll.load == 3
+    assert poll.applied_version == 3
+    assert poll.leases == {"3": 2, "1": 1}
+    assert poll.sync_state == "HOLDING"
+    assert poll.target_version == 4
+
+    registry.client = _registry_client(
+        {"applied_version": 3, "sync_state": "ERROR", "target_version": 5},
+        _loads_payload(0, 0),
+    )
+    poll = asyncio.run(registry._poll_container("h0:8000"))
+    assert poll.target_version is None, (
+        "an errored replica has no target: a leftover target_version is nulled"
+    )
+
+    registry.client = _registry_client(
+        RuntimeError("server_info down"), _loads_payload(0, 0)
+    )
+    try:
+        asyncio.run(registry._poll_container("h0:8000"))
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("server_info failure must propagate (drops the replica)")
+
+    _patch_discovery(monkeypatch, ["ta-0"])
+    registry = _RegistryApp(app_name="app", upstream_cls="Server")
+    registry.client = _registry_client(
+        RuntimeError("server_info down"), _loads_payload(0, 0)
+    )
+    assert asyncio.run(registry._poll_once()) == []
+
+
+class _FakeUpstreamResponse:
+    def __init__(self, status: int, body: bytes = b"ok") -> None:
+        self.status_code = status
+        self.headers = {"content-type": "text/plain"}
+        self._body = body
+
+    async def aiter_raw(self):
+        yield self._body
+
+
+class _FakeUpstreamStream:
+    def __init__(self, response: _FakeUpstreamResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _FakeUpstreamResponse:
+        return self._response
+
+    async def __aexit__(self, *args) -> None:
+        return None
+
+
+class _FakeUpstreamClient:
+    def __init__(self, status_by_upstream: dict[str, int]) -> None:
+        self.status_by_upstream = status_by_upstream
+        self.requested_upstreams: list[str | None] = []
+
+    def stream(self, *, headers, **_kwargs) -> _FakeUpstreamStream:
+        upstream = headers.get("modal-flash-upstream")
+        self.requested_upstreams.append(upstream)
+        status = self.status_by_upstream.get(upstream, 200)
+        return _FakeUpstreamStream(_FakeUpstreamResponse(status))
+
+
+def _proxy(fleet: dict[str, ContainerInfo]) -> tuple[_ProxyApp, Any]:
+    proxy = _ProxyApp(
+        registry_url="https://registry",
+        upstream_url="https://upstream",
+        session_routes=FakeRoutes(),
+        overload_threshold=4,
+    )
+    app = proxy.build_app()
+    proxy.containers = fleet
+    return proxy, app
+
+
+async def _post(
+    app: Any, session_id: str, exact_version: int | None
+) -> httpx.Response:
+    transport = httpx.ASGITransport(app=app)
+    headers = {"modal-session-id": session_id}
+    if exact_version is not None:
+        headers["stitch-exact-version"] = str(exact_version)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as client:
+        return await client.post(
+            "/v1/chat/completions",
+            headers=headers,
+            content=b"{}",
+        )
+
+
+def test_forward_409_passthrough_and_503_eviction() -> None:
+    """A 409 is passed through without eviction; only 503 evicts; a pin with no
+    matching version is a 409 that never touches an upstream."""
+
+    async def run() -> None:
+        fleet = {
+            "ta-s1": _leased("ta-s1", 0, 2, {"2": 4}),
+            "ta-s2": _leased("ta-s2", 0, 2, {"2": 2}),
+        }
+        proxy, app = _proxy(fleet)
+        fake = _FakeUpstreamClient({"ta-s1:8000": 409, "ta-s2:8000": 409})
+        proxy.client = fake
+        response = await _post(app, "s1", 2)
+        assert response.status_code == 409, "409 from a pinned replica is passed through"
+        assert len(fake.requested_upstreams) == 1
+        assert fake.requested_upstreams[0] in {"ta-s1:8000", "ta-s2:8000"}
+        assert set(proxy.containers) == {"ta-s1", "ta-s2"}, "409 does not evict"
+
+        proxy, app = _proxy({"ta-s1": _leased("ta-s1", 0, 2, {"2": 4})})
+        fake = _FakeUpstreamClient({})
+        proxy.client = fake
+        response = await _post(app, "s1", 1)
+        assert response.status_code == 409, (
+            "no v1 replica: 409, never a wrong-version upstream"
+        )
+        assert fake.requested_upstreams == []
+
+        proxy, app = _proxy(
+            {
+                "ta-boot": _leased("ta-boot", 0, 2, {}).model_copy(
+                    update={"ready": False}
+                )
+            }
+        )
+        fake = _FakeUpstreamClient({})
+        proxy.client = fake
+        response = await _post(app, "s1", None)
+        assert response.status_code == 503, (
+            "unpinned with no ready replica: a retryable 503, not a 409"
+        )
+        assert response.headers["retry-after"] == "1"
+        assert fake.requested_upstreams == []
+
+        fleet = {
+            "ta-s1": _leased("ta-s1", 0, 2, {"2": 4}),
+            "ta-s2": _leased("ta-s2", 1, 2, {"2": 2}),
+        }
+        proxy, app = _proxy(fleet)
+        fake = _FakeUpstreamClient({"ta-s1:8000": 503, "ta-s2:8000": 200})
+        proxy.client = fake
+        response = await _post(app, "s1", 2)
+        assert response.status_code == 200
+        assert fake.requested_upstreams == ["ta-s1:8000", "ta-s2:8000"], (
+            "ta-s1 is the lowest-load v2 match, so the 503-retry lands on ta-s2"
+        )
+        assert "ta-s1" not in proxy.containers
+        assert set(proxy.containers) == {"ta-s2"}
 
     asyncio.run(run())
 


### PR DESCRIPTION
Production series 2/7, stacked on #178.

## Summary

- source registry membership from the ungated `/server_info` (ready + load-staleness semantics); `/v1/loads` contributes only the load number, and a loads failure keeps the replica with stale load instead of dropping it mid-commit
- place version-pinned requests on replicas with that version applied
- answer 503 + Retry-After for an unpinned session when no replica is in rotation (fleet boot, all-draining windows); pinned misses keep the 409
- never evict a replica on 409; never route pinned traffic to wrong-version or draining replicas; queue on the lowest-load match when all matches are saturated
- relay `Modal-Session-Id` upstream as the internal `Stitch-Lease-Key` (strip a client-forged copy); clients send only standard headers

## Validation

- `pytest src/ cookbook/ -q` at branch head (257 passed)
- boundary walk, 409/503 asymmetry, saturation-queue, relay, and concurrent container-pop race test
- placement exercised live across all POC runs
