### PR TITLE
cookbook: derive registry upstream URL from upstream_cls

### DIFF
--- a/cookbook/common/router.py
+++ b/cookbook/common/router.py
@@ -274,10 +274,14 @@ class _RequestCancelledMiddleware:
             return None
 
 
-def serve_registry(replica: Any, *, app_name: str, upstream_cls: str, upstream_url: str) -> None:
+def serve_registry(replica: Any, *, app_name: str, upstream_cls: str) -> None:
     """Start the load-registry server on a ``RouterRegistry`` container (@modal.enter)."""
+    # Polls go through the upstream class's own URL (same app), derived here so recipes
+    # only name the class — mirrors flash-smart-router's from_name lookup in @modal.enter.
     registry = _RegistryApp(
-        app_name=app_name, upstream_cls=upstream_cls, upstream_url=upstream_url
+        app_name=app_name,
+        upstream_cls=upstream_cls,
+        upstream_url=modal.Server.from_name(app_name, upstream_cls).get_url(),
     )
     registry.start()
     replica._router_server = registry

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -334,9 +334,7 @@ class RouterRegistry:
 
     @modal.enter()
     def enter(self) -> None:
-        router.serve_registry(
-            self, app_name=APP_NAME, upstream_cls="Server", upstream_url=Server.get_url()
-        )
+        router.serve_registry(self, app_name=APP_NAME, upstream_cls="Server")
 
     @modal.exit()
     def exit(self) -> None:

--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -230,9 +230,7 @@ class RouterRegistry:
 
     @modal.enter()
     def enter(self) -> None:
-        router.serve_registry(
-            self, app_name=APP_NAME, upstream_cls="Server", upstream_url=Server.get_url()
-        )
+        router.serve_registry(self, app_name=APP_NAME, upstream_cls="Server")
 
     @modal.exit()
     def exit(self) -> None:


### PR DESCRIPTION
## Summary
Addresses https://github.com/modal-projects/stitch/pull/190#discussion_r3864660868 
- `serve_registry` now derives the pool URL from `app_name` + `upstream_cls` via `modal.Server.from_name(...).get_url()` (the same lookup flash-smart-router does in `@modal.enter`)
- dropping the `upstream_url` parameter. Recipe call sites revert to the one-line form. 
 
This also un-breaks `cookbook/standalone/app.py`, which already called `serve_registry` without `upstream_url` and would have raised `TypeError` on container start.

## Testing

- Unit: `uv run --extra modal pytest cookbook/common/router_test.py cookbook/standalone/app_test.py` — 12/12 pass.
- E2E in saatwik-dev (`router-e2e-rtr0826a`): same mock-upstream harness as #190 — 8/8 checks pass with the derived URL (replica discovery through the URL, stable per-replica load attribution, session pinning, 503 eviction + re-route). App stopped after the run.