### PR TITLE
stitch: gate the engine watchdog during cpu-destination staging

### DIFF
--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -204,6 +204,14 @@ class Reconciler:
             raise ValueError("boot_version must be non-negative")
         self.store = store
         self.engine = engine
+        # A cpu-destination stage does its heavy work inside the engine (the lazy
+        # full CPU-weight-image compile occupies the engine's HTTP loop for
+        # minutes at large-model scale), so the watchdog must not probe then.
+        # Learn the mode once: an engine that declares none keeps stock
+        # supervision (disk stages are pure file I/O beside a serving engine).
+        self._staging_occupies_engine = (
+            getattr(engine, "delta_update_mode", "disk") == "cpu"
+        )
         self.flush_cache_on_commit = flush_cache_on_commit
         self.run_id = run_id
         self.boot_version = boot_version
@@ -312,7 +320,13 @@ class Reconciler:
 
     def expects_engine_progress(self) -> bool:
         """Whether this replica should currently make inference progress."""
-        return self.ready and self.sync_state is not SyncState.COMMITTING
+        if not self.ready:
+            return False
+        if self.sync_state is SyncState.COMMITTING:
+            return False
+        return not (
+            self.sync_state is SyncState.STAGING and self._staging_occupies_engine
+        )
 
     async def wait_for_terminal_error(self) -> None:
         """Raise once reconciliation proves this replica must be replaced."""

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -190,6 +190,31 @@ def test_engine_progress_expectation_follows_serving_lifecycle(
     assert reconciler.expects_engine_progress() is expects_progress
 
 
+@pytest.mark.parametrize(
+    "delta_update_mode,expects_progress",
+    [
+        ("cpu", False),  # the cpu-weight-image compile occupies the engine's HTTP loop
+        ("disk", True),  # disk staging is pure file I/O beside a serving engine
+        (None, True),  # a mode-less engine keeps stock supervision
+    ],
+)
+def test_staging_progress_expectation_follows_delta_update_mode(
+    delta_update_mode: str | None, expects_progress: bool
+) -> None:
+    engine = FakeEngine()
+    if delta_update_mode is not None:
+        engine.delta_update_mode = delta_update_mode
+    reconciler = _make_reconciler(store=FakeStore(), engine=engine)
+    reconciler.ready = True
+
+    reconciler.sync_state = SyncState.STAGING
+    assert reconciler.expects_engine_progress() is expects_progress
+    reconciler.sync_state = SyncState.IDLE
+    assert reconciler.expects_engine_progress() is True
+    reconciler.sync_state = SyncState.COMMITTING
+    assert reconciler.expects_engine_progress() is False
+
+
 def test_catch_up() -> None:
     async def go() -> None:
         engine = FakeEngine()


### PR DESCRIPTION

## Summary

- gate the engine watchdog during cpu-destination delta staging: the stage triggers the full CPU-weight-image rebuild, which takes minutes at large-model scale, and `expects_engine_progress` only exempted COMMITTING — the watchdog killed replicas mid-compile
- engines that do not declare a delta update mode keep stock supervision (`disk` default)
- disk-destination staging keeps full probing

## Validation

- `pytest src/ cookbook/ -q` at branch head (229 passed)
- cpu/disk/mode-less watchdog asymmetry tests
- the mid-compile watchdog kill was observed live on a multi-GPU pool before this fix
