### PR TITLE
stitch: manual reconcile mode with a router-facing /reconcile endpoint

### DIFF
--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -23,7 +23,13 @@ from typing import Any, Protocol
 from stitch.engines.base import Engine
 from stitch.pools.base import Pool
 from stitch.stores.base import Store
-from stitch.sync import AdmissionGate, CommitMode, ConstraintUnmet, Reconciler
+from stitch.sync import (
+    AdmissionGate,
+    CommitMode,
+    ConstraintUnmet,
+    ReconcileMode,
+    Reconciler,
+)
 from stitch.types import PoolState, ReplicaState, VersionConstraint
 from stitch.watchdog import (
     EngineWatchdog,
@@ -59,6 +65,8 @@ class SidecarStatus(Protocol):
     def server_info(self) -> dict[str, Any]: ...
 
     def wake(self) -> None: ...
+
+    def reconcile_now(self) -> None: ...
 
     async def startup(self) -> None: ...
 
@@ -131,6 +139,14 @@ def create_app(
     @app.post("/wake")
     async def wake() -> dict[str, Any]:
         status.wake()
+        return status.server_info()
+
+    @app.post("/reconcile")
+    async def reconcile() -> dict[str, Any]:
+        # The router's reconciliation trigger: one pass toward the current latest
+        # pointer. Ungated by admission (like /server_info), idempotent, and a
+        # harmless nudge in auto mode.
+        status.reconcile_now()
         return status.server_info()
 
     async def _watch_disconnect(request: Request) -> None:
@@ -295,6 +311,7 @@ def serve(
     port: int = 8000,
     debug_requests: bool = False,
     reconcile_interval: float = 5.0,
+    reconcile_mode: ReconcileMode = "auto",
     watchdog_interval: float = 5.0,
     watchdog_failure_threshold: int = 3,
 ) -> None:
@@ -311,6 +328,7 @@ def serve(
         flush_cache_on_commit=flush_cache_on_commit,
         debug_requests=debug_requests,
         reconcile_interval=reconcile_interval,
+        reconcile_mode=reconcile_mode,
     )
     watchdog = SidecarWatchdog(
         EngineWatchdog(

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -43,6 +43,7 @@ class _GateSidecar:
         self.applied = applied
         self.ready = True
         self.gate = AdmissionGate(served_version=lambda: self.applied)
+        self.reconcile_now_calls = 0
 
     def readiness_reason(self) -> str:
         return ""
@@ -52,6 +53,9 @@ class _GateSidecar:
 
     def wake(self) -> None:
         pass
+
+    def reconcile_now(self) -> None:
+        self.reconcile_now_calls += 1
 
     async def startup(self) -> None:
         pass
@@ -263,6 +267,42 @@ def test_metrics_bypasses_weight_admission_before_first_pointer(monkeypatch):
         assert response.content.startswith(b"# TYPE sglang:num_running_reqs gauge")
         assert upstream.requests == [("GET", "http://local-engine:8001/metrics")]
         assert gate_sidecar.gate.active_requests == 0
+
+    asyncio.run(go())
+
+
+def test_reconcile_endpoint_triggers_a_pass_and_reports_server_info() -> None:
+    """POST /reconcile is ungated by admission: it nudges the reconciler and answers
+    with the server_info snapshot, in either reconcile mode."""
+
+    async def go():
+        gate_sidecar = _GateSidecar(VersionRef("run", 3))
+        app = create_app(gate_sidecar.gate, gate_sidecar, _ProxyEngine())
+        sidecar = httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://sidecar"
+        )
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def apply() -> None:
+            entered.set()
+            await release.wait()
+
+        async with sidecar:
+            commit = asyncio.create_task(
+                gate_sidecar.gate.commit(apply=apply, on_applied=lambda: None)
+            )
+            await entered.wait()  # admission is closed for the weight commit
+            response = await sidecar.post("/reconcile")  # ungated: answers anyway
+            assert response.status_code == 200
+            assert response.json() == {"ready": True}
+            assert gate_sidecar.reconcile_now_calls == 1
+            release.set()
+            await commit
+
+            again = await sidecar.post("/reconcile")  # idempotent nudge
+            assert again.status_code == 200
+            assert gate_sidecar.reconcile_now_calls == 2
 
     asyncio.run(go())
 

--- a/src/stitch/sidecar.py
+++ b/src/stitch/sidecar.py
@@ -27,7 +27,7 @@ from typing import Literal
 from stitch.engines.sglang import SGLangEngine
 from stitch.service import serve
 from stitch.stores.base import Store
-from stitch.sync import CommitMode
+from stitch.sync import CommitMode, ReconcileMode
 
 DeltaUpdateMode = Literal["disk", "cpu"]
 
@@ -62,6 +62,7 @@ class SidecarConfig:
     boot_version: int = 0
     debug_requests: bool = False
     reconcile_interval: float = 5.0
+    reconcile_mode: ReconcileMode = "auto"
     watchdog_interval: float = 5.0
     watchdog_failure_threshold: int = 3
 
@@ -70,6 +71,11 @@ class SidecarConfig:
             raise ValueError("run_id is required")
         if self.boot_version < 0:
             raise ValueError("boot_version must be non-negative")
+        if self.reconcile_mode not in ("auto", "manual"):
+            raise ValueError(
+                "reconcile_mode must be either 'auto' or 'manual', "
+                f"got {self.reconcile_mode!r}"
+            )
         if self.delta_update_mode == "disk" and not self.local_checkpoint_dir:
             raise ValueError("local_checkpoint_dir is required in disk mode")
         if ":" not in self.store_factory:
@@ -112,6 +118,8 @@ class SidecarConfig:
             str(self.boot_version),
             "--reconcile-interval",
             str(self.reconcile_interval),
+            "--reconcile-mode",
+            self.reconcile_mode,
             "--watchdog-interval",
             str(self.watchdog_interval),
             "--watchdog-failure-threshold",
@@ -159,6 +167,7 @@ class SidecarConfig:
             boot_version=args.boot_version,
             debug_requests=args.debug_requests,
             reconcile_interval=args.reconcile_interval,
+            reconcile_mode=args.reconcile_mode,
             watchdog_interval=args.watchdog_interval,
             watchdog_failure_threshold=args.watchdog_failure_threshold,
         )
@@ -188,6 +197,7 @@ def _sidecar_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--reconcile-interval", type=float, default=5.0
     )  # 0 disables the periodic re-check
+    p.add_argument("--reconcile-mode", choices=["auto", "manual"], default="auto")
     p.add_argument("--watchdog-interval", type=float, default=5.0)
     p.add_argument("--watchdog-failure-threshold", type=int, default=3)
     p.add_argument("--local-checkpoint-dir")
@@ -234,6 +244,7 @@ def run(config: SidecarConfig, store: Store) -> None:
         port=config.port,
         debug_requests=config.debug_requests,
         reconcile_interval=config.reconcile_interval,
+        reconcile_mode=config.reconcile_mode,
         watchdog_interval=config.watchdog_interval,
         watchdog_failure_threshold=config.watchdog_failure_threshold,
     )

--- a/src/stitch/sidecar_test.py
+++ b/src/stitch/sidecar_test.py
@@ -87,6 +87,7 @@ _FULL = SidecarConfig(
     boot_version=3,
     debug_requests=True,
     reconcile_interval=2.5,
+    reconcile_mode="manual",
     watchdog_interval=1.0,
     watchdog_failure_threshold=7,
 )
@@ -113,6 +114,20 @@ def test_from_argv_fills_unflagged_fields_with_defaults() -> None:
         ]
     )
     assert parsed == _MINIMAL
+
+
+def test_reconcile_mode_defaults_to_auto() -> None:
+    assert SidecarConfig(**_BASE, delta_update_mode="cpu").reconcile_mode == "auto"
+
+
+def test_sidecar_config_rejects_unknown_reconcile_mode() -> None:
+    with pytest.raises(ValueError, match="reconcile_mode"):
+        SidecarConfig(**_BASE, delta_update_mode="cpu", reconcile_mode="sometimes")
+
+
+def test_from_argv_rejects_unknown_reconcile_mode() -> None:
+    with pytest.raises(SystemExit):
+        SidecarConfig.from_argv([*_MINIMAL.to_argv(), "--reconcile-mode", "sometimes"])
 
 
 def test_disk_mode_requires_local_checkpoint_dir() -> None:
@@ -170,6 +185,7 @@ def test_run_builds_engine_and_serves(monkeypatch: pytest.MonkeyPatch) -> None:
         boot_version=2,
         debug_requests=True,
         reconcile_interval=0.0,
+        reconcile_mode="manual",
         watchdog_interval=1.0,
         watchdog_failure_threshold=7,
     )
@@ -193,6 +209,7 @@ def test_run_builds_engine_and_serves(monkeypatch: pytest.MonkeyPatch) -> None:
         "port": 8000,
         "debug_requests": True,
         "reconcile_interval": 0.0,
+        "reconcile_mode": "manual",
         "watchdog_interval": 1.0,
         "watchdog_failure_threshold": 7,
     }

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -34,6 +34,8 @@ logger = logging.getLogger(__name__)
 
 CommitMode = Literal["quiesce", "in_place"]
 
+ReconcileMode = Literal["auto", "manual"]
+
 
 @contextmanager
 def _timed(metrics: dict[str, Any], key: str):
@@ -184,7 +186,13 @@ class Reconciler:
     :class:`AdmissionGate` (``self.gate``), which reads ``self.applied`` under its
     own lock while commits flip that same attribute through ``gate.commit``. A run
     change restores the immutable boot checkpoint, so one run's chain is never
-    mistaken for another's."""
+    mistaken for another's.
+
+    ``reconcile_mode`` gates the post-ready triggers, not the mechanics: in
+    ``manual`` the boot catch-up still runs to the ready latch, but afterwards
+    only :meth:`reconcile_now` (the router-facing ``POST /reconcile``) starts a
+    pass — the periodic poll is never armed and a publish wake or 409 nudge is
+    inert. ``auto`` is stock behavior."""
 
     def __init__(
         self,
@@ -197,11 +205,16 @@ class Reconciler:
         flush_cache_on_commit: bool = False,
         debug_requests: bool = False,
         reconcile_interval: float = 5.0,
+        reconcile_mode: ReconcileMode = "auto",
     ) -> None:
         if not run_id:
             raise ValueError("run_id is required")
         if boot_version < 0:
             raise ValueError("boot_version must be non-negative")
+        if reconcile_mode not in ("auto", "manual"):
+            raise ValueError(
+                f"reconcile_mode must be 'auto' or 'manual', got {reconcile_mode!r}"
+            )
         self.store = store
         self.engine = engine
         self.flush_cache_on_commit = flush_cache_on_commit
@@ -216,6 +229,7 @@ class Reconciler:
         )
         self.debug_requests = debug_requests
         self.reconcile_interval = reconcile_interval
+        self.reconcile_mode = reconcile_mode
         self.sync_state = SyncState.IDLE
         self.last_error: str | None = None
         # Latches after first catch-up unless the replica becomes terminal.
@@ -240,7 +254,11 @@ class Reconciler:
         if self._terminal_error is not None:
             return
         await self.reconcile()
-        if self.reconcile_interval > 0 and self._terminal_error is None:
+        if (
+            self.reconcile_mode == "auto"
+            and self.reconcile_interval > 0
+            and self._terminal_error is None
+        ):
             self._periodic_task = asyncio.create_task(self._periodic_reconcile())
 
     async def shutdown(self) -> None:
@@ -333,8 +351,19 @@ class Reconciler:
         """Nudge reconciliation now (a publish wake or a 409).
 
         Multiple wakes coalesce because each pass reads the authoritative pointer. A
-        wake during an active pass requests one more pass instead of being dropped.
-        """
+        wake during an active pass requests one more pass instead of being dropped. In
+        manual mode this trigger is inert: only the router's ``POST /reconcile``
+        (:meth:`reconcile_now`) moves the replica after the boot catch-up."""
+        if self.reconcile_mode == "manual":
+            return
+        self.reconcile_now()
+
+    def reconcile_now(self) -> None:
+        """Trigger one reconciliation pass toward the current ``latest`` pointer.
+
+        The router-facing trigger (``POST /reconcile``): ungated by the reconcile
+        mode, idempotent (passes coalesce), and a harmless extra nudge in auto
+        mode — the same mechanics a publish wake uses."""
         if self._terminal_error is not None:
             return
         if self._task is not None and not self._task.done():

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -889,6 +889,119 @@ def test_constrained_409_recovers_without_backstop() -> None:
     _run(go())
 
 
+# ── manual reconcile mode ────────────────────────────────────────────────────
+def test_manual_mode_boot_catch_up_latches_ready() -> None:
+    """The boot catch-up to latest runs unchanged; only post-ready triggers are gated."""
+
+    async def go() -> None:
+        engine = FakeEngine()
+        r = _make_reconciler(
+            store=FakeStore(VersionRef("r1", 3), _full("r1", 3)),
+            engine=engine,
+            reconcile_interval=0.02,
+            reconcile_mode="manual",
+        )
+        await r.startup()
+        assert r.ready
+        assert r.applied == VersionRef("r1", 3)
+        assert r._periodic_task is None  # the poll is never armed in manual mode
+        await r.shutdown()
+
+    _run(go())
+
+
+def test_manual_mode_ignores_poll_wake_and_409_nudge() -> None:
+    """After ready, nothing but /reconcile moves the replica; new pins keep 409-ing."""
+
+    async def go() -> None:
+        store = FakeStore(VersionRef("r1", 3), _full("r1", 3), _full("r1", 5))
+        r = _make_reconciler(
+            store=store,
+            engine=FakeEngine(),
+            reconcile_interval=0.02,
+            reconcile_mode="manual",
+        )
+        await r.startup()
+        assert r.applied == VersionRef("r1", 3)
+
+        store.advance_pointer(VersionRef("r1", 5))
+        await asyncio.sleep(0.1)  # in auto mode the poll would have caught up by now
+        assert r.applied == VersionRef("r1", 3)
+
+        r.wake()  # a publish wake lands on the gated trigger
+        r._on_reject({"type": "WeightVersionNotReady"})  # the 409 nudge path
+        await asyncio.sleep(0.1)
+        assert r.applied == VersionRef("r1", 3)
+        assert r._task is None
+
+        try:
+            async with r.gate.admit(VersionConstraint(exact_version=5)):
+                raise AssertionError("should have rejected")
+        except ConstraintUnmet as e:
+            assert e.error["type"] == "WeightVersionNotReady"
+            assert e.error["target_version"] == 5
+        await asyncio.sleep(0.1)
+        assert r.applied == VersionRef("r1", 3)  # even the rejection's nudge is inert
+        await r.shutdown()
+
+    _run(go())
+
+
+def test_manual_mode_reconcile_now_converges_to_latest() -> None:
+    """The router-facing trigger converges the replica; subsequent pins serve."""
+
+    async def go() -> None:
+        store = FakeStore(VersionRef("r1", 3), _full("r1", 3), _full("r1", 5))
+        r = _make_reconciler(
+            store=store,
+            engine=FakeEngine(),
+            reconcile_interval=0.02,
+            reconcile_mode="manual",
+        )
+        await r.startup()
+        store.advance_pointer(VersionRef("r1", 5))
+
+        r.reconcile_now()
+        assert await _converged(r, VersionRef("r1", 5))
+        async with r.gate.admit(VersionConstraint(exact_version=5)) as served:
+            assert served == VersionRef("r1", 5)
+        await r.shutdown()
+
+    _run(go())
+
+
+def test_reconcile_now_in_auto_mode_is_a_harmless_nudge() -> None:
+    """Auto mode keeps the same mechanics: reconcile_now is an extra wake, idempotent."""
+
+    async def go() -> None:
+        store = FakeStore(VersionRef("r1", 3), _full("r1", 3), _full("r1", 5))
+        r = _make_reconciler(store=store, engine=FakeEngine(), reconcile_interval=0)
+        await r.startup()
+        store.advance_pointer(VersionRef("r1", 5))
+
+        r.reconcile_now()
+        assert await _converged(r, VersionRef("r1", 5))
+        r.reconcile_now()  # coalesces into the caught-up state
+        assert await _converged(r, VersionRef("r1", 5))
+        await r.shutdown()
+
+    _run(go())
+
+
+def test_reconcile_mode_defaults_to_auto() -> None:
+    assert (
+        _make_reconciler(store=FakeStore(), engine=FakeEngine()).reconcile_mode
+        == "auto"
+    )
+
+
+def test_reconcile_mode_is_validated() -> None:
+    with pytest.raises(ValueError, match="reconcile_mode"):
+        _make_reconciler(
+            store=FakeStore(), engine=FakeEngine(), reconcile_mode="sometimes"
+        )
+
+
 # ── admission gate ───────────────────────────────────────────────────────────
 def test_admit_satisfied() -> None:
     async def go() -> None:


### PR DESCRIPTION
Offline-evals series 1/6. Rollout pools where a router owns reconciliation timing.

## Summary

- add `--reconcile-mode {auto,manual}` to the sidecar; `auto` (default) is stock behavior byte for byte
- `manual`: the boot catch-up to `latest` runs unchanged until the ready latch; after that the periodic poll, publish wake, and 409 nudge are inert — reconciliation happens only when asked
- add ungated `POST /reconcile`: triggers one reconciliation pass toward the current `latest` (idempotent, works in both modes, answers during a closed admission gate), returns the server_info snapshot
- no target-version parameter: the pointer's rewind guard stays the only version authority

## Validation

- `pytest src/ cookbook/ -q` at branch head (236 passed)
- manual-mode inertness (poll ticks + 409 nudge), endpoint-driven convergence, auto-mode default equivalence, endpoint-during-commit tests
