### PR TITLE
cookbook: version-aware router placement for pinned rollouts

### DIFF
--- a/cookbook/common/router.py
+++ b/cookbook/common/router.py
@@ -409,7 +409,9 @@ class _RegistryApp(_UvicornApp):
             await asyncio.gather(self.poller_task, return_exceptions=True)
             await self.client.aclose()
 
-        @fastapi_app.get("/loads", response_model=list[ContainerInfo])
+        # response_model=None: serialization follows the instances, so a registry
+        # subclass serving an extended container model keeps its fields.
+        @fastapi_app.get("/loads", response_model=None)
         async def loads() -> list[ContainerInfo]:
             return self.containers
 
@@ -440,6 +442,36 @@ class _ProxyApp(_UvicornApp):
             yield
         finally:
             container.load = max(0, container.load - 1)
+
+    async def select_container(
+        self, session_id: str | None, headers: dict[str, str]
+    ) -> ContainerInfo | None:
+        """Placement hook: the replica to pin this request to, or None.
+
+        Stock behavior routes session traffic (``modal-session-id`` present)
+        through ``route_session`` when the registry map is populated, and
+        leaves everything else unrouted. ``headers`` are the already-filtered
+        forwarding headers. Override for non-stock placement (e.g.
+        version-aware selection).
+        """
+        if session_id and self.containers:
+            return await route_session(
+                self.session_routes,
+                session_id,
+                self.containers,
+                self.overload_threshold,
+            )
+        return None
+
+    async def unrouted_response(
+        self, session_id: str | None, headers: dict[str, str]
+    ) -> Response | None:
+        """Unrouted hook: the short-circuit response when ``select_container``
+        returned None. Stock behavior returns None — the request falls through
+        to the Flash LB unpinned. Override to answer directly (e.g.
+        a retryable 409/503) instead of falling through.
+        """
+        return None
 
     async def get_containers(self) -> dict[str, ContainerInfo]:
         response = await self.client.get(f"{self.registry_url}/loads")
@@ -553,14 +585,12 @@ class _ProxyApp(_UvicornApp):
                 headers = filter_headers(dict(request.headers))
 
                 for attempt in range(MAX_SESSION_RETRIES + 1):
-                    container = None
-                    if session_id and self.containers:
-                        container = await route_session(
-                            self.session_routes,
-                            session_id,
-                            self.containers,
-                            self.overload_threshold,
-                        )
+                    container = await self.select_container(session_id, headers)
+                    if container is None:
+                        unrouted = await self.unrouted_response(session_id, headers)
+                        if unrouted is not None:
+                            return unrouted
+                    else:
                         headers["modal-flash-upstream"] = container.upstream
 
                     logger.info(

--- a/cookbook/standalone/offline_evals/eval_router.py
+++ b/cookbook/standalone/offline_evals/eval_router.py
@@ -1,0 +1,422 @@
+"""Version-aware routing for offline-eval rollout pools.
+
+Extends the stock session-affinity router (cookbook/common/router.py) through its
+two placement hooks; forwarding, streaming, 503 eviction, and cancellation stay on
+the stock code path. The registry polls ``/server_info`` (membership: readiness +
+applied version) alongside ``/v1/loads`` (queue depth only). A ``stitch-exact-version``
+request header pins placement to replicas applied at that version, with or without a
+session id: no in-rotation match (or a cold registry) answers a retryable 409, and a
+409 from a replica never evicts it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import modal
+from fastapi import Response
+from pydantic import TypeAdapter
+
+from cookbook.common.router import (
+    SESSION_ROUTE_MAX_UPSTREAMS,
+    SESSION_ROUTE_TTL_SECONDS,
+    ContainerInfo,
+    RouteEntry,
+    RouteEntryList,
+    _container_addr,
+    _ProxyApp,
+    _RegistryApp,
+    select_underloaded_container,
+)
+from cookbook.common.router import filter_headers as _stock_filter_headers
+from stitch.pools.modal_flash import list_flash_containers_async
+from stitch.types import VersionRef
+
+logger = logging.getLogger(__name__)
+
+EXACT_VERSION_HEADER = "stitch-exact-version"
+
+
+class EvalContainerInfo(ContainerInfo):
+    """A registry member with rollout state."""
+
+    load_stale: bool = False  # load is last-known, not live
+    ready: bool = True  # False while booting or engine-dead; absent on older sidecars
+    # From /server_info's ``applied`` identity; None when nothing is applied yet.
+    applied_version: int | None = None
+    draining: bool = False  # excluded from every proxy selection path
+
+
+EvalContainerInfoList = TypeAdapter(list[EvalContainerInfo])
+
+
+def filter_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Stock hop-by-hop filtering plus the whole ``Modal-*`` namespace: the platform
+    hashes Modal-Session-ID for its own session affinity, which takes precedence over
+    an explicit ``modal-flash-upstream`` pin mid-path. The pin is re-added after."""
+    filtered = _stock_filter_headers(headers)
+    return {k: v for k, v in filtered.items() if not k.lower().startswith("modal-")}
+
+
+def _parse_exact_version(
+    headers: Mapping[str, str], session_id: str | None, *, warn: bool = True
+) -> int | None:
+    """The version pin, or None. Placement is advisory: a malformed pin is ignored."""
+    raw = headers.get(EXACT_VERSION_HEADER, "").strip()
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        if warn:
+            logger.warning(
+                "[session %s] ignoring malformed %s header: %r",
+                session_id,
+                EXACT_VERSION_HEADER,
+                raw,
+            )
+        return None
+
+
+def _in_rotation(container: EvalContainerInfo) -> bool:
+    return container.ready and not container.draining
+
+
+def _version_matched(
+    containers: dict[str, EvalContainerInfo],
+    overload_threshold: int,
+    exact_version: int,
+) -> list[EvalContainerInfo]:
+    """In-rotation replicas applied at ``exact_version``, preferring those under the
+    overload threshold: the threshold ranks replicas, it never denies the only correct
+    version — a pinned request queues on the lowest-load match rather than failing."""
+    in_rotation = [
+        c
+        for c in containers.values()
+        if _in_rotation(c) and c.applied_version == exact_version
+    ]
+    underloaded = [c for c in in_rotation if c.load < overload_threshold]
+    return underloaded or in_rotation
+
+
+async def route_session(
+    session_routes: modal.Dict,
+    session_id: str,
+    containers: dict[str, EvalContainerInfo],
+    overload_threshold: int,
+    exact_version: int | None = None,
+) -> EvalContainerInfo | None:
+    """Pick the replica for one session: its freshest in-rotation sticky route with
+    headroom (and, when pinned, the matching applied version), else a fresh pick —
+    lowest-load version match pinned, random with headroom unpinned. Returns None
+    without persisting a route when nothing in rotation matches. Mutates and persists
+    the session's routes."""
+    current_time = time.time()
+
+    routes: list[RouteEntry] = RouteEntryList.validate_python(
+        await session_routes.get.aio(session_id, [])
+    )
+    # Drop expired routes and replicas this pod hasn't discovered (they may just be
+    # new; every session lands on some pod's view, so this only trims the dead).
+    routes = [
+        entry
+        for entry in routes
+        if current_time - entry.last_sent <= SESSION_ROUTE_TTL_SECONDS
+        and entry.task_id in containers
+    ]
+    routes.sort(key=lambda entry: entry.last_sent, reverse=True)
+
+    async def save_routes() -> None:
+        await session_routes.put.aio(
+            session_id,
+            RouteEntryList.dump_python(
+                routes[:SESSION_ROUTE_MAX_UPSTREAMS], mode="json"
+            ),
+        )
+
+    for entry in list(routes):
+        # Re-lookup defensively: a concurrent 503-evict can pop the shared map
+        # while this coroutine is suspended in save_routes() — indexing would
+        # turn that race into a KeyError 500.
+        container = containers.get(entry.task_id)
+        if container is None:
+            continue
+        if not _in_rotation(container):
+            # Delete, don't skip: a kept sticky route would re-admit the session
+            # onto a replica about to swap weights or one serving boot weights.
+            logger.info(
+                "session %s: evicting sticky route %s (%s)",
+                session_id,
+                container.task_id,
+                "draining" if container.draining else "not ready",
+            )
+            routes.remove(entry)
+            await save_routes()
+            continue
+        if container.load < overload_threshold:
+            if exact_version is not None and container.applied_version != exact_version:
+                logger.info(
+                    "session %s: sticky route %s applied_version=%s != pin %d; skipping",
+                    session_id,
+                    container.task_id,
+                    container.applied_version,
+                    exact_version,
+                )
+                continue
+            entry.last_sent = current_time
+            await save_routes()
+            return container
+
+    if exact_version is not None:
+        matched = _version_matched(containers, overload_threshold, exact_version)
+        if not matched:
+            logger.info(
+                "session %s: no in-rotation upstream at exact_version=%d (%d known); "
+                "not re-pinning",
+                session_id,
+                exact_version,
+                len(containers),
+            )
+            return None
+        selected = min(matched, key=lambda container: container.load)
+    else:
+        in_rotation = {
+            container.task_id: container
+            for container in containers.values()
+            if _in_rotation(container)
+        }
+        if not in_rotation:
+            logger.info("session %s: no replica in rotation; no selection", session_id)
+            return None
+        selected = select_underloaded_container(in_rotation, overload_threshold)
+
+    logger.info(
+        "session %s: pinning upstream %s (load %d, applied_version=%s, pin=%s, "
+        "prior=[%s])",
+        session_id,
+        selected.task_id,
+        selected.load,
+        selected.applied_version,
+        exact_version,
+        ", ".join(entry.task_id for entry in routes),
+    )
+    routes.insert(0, RouteEntry(task_id=selected.task_id, last_sent=current_time))
+    await save_routes()
+    return selected
+
+
+def serve_eval_registry(replica: Any, *, app_name: str, upstream_cls: str) -> None:
+    """Start the version-aware load registry on a ``RouterRegistry`` container
+    (@modal.enter). Polls go through the upstream class's own URL, derived here
+    so recipes only name the class."""
+    registry = EvalRegistryApp(
+        app_name=app_name,
+        upstream_cls=upstream_cls,
+        upstream_url=modal.Server.from_name(app_name, upstream_cls).get_url(),
+    )
+    registry.start()
+    replica._router_server = registry
+
+
+def serve_eval_router(
+    replica: Any,
+    *,
+    registry_url: str,
+    upstream_url: str,
+    session_routes: modal.Dict,
+    overload_threshold: int,
+) -> None:
+    """Start the version-aware session-routing proxy on a ``Router`` container
+    (@modal.enter)."""
+    router = EvalProxyApp(
+        registry_url=registry_url,
+        upstream_url=upstream_url,
+        session_routes=session_routes,
+        overload_threshold=overload_threshold,
+    )
+    router.start()
+    replica._router_server = router
+
+
+@dataclass
+class _ReplicaPoll:
+    """One replica's poll result. ``load=None`` means /v1/loads failed — the replica
+    stays a member (/server_info is the membership contract) on its last-known load."""
+
+    load: int | None
+    applied_version: int | None
+    ready: bool
+
+
+class EvalRegistryApp(_RegistryApp):
+    """Polls replicas' /server_info (membership, applied version) and /v1/loads
+    (queue depth) through the pool URL; serves the snapshot at /loads."""
+
+    def __init__(self, *, app_name: str, upstream_cls: str, upstream_url: str) -> None:
+        super().__init__(
+            app_name=app_name, upstream_cls=upstream_cls, upstream_url=upstream_url
+        )
+        self.containers: list[EvalContainerInfo] = []
+        self._last_loads: dict[str, int] = {}
+
+    async def _poll_container(self, upstream: str) -> _ReplicaPoll:
+        """/server_info is membership and liveness in one probe: its failure drops
+        the replica. /v1/loads is the load number only: its failure never drops the
+        replica — a sidecar mid weight-stage can block /v1/loads for minutes while
+        still serving."""
+        headers = {"modal-flash-upstream": upstream}
+        server_info_response, loads_response = await asyncio.gather(
+            self.client.get(f"{self.upstream_url}/server_info", headers=headers),
+            self.client.get(
+                f"{self.upstream_url}/v1/loads",
+                params={"include": "core"},
+                headers=headers,
+            ),
+            return_exceptions=True,
+        )
+        if isinstance(server_info_response, BaseException):
+            raise server_info_response
+        server_info_response.raise_for_status()
+        data = server_info_response.json()
+
+        applied_version: int | None = None
+        if applied := data.get("applied"):
+            try:
+                applied_version = VersionRef.parse(str(applied)).version
+            except ValueError:
+                logger.warning(
+                    "replica %s: unparseable applied identity %r", upstream, applied
+                )
+
+        load: int | None = None
+        if not isinstance(loads_response, BaseException):
+            try:
+                loads_response.raise_for_status()
+                loads = loads_response.json()["loads"]
+                load = sum(
+                    int(entry["num_waiting_reqs"]) + int(entry["num_running_reqs"])
+                    for entry in loads
+                )
+            except Exception as exc:
+                logger.debug("loads poll failed for %s: %r", upstream, exc)
+
+        # Older sidecars omit `ready`; absence reads as ready.
+        return _ReplicaPoll(
+            load=load,
+            applied_version=applied_version,
+            ready=bool(data.get("ready", True)),
+        )
+
+    async def _poll_once(self) -> list[EvalContainerInfo]:
+        discovered = await list_flash_containers_async(self.app_name, self.upstream_cls)
+        upstreams = {}
+        for container in discovered:
+            task_id = (
+                container.get("task_id")
+                if isinstance(container, dict)
+                else getattr(container, "task_id", None)
+            )
+            addr = _container_addr(container)
+            if task_id and addr:
+                upstreams[task_id] = addr
+        results = await asyncio.gather(
+            *(self._poll_container(upstream) for upstream in upstreams.values()),
+            return_exceptions=True,
+        )
+        updated: list[EvalContainerInfo] = []
+        for (task_id, upstream), result in zip(upstreams.items(), results, strict=True):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "server_info poll failed for %s: %r; dropped", task_id, result
+                )
+                self._last_loads.pop(task_id, None)
+                continue
+            if result.load is None:
+                load, load_stale = self._last_loads.get(task_id, 0), True
+            else:
+                load, load_stale = result.load, False
+                self._last_loads[task_id] = load
+            updated.append(
+                EvalContainerInfo(
+                    task_id=task_id,
+                    upstream=upstream,
+                    load=load,
+                    load_stale=load_stale,
+                    applied_version=result.applied_version,
+                    ready=result.ready,
+                )
+            )
+        return updated
+
+
+class EvalProxyApp(_ProxyApp):
+    """Version-aware placement over the stock proxy via the two routing hooks."""
+
+    async def get_containers(self) -> dict[str, EvalContainerInfo]:
+        response = await self.client.get(f"{self.registry_url}/loads")
+        response.raise_for_status()
+        containers = EvalContainerInfoList.validate_json(response.content)
+        return {container.task_id: container for container in containers}
+
+    async def select_container(
+        self, session_id: str | None, headers: dict[str, str]
+    ) -> EvalContainerInfo | None:
+        # Re-filter the forwarding headers in place: the eval policy also strips
+        # the Modal-* namespace (see filter_headers).
+        filtered = filter_headers(headers)
+        headers.clear()
+        headers.update(filtered)
+
+        exact_version = _parse_exact_version(headers, session_id)
+        if exact_version is not None and not self.containers:
+            return None  # cold registry: unrouted_response answers 409
+        if exact_version is not None and not session_id:
+            # Pinned without a session: version-aware selection, no sticky state.
+            matched = _version_matched(
+                self.containers, self.overload_threshold, exact_version
+            )
+            return min(matched, key=lambda c: c.load) if matched else None
+        if session_id and self.containers:
+            return await route_session(
+                self.session_routes,
+                session_id,
+                self.containers,
+                self.overload_threshold,
+                exact_version=exact_version,
+            )
+        return None
+
+    async def unrouted_response(
+        self, session_id: str | None, headers: dict[str, str]
+    ) -> Response | None:
+        # select_container already warned on a malformed pin.
+        exact_version = _parse_exact_version(headers, session_id, warn=False)
+        if exact_version is not None:
+            # Pinned with no in-rotation match or a cold registry: a retryable
+            # 409 — pinned traffic never lands on a wrong-version or draining
+            # replica and never falls through to the Flash LB.
+            logger.info(
+                "[session %s] no in-rotation upstream (exact_version=%d); 409",
+                session_id,
+                exact_version,
+            )
+            return Response(
+                content=b"No healthy upstream",
+                status_code=409,
+                media_type="text/plain",
+            )
+        if session_id and self.containers:
+            # Zero replicas in rotation (all booting or draining): a retryable 503.
+            logger.info("[session %s] no replica in rotation; 503", session_id)
+            return Response(
+                content=b"No replica in rotation",
+                status_code=503,
+                headers={"Retry-After": "1"},
+                media_type="text/plain",
+            )
+        return None  # stock: fall through to the Flash LB

--- a/cookbook/standalone/offline_evals/eval_router_test.py
+++ b/cookbook/standalone/offline_evals/eval_router_test.py
@@ -1,0 +1,424 @@
+"""Eval router: three end-to-end walks against in-memory fakes — version-aware
+session routing, the /server_info-membership registry poll, and the ASGI forward
+path (pin cells, 409/503 semantics, eviction, header strip)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import httpx
+
+from cookbook.common.router import RouteEntry, RouteEntryList
+from cookbook.standalone.offline_evals import eval_router
+from cookbook.standalone.offline_evals.eval_router import (
+    EvalContainerInfo,
+    EvalProxyApp,
+    EvalRegistryApp,
+    route_session,
+)
+
+
+class _SyncAsync:
+    """Duck-types a Modal SDK synchronicity-wrapped method (callable, with ``.aio``)."""
+
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __call__(self, *args):
+        return self.fn(*args)
+
+    async def aio(self, *args):
+        return self.fn(*args)
+
+
+class FakeRoutes:
+    """Stands in for the session-routes ``modal.Dict``; stores the dumped JSON forms."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, list] = {}
+        self.get = _SyncAsync(lambda key, default: self.store.get(key, default))
+        self.put = _SyncAsync(lambda key, value: self.store.__setitem__(key, value))
+
+
+def _seeded(routes: FakeRoutes, session: str, entries: list[dict]) -> None:
+    routes.store[session] = RouteEntryList.dump_python(
+        [RouteEntry(**entry) for entry in entries], mode="json"
+    )
+
+
+def _versioned(
+    task_id: str,
+    load: int,
+    applied_version: int | None,
+    *,
+    ready: bool = True,
+    draining: bool = False,
+) -> EvalContainerInfo:
+    return EvalContainerInfo(
+        task_id=task_id,
+        upstream=f"{task_id}:8000",
+        load=load,
+        applied_version=applied_version,
+        ready=ready,
+        draining=draining,
+    )
+
+
+def test_route_session_walk() -> None:
+    """One walk of version-aware session routing: preference, sticky skips and
+    evictions, no-match no-repin, saturation queuing, and the concurrent-pop race."""
+
+    def pick(
+        fleet: dict, pin: int | None, routes: FakeRoutes | None = None, session="s1"
+    ) -> EvalContainerInfo | None:
+        routes = routes if routes is not None else FakeRoutes()
+        return asyncio.run(route_session(routes, session, fleet, 4, exact_version=pin))
+
+    containers = {
+        "ta-0": _versioned("ta-0", 0, 1),
+        "ta-1": _versioned("ta-1", 0, 2),
+    }
+    routes = FakeRoutes()
+    picked = pick(containers, 2, routes)
+    assert picked.task_id == "ta-1", "version preference picks the matching replica"
+    assert picked.applied_version == 2
+
+    picked = pick(containers, 2, routes)
+    assert picked.task_id == "ta-1", "sticky route holds across requests"
+    routes2 = FakeRoutes()
+    _seeded(routes2, "s2", [{"task_id": "ta-0", "last_sent": time.time()}])
+    picked = pick(containers, 2, routes2, session="s2")
+    assert picked.task_id == "ta-1", "sticky wrong-version route is skipped"
+
+    routes = FakeRoutes()
+    picked = pick({"ta-0": containers["ta-0"]}, 99, routes)
+    assert picked is None, "no version match returns None"
+    assert "s1" not in routes.store, "no match must not re-pin"
+
+    picked = pick(
+        {"ta-0": _versioned("ta-0", 0, 2), "ta-1": _versioned("ta-1", 0, None)}, 1
+    )
+    assert picked is None, "an unknown (None) applied_version never matches a pin"
+
+    picked = pick({"ta-0": _versioned("ta-0", 0, 1, draining=True)}, 1)
+    assert picked is None, "a draining replica never matches, even version-aligned"
+
+    routes = FakeRoutes()
+    picked = pick(
+        {
+            "ta-0": _versioned("ta-0", 9, 1),
+            "ta-1": _versioned("ta-1", 12, 1),
+            "ta-2": _versioned("ta-2", 0, 2),
+        },
+        1,
+        routes,
+    )
+    assert picked.task_id == "ta-0", "saturated matching replica queues, never 409s"
+    assert routes.store["s1"][0]["task_id"] == "ta-0"
+
+    routes = FakeRoutes()
+    _seeded(routes, "s3", [{"task_id": "ta-0", "last_sent": time.time()}])
+    fleet = {
+        "ta-0": _versioned("ta-0", 0, 1, draining=True),
+        "ta-1": _versioned("ta-1", 0, 1),
+    }
+    picked = pick(fleet, None, routes, session="s3")
+    assert picked.task_id == "ta-1"
+    assert [entry["task_id"] for entry in routes.store["s3"]] == ["ta-1"], (
+        "a sticky route to a draining replica is deleted, not kept"
+    )
+
+    async def race() -> None:
+        # A container-map pop racing a selection suspended in save_routes degrades
+        # to another replica or None, never a KeyError.
+        routes = FakeRoutes()
+
+        class _YieldingPut:
+            async def aio(self, key: str, value: list) -> None:
+                await asyncio.sleep(0)  # let the popper interleave mid-save
+                routes.store[key] = value
+
+        routes.put = _YieldingPut()  # type: ignore[assignment]
+        fleet = {f"ta-{i}": _versioned(f"ta-{i}", 0, 1) for i in range(3)}
+        _seeded(routes, "s", [{"task_id": "ta-1", "last_sent": time.time()}])
+        picks: list[str] = []
+
+        async def popper() -> None:
+            for _ in range(400):
+                popped = fleet.pop("ta-1", None)
+                await asyncio.sleep(0)
+                if popped is not None:
+                    fleet["ta-1"] = popped
+                await asyncio.sleep(0)
+
+        async def select_loop() -> None:
+            for _ in range(200):
+                picked = await route_session(routes, "s", fleet, 4)
+                if picked is not None:
+                    picks.append(picked.task_id)
+
+        await asyncio.gather(popper(), *(select_loop() for _ in range(8)))
+        assert picks, "selections kept succeeding around concurrent pops"
+        fleet.pop("ta-1", None)
+        final = await route_session(routes, "s", fleet, 4)
+        assert final is not None and final.task_id != "ta-1"
+
+    asyncio.run(race())
+
+
+class _FakeResp:
+    def __init__(self, payload: dict, *, ok: bool = True) -> None:
+        self._payload = payload
+        self._ok = ok
+
+    def raise_for_status(self) -> None:
+        if not self._ok:
+            raise RuntimeError("HTTP 503")
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def _loads_payload(waiting: int, running: int) -> dict:
+    return {"loads": [{"num_waiting_reqs": waiting, "num_running_reqs": running}]}
+
+
+def _registry_client(server_info: dict | Exception, loads: dict | Exception) -> object:
+    class FakeClient:
+        def __init__(self) -> None:
+            self.seen_upstreams: list[str | None] = []
+
+        async def get(self, url: str, **kwargs) -> _FakeResp:
+            self.seen_upstreams.append(
+                (kwargs.get("headers") or {}).get("modal-flash-upstream")
+            )
+            payload = (
+                server_info
+                if url.endswith("/server_info")
+                else loads
+                if url.endswith("/v1/loads")
+                else None
+            )
+            if payload is None:
+                raise AssertionError(f"unexpected url: {url}")
+            if isinstance(payload, Exception):
+                raise payload
+            return _FakeResp(payload)
+
+    return FakeClient()
+
+
+def test_registry_poll_walk(monkeypatch) -> None:
+    """One walk of the registry poll: load/version passthrough through the pool
+    URL, unparseable and absent applied identities, server_info failure dropping
+    the replica, and a loads failure keeping it on a stale load."""
+
+    def registry(client: object) -> EvalRegistryApp:
+        app = EvalRegistryApp(
+            app_name="app", upstream_cls="Server", upstream_url="https://pool"
+        )
+        app.client = client
+        return app
+
+    client = _registry_client(
+        {"applied": "run-a/weight_v000003", "ready": True}, _loads_payload(1, 2)
+    )
+    poll = asyncio.run(registry(client)._poll_container("h0:8000"))
+    assert poll.load == 3
+    assert poll.applied_version == 3, "applied identity parses via VersionRef"
+    assert poll.ready is True
+    assert client.seen_upstreams == ["h0:8000", "h0:8000"], (
+        "both polls traverse the pool URL with the modal-flash-upstream pin"
+    )
+
+    poll = asyncio.run(
+        registry(
+            _registry_client({"applied": None, "ready": False}, _loads_payload(0, 0))
+        )._poll_container("h0:8000")
+    )
+    assert poll.applied_version is None and poll.ready is False
+
+    poll = asyncio.run(
+        registry(
+            _registry_client({"applied": "garbage"}, _loads_payload(0, 0))
+        )._poll_container("h0:8000")
+    )
+    assert poll.applied_version is None, "unparseable identity reads as unknown"
+
+    try:
+        asyncio.run(
+            registry(
+                _registry_client(RuntimeError("server_info down"), _loads_payload(0, 0))
+            )._poll_container("h0:8000")
+        )
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("server_info failure must propagate (drops the replica)")
+
+    async def discover(_app_name: str, _cls: str) -> list[dict]:
+        return [{"task_id": "ta-0", "host": "h-ta-0", "port": 8000}]
+
+    monkeypatch.setattr(eval_router, "list_flash_containers_async", discover)
+    down = registry(
+        _registry_client(RuntimeError("server_info down"), _loads_payload(0, 0))
+    )
+    assert asyncio.run(down._poll_once()) == []
+
+    app = registry(
+        _registry_client({"applied": "weight_v000001"}, _loads_payload(2, 1))
+    )
+    (first,) = asyncio.run(app._poll_once())
+    assert first.load == 3 and not first.load_stale
+    app.client = _registry_client(
+        {"applied": "weight_v000001"}, RuntimeError("loads down")
+    )
+    (second,) = asyncio.run(app._poll_once())
+    assert second.load == 3 and second.load_stale, (
+        "a failed loads poll keeps the replica on its last-known load"
+    )
+
+
+class _FakeUpstreamResponse:
+    def __init__(self, status: int, body: bytes = b"ok") -> None:
+        self.status_code = status
+        self.headers = {"content-type": "text/plain"}
+        self._body = body
+
+    async def aiter_raw(self):
+        yield self._body
+
+
+class _FakeUpstreamStream:
+    def __init__(self, response: _FakeUpstreamResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _FakeUpstreamResponse:
+        return self._response
+
+    async def __aexit__(self, *args) -> None:
+        return None
+
+
+class _FakeUpstreamClient:
+    def __init__(self, status_by_upstream: dict[str, int]) -> None:
+        self.status_by_upstream = status_by_upstream
+        self.requested_upstreams: list[str | None] = []
+        self.requested_headers: list[dict[str, str]] = []
+
+    def stream(self, *, headers, **_kwargs) -> _FakeUpstreamStream:
+        upstream = headers.get("modal-flash-upstream")
+        self.requested_upstreams.append(upstream)
+        self.requested_headers.append(dict(headers))
+        status = self.status_by_upstream.get(upstream, 200)
+        return _FakeUpstreamStream(_FakeUpstreamResponse(status))
+
+
+def _proxy(
+    fleet: dict[str, EvalContainerInfo], statuses: dict[str, int] | None = None
+) -> tuple[EvalProxyApp, Any, _FakeUpstreamClient]:
+    proxy = EvalProxyApp(
+        registry_url="https://registry",
+        upstream_url="https://upstream",
+        session_routes=FakeRoutes(),
+        overload_threshold=4,
+    )
+    app = proxy.build_app()
+    proxy.containers = fleet
+    proxy.client = _FakeUpstreamClient(statuses or {})
+    return proxy, app, proxy.client
+
+
+async def _post(
+    app: Any,
+    session_id: str | None,
+    exact_version: int | None | str = None,
+    extra_headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    transport = httpx.ASGITransport(app=app)
+    headers = {"modal-session-id": session_id} if session_id is not None else {}
+    if exact_version is not None:
+        headers["stitch-exact-version"] = str(exact_version)
+    headers.update(extra_headers or {})
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        return await client.post("/v1/chat/completions", headers=headers, content=b"{}")
+
+
+def test_forward_walk() -> None:
+    """One walk of the ASGI forward path: every pin cell (pinned with/without a
+    session, cold registry, no match), 409 passthrough without eviction, 503
+    eviction with retry, the unpinned 503, malformed pins, and the Modal-* strip."""
+
+    async def run() -> None:
+        fleet = {
+            "ta-s1": _versioned("ta-s1", 0, 2),
+            "ta-s2": _versioned("ta-s2", 0, 2),
+        }
+        proxy, app, fake = _proxy(fleet, {"ta-s1:8000": 409, "ta-s2:8000": 409})
+        response = await _post(
+            app, "s1", 2, extra_headers={"Modal-Anything": "forged", "x-keep": "v"}
+        )
+        assert response.status_code == 409, "409 from a pinned replica passes through"
+        assert len(fake.requested_upstreams) == 1
+        assert set(proxy.containers) == {"ta-s1", "ta-s2"}, "409 does not evict"
+        (sent,) = fake.requested_headers
+        assert sent.get("x-keep") == "v"
+        forged = [
+            k
+            for k in sent
+            if k.lower().startswith("modal-") and k.lower() != "modal-flash-upstream"
+        ]
+        assert forged == [], "only the router's own pin survives in Modal-*"
+
+        proxy, app, fake = _proxy({"ta-s1": _versioned("ta-s1", 0, 2)})
+        response = await _post(app, "s1", 1)
+        assert response.status_code == 409, "no v1 replica: 409, never wrong-version"
+        assert fake.requested_upstreams == []
+
+        proxy, app, fake = _proxy({"ta-boot": _versioned("ta-boot", 0, 2, ready=False)})
+        response = await _post(app, "s1", None)
+        assert response.status_code == 503, "unpinned, nothing ready: retryable 503"
+        assert response.headers["retry-after"] == "1"
+        assert fake.requested_upstreams == []
+
+        fleet = {
+            "ta-s1": _versioned("ta-s1", 0, 2),
+            "ta-s2": _versioned("ta-s2", 1, 2),
+        }
+        proxy, app, fake = _proxy(fleet, {"ta-s1:8000": 503, "ta-s2:8000": 200})
+        response = await _post(app, "s1", 2)
+        assert response.status_code == 200
+        assert fake.requested_upstreams == ["ta-s1:8000", "ta-s2:8000"], (
+            "ta-s1 is the lowest-load v2 match, so the 503-retry lands on ta-s2"
+        )
+        assert set(proxy.containers) == {"ta-s2"}, "503 evicts"
+
+        proxy, app, fake = _proxy({})
+        for session_id in (None, "s1"):
+            response = await _post(app, session_id, 2)
+            assert response.status_code == 409, "cold registry: pinned is 409"
+            assert response.text == "No healthy upstream"
+        assert fake.requested_upstreams == []
+
+        fleet = {
+            "ta-v1": _versioned("ta-v1", 0, 1),
+            "ta-v2": _versioned("ta-v2", 0, 2),
+        }
+        proxy, app, fake = _proxy(fleet)
+        response = await _post(app, None, 2)
+        assert response.status_code == 200
+        assert fake.requested_upstreams == ["ta-v2:8000"], (
+            "pinned and sessionless: version-aware placement, no fallthrough"
+        )
+        assert proxy.session_routes.store == {}, "no sticky lookup, no record"
+
+        proxy, app, fake = _proxy({"ta-s1": _versioned("ta-s1", 0, 2)})
+        response = await _post(app, "s1", "abc")
+        assert response.status_code == 200
+        assert fake.requested_upstreams == ["ta-s1:8000"], (
+            "a malformed pin is dropped; placement proceeds unpinned"
+        )
+
+    asyncio.run(run())


### PR DESCRIPTION
Offline-evals 1/5, on main. 
Two commits: a behavior-neutral hook refactor in the shared router, then the eval router under `cookbook/standalone/offline_evals/` — other recipes keep stock routing.

## Summary

- common/router.py: extract `select_container` / `unrouted_response` as overridable methods; stock behavior byte-identical (existing router tests pass unchanged)
- add `offline_evals/eval_router.py`: registry membership from the ungated `/server_info` (applied version parsed from the `applied` identity); `/v1/loads` contributes load only, and a loads failure keeps the replica on stale load instead of dropping it mid-commit
- a version pin (`stitch-exact-version`) gates version-aware selection regardless of session id; pinned with no in-rotation match — or an empty registry — answers an immediate retryable 409, never a wrong-version or draining replica
- unpinned traffic with a session and nothing in rotation answers 503 + Retry-After; unpinned without a session stays stock (Flash fallthrough); 409 from a replica never evicts, 503 evicts; saturated matches queue on lowest load

## Validation

- `pytest src/ cookbook/ -q` at branch head (229 passed); stock router tests byte-identical to main
- three end-to-end walks: version-aware session routing (incl. the concurrent-pop race), the registry poll, and the ASGI forward path (every pin cell, eviction, header strip)
- placement semantics carried from a live-validated predecessor series (~25k requests, zero pin violations)


