### PR TITLE
cookbook: router-owned session lifecycle and reconcile control

### DIFF
--- a/cookbook/common/process.py
+++ b/cookbook/common/process.py
@@ -40,6 +40,7 @@ def start_sidecar(
     boot_version: int,
     commit_mode: str,
     flush_cache_on_commit: bool = False,
+    reconcile_interval: float = 5.0,
     debug_requests: bool = False,
 ) -> subprocess.Popen:
     """Launch the versioned rollout proxy (the shared sidecar) beside sglang."""
@@ -64,6 +65,7 @@ def start_sidecar(
         store_options=store_options,
         commit_mode=commit_mode,
         flush_cache_on_commit=flush_cache_on_commit,
+        reconcile_interval=reconcile_interval,
         run_id=run_id,
         boot_version=boot_version,
         debug_requests=debug_requests,

--- a/cookbook/common/process_test.py
+++ b/cookbook/common/process_test.py
@@ -110,3 +110,43 @@ def test_start_sidecar_passes_s3_store_settings(monkeypatch) -> None:
     )
     assert isinstance(store, S3Store)
     assert store.run_id == "run-a"
+
+
+def test_start_sidecar_reconcile_interval_round_trip(monkeypatch) -> None:
+    """serve_startup's reconcile_interval pass-through lands on the sidecar argv
+    as --reconcile-interval and parses back to the same value; unset defaults
+    to the stock 5.0 seconds."""
+    commands: list[list[str]] = []
+
+    def popen(command: list[str], **_kwargs):
+        commands.append(command)
+        return object()
+
+    monkeypatch.setattr(process.subprocess, "Popen", popen)
+
+    base_kwargs = dict(
+        sidecar_port=8000,
+        sglang_port=8001,
+        bulletin_root="/cache/run-a",
+        base_checkpoint_dir="/model",
+        local_checkpoint_dir=None,
+        delta_update_mode="cpu",
+        disk_load_format="auto",
+        store_backend=storage.MODAL_VOLUME,
+        volume_name="run-volume",
+        s3_root=None,
+        s3_endpoint_url=None,
+        run_id="run-a",
+        boot_version=0,
+        commit_mode="in_place",
+    )
+
+    process.start_sidecar(**base_kwargs)
+    config = SidecarConfig.from_argv(commands[0][3:])
+    assert config.reconcile_interval == 5.0, "unset defaults to the stock interval"
+
+    process.start_sidecar(**base_kwargs, reconcile_interval=365 * 24 * 3600.0)
+    command = commands[1]
+    assert command[command.index("--reconcile-interval") + 1] == "31536000.0"
+    config = SidecarConfig.from_argv(command[3:])
+    assert config.reconcile_interval == 365 * 24 * 3600.0

--- a/cookbook/common/server.py
+++ b/cookbook/common/server.py
@@ -32,6 +32,7 @@ def serve_startup(
     run_id: str,
     commit_mode: str,
     flush_cache_on_commit: bool = False,
+    reconcile_interval: float = 5.0,
     startup_timeout: int,
 ) -> None:
     """Start sglang + the versioned-proxy sidecar on a Server replica (from ``@modal.enter``).
@@ -92,6 +93,7 @@ def serve_startup(
         boot_version=boot_version,
         commit_mode=commit_mode,
         flush_cache_on_commit=flush_cache_on_commit,
+        reconcile_interval=reconcile_interval,
     )
     # Modal admits the container when @enter returns. The sidecar owns readiness:
     # /health stays 503 through destination initialization and first catch-up.

--- a/cookbook/standalone/app.py
+++ b/cookbook/standalone/app.py
@@ -164,6 +164,8 @@ class Server:
             run_id=RUN_ID,
             commit_mode=exp.SIDECAR_COMMIT_MODE,
             flush_cache_on_commit=exp.SIDECAR_FLUSH_CACHE_ON_COMMIT,
+            # Base configs omit SIDECAR_RECONCILE_INTERVAL: 5.0s is stock behavior.
+            reconcile_interval=getattr(exp, "SIDECAR_RECONCILE_INTERVAL", 5.0),
             startup_timeout=SERVER_STARTUP_TIMEOUT,
         )
 
@@ -202,9 +204,13 @@ def claim_boot_pointer() -> None:
     checkpoint.claim_boot_pointer(store, RUN_ID)
 
 
-# ── Session-routing LB (cookbook/common/router.py) ─────────────────────────────
+# ── Session-routing LB ─────────────────────────────────────────────────────────
 # The router is two CPU Flash classes in this same app, so it deploys and dies with
 # the pool; the GPU class keeps ``Server``, rollout traffic enters through ``Router``.
+# OFFLINE_EVALS on the experiment config opts into the offline-evals router
+# (cookbook/standalone/offline_evals/): version-pinned placement plus the
+# registry-driven rollout control loop. Unset, the wiring is the stock
+# common-router pair below.
 router_image = router.build_router_image(
     EXPERIMENT,
     RUN_ID,
@@ -212,56 +218,148 @@ router_image = router.build_router_image(
 )
 session_routes = router.session_routes_dict(APP_NAME)
 
+if getattr(exp, "OFFLINE_EVALS", False):
+    from cookbook.standalone.offline_evals import eval_router, rollout_control
 
-@app.server(
-    image=router_image,
-    cpu=2,
-    memory=1024,
-    min_containers=modal_cfg.router_registry_min_containers,
-    routing_region=modal_cfg.routing_region,
-    include_source=False,
-    port=8000,
-    unauthenticated=True,
-)
-class RouterRegistry:
-    """Polls Server replicas' live queue depth; serves the snapshot at /loads."""
+    if STORE_DEPLOYMENT.extra_packages:
+        # The registry container reads the checkpoint store (rollout control loop).
+        router_image = router_image.pip_install(*STORE_DEPLOYMENT.extra_packages)
+    rollout_marks = rollout_control.rollout_control_dict(APP_NAME)
 
-    @modal.enter()
-    def enter(self) -> None:
-        router.serve_registry(self, app_name=APP_NAME, upstream_cls="Server")
+    @app.server(
+        image=router_image,
+        cpu=2,
+        memory=1024,
+        # Single-writer: the rollout control loop is correct only with exactly one
+        # registry container, so the registry is pinned to 1 regardless of config.
+        min_containers=1,
+        max_containers=1,
+        routing_region=modal_cfg.routing_region,
+        volumes=(
+            {str(STITCH_PATH): run_volume}
+            if STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME
+            else {}
+        ),
+        secrets=STORE_SECRETS,
+        include_source=False,
+        port=8000,
+        unauthenticated=True,
+    )
+    class RouterRegistry:
+        """Polls Server replicas' server_info + queue depth; serves the snapshot at /loads.
 
-    @modal.exit()
-    def exit(self) -> None:
-        router.stop_server(self)
+        Also drives the rollout control loop (session liveness, pending-reconcile
+        marks, reconcile nudges) — correct only with a single registry container."""
 
+        @modal.enter()
+        def enter(self) -> None:
+            STORE_DEPLOYMENT.bootstrap_credentials()
+            store_config = STORE_DEPLOYMENT.hook_config(APP_NAME)
+            store = storage.create_store(
+                store_config["stitch_store_backend"],
+                local_root=RUN_DIR,
+                run_id=RUN_ID,
+                volume_name=exp.EXPERIMENT_VOLUME_NAME,
+                s3_root=store_config.get("stitch_s3_root"),
+                s3_endpoint_url=store_config.get("stitch_s3_endpoint_url"),
+            )
+            eval_router.serve_eval_registry(
+                self,
+                app_name=APP_NAME,
+                upstream_cls="Server",
+                session_routes=session_routes,
+                control=rollout_marks,
+                store=store,
+                session_ttl=getattr(
+                    exp, "SESSION_TTL_SECONDS", eval_router.DEFAULT_SESSION_TTL_SECONDS
+                ),
+            )
 
-@app.server(
-    image=router_image,
-    cpu=4,
-    memory=2048,
-    min_containers=modal_cfg.router_min_containers,
-    target_concurrency=modal_cfg.router_target_concurrency,
-    routing_region=modal_cfg.routing_region,
-    include_source=False,
-    port=8000,
-    unauthenticated=True,
-    exit_grace_period=30 * MINUTES,
-)
-class Router:
-    """Front door for rollout traffic: session-affinity routing across Server replicas,
-    with 503 eviction + retry, so a saturated replica sheds sessions instead of
-    attracting them."""
+        @modal.exit()
+        def exit(self) -> None:
+            router.stop_server(self)
 
-    @modal.enter()
-    def enter(self) -> None:
-        router.serve_router(
-            self,
-            registry_url=RouterRegistry.get_url(),
-            upstream_url=Server.get_url(),
-            session_routes=session_routes,
-            overload_threshold=ROLLOUT_CONCURRENCY,
-        )
+    @app.server(
+        image=router_image,
+        cpu=4,
+        memory=2048,
+        min_containers=modal_cfg.router_min_containers,
+        target_concurrency=modal_cfg.router_target_concurrency,
+        routing_region=modal_cfg.routing_region,
+        include_source=False,
+        port=8000,
+        unauthenticated=True,
+        exit_grace_period=30 * MINUTES,
+    )
+    class Router:
+        """Front door for rollout traffic: version-pinned, session-affinity routing
+        across Server replicas, with 503 eviction + retry, so a saturated replica
+        sheds sessions instead of attracting them."""
 
-    @modal.exit()
-    def exit(self) -> None:
-        router.stop_server(self)
+        @modal.enter()
+        def enter(self) -> None:
+            eval_router.serve_eval_router(
+                self,
+                registry_url=RouterRegistry.get_url(),
+                upstream_url=Server.get_url(),
+                session_routes=session_routes,
+                overload_threshold=ROLLOUT_CONCURRENCY,
+            )
+
+        @modal.exit()
+        def exit(self) -> None:
+            router.stop_server(self)
+
+else:
+
+    @app.server(
+        image=router_image,
+        cpu=2,
+        memory=1024,
+        min_containers=modal_cfg.router_registry_min_containers,
+        routing_region=modal_cfg.routing_region,
+        include_source=False,
+        port=8000,
+        unauthenticated=True,
+    )
+    class RouterRegistry:
+        """Polls Server replicas' live queue depth; serves the snapshot at /loads."""
+
+        @modal.enter()
+        def enter(self) -> None:
+            router.serve_registry(self, app_name=APP_NAME, upstream_cls="Server")
+
+        @modal.exit()
+        def exit(self) -> None:
+            router.stop_server(self)
+
+    @app.server(
+        image=router_image,
+        cpu=4,
+        memory=2048,
+        min_containers=modal_cfg.router_min_containers,
+        target_concurrency=modal_cfg.router_target_concurrency,
+        routing_region=modal_cfg.routing_region,
+        include_source=False,
+        port=8000,
+        unauthenticated=True,
+        exit_grace_period=30 * MINUTES,
+    )
+    class Router:
+        """Front door for rollout traffic: session-affinity routing across Server replicas,
+        with 503 eviction + retry, so a saturated replica sheds sessions instead of
+        attracting them."""
+
+        @modal.enter()
+        def enter(self) -> None:
+            router.serve_router(
+                self,
+                registry_url=RouterRegistry.get_url(),
+                upstream_url=Server.get_url(),
+                session_routes=session_routes,
+                overload_threshold=ROLLOUT_CONCURRENCY,
+            )
+
+        @modal.exit()
+        def exit(self) -> None:
+            router.stop_server(self)

--- a/cookbook/standalone/app_test.py
+++ b/cookbook/standalone/app_test.py
@@ -23,6 +23,21 @@ def test_engine_only_app_has_no_trainer(monkeypatch) -> None:
     assert not hasattr(app, "Trainer")
 
 
+def test_offline_evals_gate_both_wiring_paths(monkeypatch) -> None:
+    _standalone_env(monkeypatch)
+    import cookbook.standalone.configs.glm5_2_fp8 as glm_config
+
+    app = importlib.import_module("cookbook.standalone.app")
+    # OFFLINE_EVALS unset on the config: the stock common-router wiring, no
+    # rollout-control state.
+    assert not hasattr(app, "rollout_marks"), "gate unset: stock wiring"
+
+    monkeypatch.setattr(glm_config, "OFFLINE_EVALS", True, raising=False)
+    sys.modules.pop("cookbook.standalone.app", None)
+    app = importlib.import_module("cookbook.standalone.app")
+    assert hasattr(app, "rollout_marks"), "gate set: eval router wiring"
+
+
 def test_rl_serving_contract(monkeypatch) -> None:
     _standalone_env(monkeypatch)
 

--- a/cookbook/standalone/offline_evals/eval_router.py
+++ b/cookbook/standalone/offline_evals/eval_router.py
@@ -20,20 +20,23 @@ from typing import Any
 
 import modal
 from fastapi import Response
-from pydantic import TypeAdapter
+from pydantic import BaseModel, TypeAdapter
 
 from cookbook.common.router import (
     SESSION_ROUTE_MAX_UPSTREAMS,
     SESSION_ROUTE_TTL_SECONDS,
     ContainerInfo,
-    RouteEntry,
-    RouteEntryList,
     _container_addr,
     _ProxyApp,
     _RegistryApp,
     select_underloaded_container,
 )
 from cookbook.common.router import filter_headers as _stock_filter_headers
+from cookbook.standalone.offline_evals.rollout_control import (
+    DEFAULT_SESSION_TTL_SECONDS,
+    RolloutPolicy,
+    tombstone_session,
+)
 from stitch.pools.modal_flash import list_flash_containers_async
 from stitch.types import VersionRef
 
@@ -50,9 +53,28 @@ class EvalContainerInfo(ContainerInfo):
     # From /server_info's ``applied`` identity; None when nothing is applied yet.
     applied_version: int | None = None
     draining: bool = False  # excluded from every proxy selection path
+    # Session records pinned here (registry-computed; drives packing) and
+    # in-flight requests (/server_info; gates the reconcile nudge).
+    live_sessions: int = 0
+    active_requests: int = 0
 
 
 EvalContainerInfoList = TypeAdapter(list[EvalContainerInfo])
+
+
+class EvalRouteEntry(BaseModel):
+    """One session route entry: the replica's applied version at pin time, the
+    last placement touch, and the tombstone. Every stored entry carries the
+    full schema."""
+
+    task_id: str
+    last_sent: float
+    version: int | None
+    last_seen: float
+    tombstoned: bool = False
+
+
+EvalRouteEntryList = TypeAdapter(list[EvalRouteEntry])
 
 
 def filter_headers(headers: dict[str, str]) -> dict[str, str]:
@@ -104,6 +126,19 @@ def _version_matched(
     return underloaded or in_rotation
 
 
+def select_packed_container(candidates: list[EvalContainerInfo]) -> EvalContainerInfo:
+    """Pack pinned-version traffic onto replicas already holding live sessions:
+    lowest load among the holders, or among all candidates when none hold any.
+    Packing concentrates same-version sessions so empty old-version replicas
+    drain to zero live sessions and become reconcile candidates."""
+    holders = [c for c in candidates if c.live_sessions > 0]
+    # A stale load is last-known, not live (a staged replica can sit at a
+    # frozen zero): when any candidate reports fresh load, pack across those.
+    fresh = [c for c in (holders or candidates) if not c.load_stale]
+    pool = fresh or holders or list(candidates)
+    return min(pool, key=lambda c: c.load)
+
+
 async def route_session(
     session_routes: modal.Dict,
     session_id: str,
@@ -118,23 +153,25 @@ async def route_session(
     the session's routes."""
     current_time = time.time()
 
-    routes: list[RouteEntry] = RouteEntryList.validate_python(
+    routes: list[EvalRouteEntry] = EvalRouteEntryList.validate_python(
         await session_routes.get.aio(session_id, [])
     )
-    # Drop expired routes and replicas this pod hasn't discovered (they may just be
-    # new; every session lands on some pod's view, so this only trims the dead).
+    # Drop expired routes, tombstoned entries (an ended session re-pins clean),
+    # and replicas this pod hasn't discovered (they may just be new; every
+    # session lands on some pod's view, so this only trims the dead).
     routes = [
         entry
         for entry in routes
         if current_time - entry.last_sent <= SESSION_ROUTE_TTL_SECONDS
         and entry.task_id in containers
+        and not entry.tombstoned
     ]
     routes.sort(key=lambda entry: entry.last_sent, reverse=True)
 
     async def save_routes() -> None:
         await session_routes.put.aio(
             session_id,
-            RouteEntryList.dump_python(
+            EvalRouteEntryList.dump_python(
                 routes[:SESSION_ROUTE_MAX_UPSTREAMS], mode="json"
             ),
         )
@@ -169,6 +206,7 @@ async def route_session(
                 )
                 continue
             entry.last_sent = current_time
+            entry.last_seen = current_time
             await save_routes()
             return container
 
@@ -183,7 +221,7 @@ async def route_session(
                 len(containers),
             )
             return None
-        selected = min(matched, key=lambda container: container.load)
+        selected = select_packed_container(matched)
     else:
         in_rotation = {
             container.task_id: container
@@ -205,19 +243,43 @@ async def route_session(
         exact_version,
         ", ".join(entry.task_id for entry in routes),
     )
-    routes.insert(0, RouteEntry(task_id=selected.task_id, last_sent=current_time))
+    routes.insert(
+        0,
+        EvalRouteEntry(
+            task_id=selected.task_id,
+            last_sent=current_time,
+            version=selected.applied_version,
+            last_seen=current_time,
+        ),
+    )
     await save_routes()
     return selected
 
 
-def serve_eval_registry(replica: Any, *, app_name: str, upstream_cls: str) -> None:
+def serve_eval_registry(
+    replica: Any,
+    *,
+    app_name: str,
+    upstream_cls: str,
+    session_routes: Any,
+    control: Any,
+    store: Any,
+    session_ttl: float = DEFAULT_SESSION_TTL_SECONDS,
+) -> None:
     """Start the version-aware load registry on a ``RouterRegistry`` container
     (@modal.enter). Polls go through the upstream class's own URL, derived here
-    so recipes only name the class."""
+    so recipes only name the class. The registry also drives the rollout control
+    loop (rollout_control): it reads the store's ``latest`` pointer each poll and
+    reconciles stale replicas toward it. ``session_ttl`` bounds how long an idle
+    session record counts as live; explicit tombstones are the primary signal."""
     registry = EvalRegistryApp(
         app_name=app_name,
         upstream_cls=upstream_cls,
         upstream_url=modal.Server.from_name(app_name, upstream_cls).get_url(),
+        session_routes=session_routes,
+        control=control,
+        store=store,
+        session_ttl=session_ttl,
     )
     registry.start()
     replica._router_server = registry
@@ -251,18 +313,73 @@ class _ReplicaPoll:
     load: int | None
     applied_version: int | None
     ready: bool
+    active_requests: int
 
 
 class EvalRegistryApp(_RegistryApp):
     """Polls replicas' /server_info (membership, applied version) and /v1/loads
-    (queue depth) through the pool URL; serves the snapshot at /loads."""
+    (queue depth) through the pool URL; serves the snapshot at /loads. Between
+    polls it drives the rollout control loop: pointer watch, session liveness,
+    pending-reconcile marks, reconciliation nudges."""
 
-    def __init__(self, *, app_name: str, upstream_cls: str, upstream_url: str) -> None:
+    def __init__(
+        self,
+        *,
+        app_name: str,
+        upstream_cls: str,
+        upstream_url: str,
+        session_routes: Any,
+        control: Any,
+        store: Any,
+        session_ttl: float = DEFAULT_SESSION_TTL_SECONDS,
+    ) -> None:
         super().__init__(
             app_name=app_name, upstream_cls=upstream_cls, upstream_url=upstream_url
         )
         self.containers: list[EvalContainerInfo] = []
         self._last_loads: dict[str, int] = {}
+        self.store = store
+        self._pointer_version: int | None = None
+        self._rollout_policy = RolloutPolicy(
+            session_routes=session_routes,
+            control=control,
+            session_ttl=session_ttl,
+            reconcile=self._post_wake,
+        )
+
+    def _read_pointer_version(self) -> int | None:
+        """The store's ``latest`` pointer, cached — only a change logs (and arms
+        the retire pass). Reuses the standard store read path, so any publish —
+        library-path included — is observed. A read failure keeps last-known."""
+        if self.store is None:
+            return None
+        try:
+            self.store.refresh()
+            pointer = self.store.read_pointer()
+        except Exception:
+            logger.exception("rollout: pointer read failed; keeping last-known")
+            return self._pointer_version
+        version = pointer.version if pointer is not None else None
+        if version != self._pointer_version:
+            logger.info(
+                "rollout: store pointer %s -> %s", self._pointer_version, version
+            )
+            self._pointer_version = version
+        return self._pointer_version
+
+    async def _post_wake(self, upstream: str) -> None:
+        """POST /wake to one replica through the pool URL (the same path
+        polls traverse): the stock sidecar wake, which reconciles the replica
+        to the store pointer. A failed nudge is logged, never fatal — the
+        control loop re-nudges on its bounded schedule."""
+        try:
+            response = await self.client.post(
+                f"{self.upstream_url}/wake",
+                headers={"modal-flash-upstream": upstream},
+            )
+            response.raise_for_status()
+        except Exception:
+            logger.exception("rollout: wake nudge failed for %s", upstream)
 
     async def _poll_container(self, upstream: str) -> _ReplicaPoll:
         """/server_info is membership and liveness in one probe: its failure drops
@@ -310,6 +427,7 @@ class EvalRegistryApp(_RegistryApp):
             load=load,
             applied_version=applied_version,
             ready=bool(data.get("ready", True)),
+            active_requests=int(data.get("active_requests") or 0),
         )
 
     async def _poll_once(self) -> list[EvalContainerInfo]:
@@ -349,13 +467,43 @@ class EvalRegistryApp(_RegistryApp):
                     load_stale=load_stale,
                     applied_version=result.applied_version,
                     ready=result.ready,
+                    active_requests=result.active_requests,
                 )
             )
+        pointer_version = self._read_pointer_version()
+        try:
+            await self._rollout_policy.update(updated, pointer_version, time.time())
+        except Exception:
+            # The placement snapshot must still refresh — a control-loop bug
+            # costs reconciliation, never routing data.
+            logger.exception("rollout: control update failed")
         return updated
 
 
 class EvalProxyApp(_ProxyApp):
     """Version-aware placement over the stock proxy via the two routing hooks."""
+
+    def build_app(self) -> Any:
+        fastapi_app = super().build_app()
+
+        @fastapi_app.post("/sessions/{session_id}/end")
+        async def end_session(session_id: str) -> Response:
+            # Session tombstone — the primary end-of-session signal. Idempotent
+            # and 200 always: ending an unknown or already-ended session is a
+            # no-op.
+            await tombstone_session(self.session_routes, session_id)
+            return Response(status_code=200)
+
+        # The decorator appends; the tombstone must precede the stock catch-all
+        # proxy route or it never matches.
+        routes = fastapi_app.router.routes
+        catch_all = next(
+            i
+            for i, route in enumerate(routes)
+            if getattr(route, "path", None) == "/{path:path}"
+        )
+        routes.insert(catch_all, routes.pop())
+        return fastapi_app
 
     async def get_containers(self) -> dict[str, EvalContainerInfo]:
         response = await self.client.get(f"{self.registry_url}/loads")
@@ -380,7 +528,7 @@ class EvalProxyApp(_ProxyApp):
             matched = _version_matched(
                 self.containers, self.overload_threshold, exact_version
             )
-            return min(matched, key=lambda c: c.load) if matched else None
+            return select_packed_container(matched) if matched else None
         if session_id and self.containers:
             return await route_session(
                 self.session_routes,

--- a/cookbook/standalone/offline_evals/eval_router_test.py
+++ b/cookbook/standalone/offline_evals/eval_router_test.py
@@ -10,14 +10,17 @@ from typing import Any
 
 import httpx
 
-from cookbook.common.router import RouteEntry, RouteEntryList
 from cookbook.standalone.offline_evals import eval_router
 from cookbook.standalone.offline_evals.eval_router import (
     EvalContainerInfo,
     EvalProxyApp,
     EvalRegistryApp,
+    EvalRouteEntry,
+    EvalRouteEntryList,
     route_session,
+    select_packed_container,
 )
+from cookbook.standalone.offline_evals.testing import _LocalDict
 
 
 class _SyncAsync:
@@ -43,8 +46,19 @@ class FakeRoutes:
 
 
 def _seeded(routes: FakeRoutes, session: str, entries: list[dict]) -> None:
-    routes.store[session] = RouteEntryList.dump_python(
-        [RouteEntry(**entry) for entry in entries], mode="json"
+    routes.store[session] = EvalRouteEntryList.dump_python(
+        [
+            EvalRouteEntry(
+                **{
+                    "version": None,
+                    "tombstoned": False,
+                    **entry,
+                    "last_seen": entry.get("last_seen", entry["last_sent"]),
+                }
+            )
+            for entry in entries
+        ],
+        mode="json",
     )
 
 
@@ -217,7 +231,12 @@ def test_registry_poll_walk(monkeypatch) -> None:
 
     def registry(client: object) -> EvalRegistryApp:
         app = EvalRegistryApp(
-            app_name="app", upstream_cls="Server", upstream_url="https://pool"
+            app_name="app",
+            upstream_cls="Server",
+            upstream_url="https://pool",
+            session_routes=_LocalDict(),
+            control=_LocalDict(),
+            store=None,
         )
         app.client = client
         return app
@@ -422,3 +441,49 @@ def test_forward_walk() -> None:
         )
 
     asyncio.run(run())
+
+
+def test_end_session_tombstones_idempotently() -> None:
+    """POST /sessions/{id}/end: 200 always, marks the record tombstoned, and a
+    tombstoned session re-pins clean on its next request."""
+
+    async def run() -> None:
+        proxy, app, _ = _proxy({"ta-s1": _versioned("ta-s1", 0, 2)})
+        assert (await _post(app, "s1", 2)).status_code == 200
+        assert proxy.session_routes.store["s1"][0]["task_id"] == "ta-s1"
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            for session in ("s1", "s1", "never-seen"):
+                end = await client.post(f"/sessions/{session}/end")
+                assert end.status_code == 200, "idempotent: 200 always"
+        record = proxy.session_routes.store["s1"]
+        assert all(entry["tombstoned"] for entry in record)
+
+        assert (await _post(app, "s1", 2)).status_code == 200
+        record = proxy.session_routes.store["s1"]
+        assert not record[0]["tombstoned"], "a reused session id starts clean"
+
+    asyncio.run(run())
+
+
+def test_select_packed_container_packs_live_holders() -> None:
+    candidates = [
+        _versioned("ta-0", 0, 1),
+        _versioned("ta-1", 3, 1),
+        _versioned("ta-2", 5, 1),
+    ]
+    candidates[1].live_sessions = 2
+    candidates[2].live_sessions = 1
+    picked = select_packed_container(candidates)
+    assert picked.task_id == "ta-1", "lowest load among live-session holders"
+    for candidate in candidates:
+        candidate.live_sessions = 0
+    assert select_packed_container(candidates).task_id == "ta-0", (
+        "no holders: lowest load overall"
+    )
+    candidates[0].load_stale = True
+    assert select_packed_container(candidates).task_id == "ta-1", (
+        "a stale (frozen) load reading never wins the pack"
+    )

--- a/cookbook/standalone/offline_evals/rollout_control.py
+++ b/cookbook/standalone/offline_evals/rollout_control.py
@@ -1,0 +1,284 @@
+"""Router-owned session lifecycle and reconcile control — the rollout policy loop.
+
+Session records carry a pinned version, a last-seen timestamp, and a tombstone.
+Once per registry poll, ``RolloutPolicy.update`` counts live sessions per
+replica, marks stale zero-live replicas pending-reconcile in the shared
+rollout-control Dict, and nudges them toward the ``latest`` pointer with the
+stock sidecar ``POST /wake``. Marks surface in the ``/loads`` snapshot as
+``draining`` — the one exclusion concept proxies honor, so a mark costs no new
+per-request RPC. The loop is single-writer: exactly one registry container
+drives it. The sidecar's body-pin 409 is the correctness backstop — a bug here
+costs availability, never wrong weights. The policy records which replicas it
+commanded; an applied version that advances while unmarked is an uncommanded
+flip (e.g. a mismatched pin reaching a held replica via the stock 409 wake)
+and is logged at error level.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+import modal
+
+if TYPE_CHECKING:
+    from cookbook.standalone.offline_evals.eval_router import EvalContainerInfo
+
+logger = logging.getLogger(__name__)
+
+# A session record with no placement within session_ttl is treated as
+# tombstoned. Last resort only — explicit tombstones (POST /sessions/{id}/end)
+# are the primary end-of-session signal.
+DEFAULT_SESSION_TTL_SECONDS = 1800.0
+
+# A mark is cleared only after this many consecutive polls where the replica
+# has reached the pointer (or left): a single /server_info blip must not
+# readmit a mid-reconcile replica.
+MARK_CLEAR_HYSTERESIS_POLLS = 3
+# A marked replica that hasn't flipped is re-nudged after this many polls...
+RECONCILE_RENUDGE_POLLS = 10
+# ...at most this many times per pointer (bounded retries + log, never wedge).
+MAX_RECONCILE_NUDGES = 3
+
+KIND_RETIRE = "retire"  # zero-live replica catching up to the pointer
+
+_MARKS_KEY = "marks"
+
+
+def rollout_control_dict(app_name: str) -> modal.Dict:
+    """The run's pending-reconcile marks, namespaced to the run app. Persisted
+    outside /loads so a registry restart cannot silently clear or duplicate a
+    mark mid-reconcile."""
+    return modal.Dict.from_name(f"{app_name}-rollout-control", create_if_missing=True)
+
+
+# ── session records ──────────────────────────────────────────────────────────
+# A session record is the route-entry list the placement path persists per
+# session id (MRU-first): plain JSON dicts carrying
+# ``version``/``last_seen``/``tombstoned`` on every entry.
+
+
+def session_is_live(record: list[dict], now: float, session_ttl: float) -> bool:
+    """A session lives at its freshest route entry while that entry is neither
+    tombstoned nor TTL-expired."""
+    if not record:
+        return False
+    freshest = record[0]
+    if freshest["tombstoned"]:
+        return False
+    return now - freshest["last_seen"] <= session_ttl
+
+
+def live_session_counts(
+    sessions: dict[str, list[dict]], now: float, session_ttl: float
+) -> dict[str, int]:
+    """live[replica] = count of session records at that replica: not tombstoned,
+    not expired."""
+    counts: dict[str, int] = {}
+    for record in sessions.values():
+        if session_is_live(record, now, session_ttl):
+            task_id = record[0]["task_id"]
+            counts[task_id] = counts.get(task_id, 0) + 1
+    return counts
+
+
+async def tombstone_session(session_routes: Any, session_id: str) -> None:
+    """Mark a session's record tombstoned. Idempotent: an unknown or already
+    tombstoned session is a no-op."""
+    record = await session_routes.get.aio(session_id, [])
+    if not record:
+        return
+    for entry in record:
+        entry["tombstoned"] = True
+    await session_routes.put.aio(session_id, record)
+
+
+# ── the policy loop ──────────────────────────────────────────────────────────
+
+
+class RolloutPolicy:
+    """The control loop's mutable state: hysteresis counters, nudge budgets,
+    and the shared pending-reconcile marks."""
+
+    def __init__(
+        self,
+        *,
+        session_routes: Any,
+        control: Any,
+        session_ttl: float,
+        reconcile: Callable[[str], Awaitable[None]],
+    ) -> None:
+        self.session_routes = session_routes
+        self.control = control
+        self.session_ttl = session_ttl
+        self._reconcile = reconcile
+        self._clear_polls: dict[str, int] = {}
+        self._nudges: dict[str, dict[str, int]] = {}
+        self._poll_index = 0
+        self._expiry_logged: set[str] = set()
+        # Last applied version seen per replica; the commanded set is the
+        # marks, so an advance while unmarked is an uncommanded flip.
+        self._applied_seen: dict[str, int] = {}
+
+    def _alarm_uncommanded_flips(
+        self, containers: list[EvalContainerInfo], marks: dict[str, dict]
+    ) -> None:
+        """Error-log any replica whose applied version advanced since the last
+        poll without a pending-reconcile mark — only marked replicas are woken
+        by this loop, so an unmarked advance came from outside it."""
+        for container in containers:
+            applied = container.applied_version
+            if applied is None:
+                continue
+            previous = self._applied_seen.get(container.task_id)
+            if (
+                previous is not None
+                and applied > previous
+                and container.task_id not in marks
+            ):
+                logger.error(
+                    "rollout: replica %s flipped v%d -> v%d without a "
+                    "registry-commanded wake",
+                    container.task_id,
+                    previous,
+                    applied,
+                )
+            self._applied_seen[container.task_id] = applied
+        present = {container.task_id for container in containers}
+        for task_id in list(self._applied_seen):
+            if task_id not in present:
+                del self._applied_seen[task_id]
+
+    def _log_expired(self, sessions: dict[str, list[dict]], now: float) -> None:
+        """One log line per record the TTL tombstones (last resort)."""
+        expired = set()
+        for session_id, record in sessions.items():
+            if not record or record[0]["tombstoned"]:
+                continue
+            if now - record[0]["last_seen"] > self.session_ttl:
+                expired.add(session_id)
+                if session_id not in self._expiry_logged:
+                    logger.info(
+                        "rollout: session %s idle beyond TTL (%.0fs); "
+                        "treated as tombstoned",
+                        session_id,
+                        self.session_ttl,
+                    )
+        self._expiry_logged = expired
+
+    async def update(
+        self,
+        containers: list[EvalContainerInfo],
+        pointer_version: int | None,
+        now: float,
+    ) -> None:
+        """One control-loop pass over this poll's container snapshot.
+
+        Annotates the snapshot (``live_sessions`` from the session records,
+        ``draining`` for marked replicas), marks stale zero-live replicas
+        pending-reconcile in the shared Dict, nudges marked replicas whose
+        active_requests drained to zero, and clears marks once applied_version
+        reaches the pointer (MARK_CLEAR_HYSTERESIS_POLLS consecutive polls)."""
+        self._poll_index += 1
+        if pointer_version is None:
+            return  # no pointer read yet: nothing to reconcile toward
+
+        sessions = {
+            session_id: record
+            async for session_id, record in self.session_routes.items.aio()
+        }
+        marks: dict[str, dict] = dict(await self.control.get.aio(_MARKS_KEY, {}) or {})
+        live = live_session_counts(sessions, now, self.session_ttl)
+        self._log_expired(sessions, now)
+        self._alarm_uncommanded_flips(containers, marks)
+        for container in containers:
+            container.live_sessions = live.get(container.task_id, 0)
+        by_id = {container.task_id: container for container in containers}
+        changed = False
+
+        # Retire: every stale replica with zero live sessions can catch up.
+        for container in containers:
+            if (
+                container.task_id not in marks
+                and container.ready
+                and not container.draining
+                and container.applied_version is not None
+                and container.applied_version < pointer_version
+                and live.get(container.task_id, 0) == 0
+            ):
+                marks[container.task_id] = {
+                    "version": container.applied_version,
+                    "kind": KIND_RETIRE,
+                    "marked_at": now,
+                }
+                changed = True
+                logger.info(
+                    "rollout: marking %s pending-reconcile "
+                    "(applied v%d < pointer v%d, no live sessions)",
+                    container.task_id,
+                    container.applied_version,
+                    pointer_version,
+                )
+
+        # Drive marked replicas: exclude from placement, nudge at zero active
+        # requests, clear once the flip (or departure) holds for the hysteresis.
+        for task_id in list(marks):
+            container = by_id.get(task_id)
+            keep = (
+                container is not None
+                and container.applied_version is not None
+                and container.applied_version < pointer_version
+            )
+            if not keep:
+                if container is not None:
+                    container.draining = True  # status quo across the clear window
+                clear_polls = self._clear_polls.get(task_id, 0) + 1
+                self._clear_polls[task_id] = clear_polls
+                if clear_polls >= MARK_CLEAR_HYSTERESIS_POLLS:
+                    del marks[task_id]
+                    changed = True
+                    self._clear_polls.pop(task_id, None)
+                    self._nudges.pop(task_id, None)
+                    logger.info(
+                        "rollout: replica %s unmarked (reached pointer v%d or left)",
+                        task_id,
+                        pointer_version,
+                    )
+                continue
+            self._clear_polls.pop(task_id, None)
+            container.draining = True  # the exclusion proxies already honor
+            nudge = self._nudges.setdefault(
+                task_id,
+                {"count": 0, "last_poll": -RECONCILE_RENUDGE_POLLS, "pointer": -1},
+            )
+            if nudge["pointer"] != pointer_version:
+                # A new pointer is a fresh target: reset the nudge budget.
+                nudge.update(
+                    count=0, last_poll=-RECONCILE_RENUDGE_POLLS, pointer=pointer_version
+                )
+            if container.active_requests > 0:
+                continue  # wait for in-flight requests to drain
+            if nudge["count"] >= MAX_RECONCILE_NUDGES:
+                if not nudge.get("exhausted"):
+                    logger.warning(
+                        "rollout: replica %s unflipped after %d nudges; "
+                        "staying marked, no more nudges",
+                        task_id,
+                        MAX_RECONCILE_NUDGES,
+                    )
+                    nudge["exhausted"] = 1
+                continue
+            if self._poll_index - nudge["last_poll"] >= RECONCILE_RENUDGE_POLLS:
+                logger.info(
+                    "rollout: POST /wake to replica %s (nudge %d/%d)",
+                    task_id,
+                    nudge["count"] + 1,
+                    MAX_RECONCILE_NUDGES,
+                )
+                await self._reconcile(container.upstream)
+                nudge["count"] += 1
+                nudge["last_poll"] = self._poll_index
+
+        if changed:
+            await self.control.put.aio(_MARKS_KEY, marks)

--- a/cookbook/standalone/offline_evals/rollout_control_test.py
+++ b/cookbook/standalone/offline_evals/rollout_control_test.py
@@ -1,0 +1,210 @@
+"""Rollout control loop: session liveness, tombstones/TTL, and the retire flip
+walk (mark, exclusion, nudge, clear) — all against in-memory fakes (no Modal,
+no cloud)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from cookbook.standalone.offline_evals.eval_router import (
+    EvalContainerInfo,
+    route_session,
+)
+from cookbook.standalone.offline_evals.rollout_control import (
+    KIND_RETIRE,
+    MARK_CLEAR_HYSTERESIS_POLLS,
+    MAX_RECONCILE_NUDGES,
+    RolloutPolicy,
+    live_session_counts,
+    tombstone_session,
+)
+from cookbook.standalone.offline_evals.testing import _LocalDict
+
+NOW = 1_000_000.0
+TTL = 1800.0
+
+
+def _member(
+    task_id: str,
+    *,
+    load: int = 0,
+    applied: int | None = 1,
+    ready: bool = True,
+    active: int = 0,
+    load_stale: bool = False,
+) -> EvalContainerInfo:
+    return EvalContainerInfo(
+        task_id=task_id,
+        upstream=f"{task_id}:8000",
+        load=load,
+        applied_version=applied,
+        ready=ready,
+        active_requests=active,
+        load_stale=load_stale,
+    )
+
+
+def _record(
+    task_id: str, *, version: int | None = 1, last_seen: float = NOW
+) -> list[dict]:
+    return [
+        {
+            "task_id": task_id,
+            "version": version,
+            "last_seen": last_seen,
+            "tombstoned": False,
+        }
+    ]
+
+
+def _policy(
+    *,
+    session_routes: _LocalDict | None = None,
+    control: _LocalDict | None = None,
+    ttl: float = TTL,
+) -> tuple[RolloutPolicy, _LocalDict, _LocalDict, list[str]]:
+    session_routes = session_routes if session_routes is not None else _LocalDict()
+    control = control if control is not None else _LocalDict()
+    calls: list[str] = []
+
+    async def reconcile(upstream: str) -> None:
+        calls.append(upstream)
+
+    policy = RolloutPolicy(
+        session_routes=session_routes,
+        control=control,
+        session_ttl=ttl,
+        reconcile=reconcile,
+    )
+    return policy, session_routes, control, calls
+
+
+def _fleet(*members: EvalContainerInfo) -> list[EvalContainerInfo]:
+    return list(members)
+
+
+def test_session_liveness_ttl_and_tombstone(caplog) -> None:
+    sessions = {
+        "fresh": _record("ta-0"),
+        "expired": _record("ta-1", last_seen=NOW - TTL - 1),
+        "tombstoned": [{**_record("ta-2")[0], "tombstoned": True}],
+        "empty": [],
+        # The freshest entry decides: an ended session is dead everywhere.
+        "ended": [
+            {**_record("ta-5")[0], "tombstoned": True},
+            _record("ta-6")[0],
+        ],
+    }
+    counts = live_session_counts(sessions, NOW, TTL)
+    assert counts == {"ta-0": 1}
+
+    policy, _, _, _ = _policy()
+    with caplog.at_level(
+        logging.INFO, logger="cookbook.standalone.offline_evals.rollout_control"
+    ):
+        policy._log_expired(sessions, NOW)
+        policy._log_expired(sessions, NOW)
+    expired_logs = [r for r in caplog.records if "treated as tombstoned" in r.message]
+    assert len(expired_logs) == 1, "one log line per TTL-expired record, once"
+    assert {r.args[0] for r in expired_logs} == {"expired"}
+
+    async def run() -> None:
+        session_routes = _LocalDict()
+        await session_routes.put.aio(
+            "s1", _record("ta-0") + _record("ta-1", last_seen=NOW - 10)
+        )
+        await tombstone_session(session_routes, "s1")
+        record = await session_routes.get.aio("s1")
+        assert all(entry["tombstoned"] for entry in record)
+        assert live_session_counts({"s1": record}, NOW, TTL) == {}
+        # Idempotent: re-tombstone and unknown sessions are no-ops.
+        await tombstone_session(session_routes, "s1")
+        await tombstone_session(session_routes, "never-seen")
+        assert await session_routes.get.aio("never-seen", None) is None
+
+    asyncio.run(run())
+
+
+def test_retire_flip_walk(caplog) -> None:
+    """Pointer moves -> zero-live stale replica is marked -> exclusion visible to
+    placement (the mark beats the pin) -> wake nudge -> mark clears on the flip
+    (3-poll hysteresis). Nudges wait for active_requests == 0, re-nudge on a
+    bounded schedule, and a new pointer resets the budget. A commanded flip is
+    silent; an unmarked replica advancing is error-logged as uncommanded."""
+
+    async def run() -> None:
+        policy, _, control, calls = _policy()
+        fleet = _fleet(_member("ta-0", applied=1, active=2), _member("ta-1", applied=2))
+        await policy.update(fleet, 2, NOW)
+        assert calls == [], "in-flight requests gate the nudge"
+        fleet = _fleet(_member("ta-0", applied=1), _member("ta-1", applied=2))
+        await policy.update(fleet, 2, NOW)
+        marks = await control.get.aio("marks")
+        assert list(marks) == ["ta-0"]
+        assert marks["ta-0"]["kind"] == KIND_RETIRE
+        assert fleet[0].draining and not fleet[1].draining
+        assert calls == ["ta-0:8000"], "first nudge fires at active_requests == 0"
+
+        # The mark is the exclusion proxies honor: ta-0 is never placed, even
+        # though unpinned ta-1 and pinned-to-v1 both would otherwise consider it.
+        containers = {c.task_id: c for c in fleet}
+        picked = await route_session(_LocalDict(), "s", containers, 4)
+        assert picked.task_id == "ta-1"
+        picked = await route_session(_LocalDict(), "s", containers, 4, exact_version=1)
+        assert picked is None, "marked replica never selected, even for a pinned match"
+        containers["ta-9"] = _member("ta-9", applied=1)
+        picked = await route_session(_LocalDict(), "s", containers, 4, exact_version=1)
+        assert picked.task_id == "ta-9", "only the marked v1 holder is excluded"
+
+        # No re-nudge before the re-nudge interval; re-nudges are bounded, so a
+        # replica that never flips goes quiet instead of wedging the loop.
+        fleet = _fleet(_member("ta-0", applied=1), _member("ta-1", applied=2))
+        for _ in range(5):
+            await policy.update(fleet, 2, NOW)
+        assert calls == ["ta-0:8000"], "no re-nudge inside the interval"
+        for _ in range(35):
+            await policy.update(fleet, 2, NOW)
+        assert calls == ["ta-0:8000"] * MAX_RECONCILE_NUDGES, "bounded re-nudges"
+
+        # A new pointer is a fresh target: the nudge budget resets (ta-1 is now
+        # also stale and zero-live, so it is retire-marked and nudged as well).
+        await policy.update(fleet, 3, NOW)
+        assert calls.count("ta-0:8000") == MAX_RECONCILE_NUDGES + 1
+        assert "ta-1:8000" in calls
+
+        # The flip needs 3 polls at the pointer to clear the mark.
+        for _ in range(MARK_CLEAR_HYSTERESIS_POLLS - 1):
+            fleet = _fleet(_member("ta-0", applied=3), _member("ta-1", applied=3))
+            await policy.update(fleet, 3, NOW)
+            assert fleet[0].draining, "status quo across the clear window"
+            assert (await control.get.aio("marks")) != {}
+        fleet = _fleet(_member("ta-0", applied=3), _member("ta-1", applied=3))
+        await policy.update(fleet, 3, NOW)
+        assert (await control.get.aio("marks")) == {}
+        fleet = _fleet(_member("ta-0", applied=3), _member("ta-1", applied=3))
+        await policy.update(fleet, 3, NOW)
+        assert not fleet[0].draining and not fleet[1].draining
+        assert calls.count("ta-0:8000") == MAX_RECONCILE_NUDGES + 1
+        assert calls.count("ta-1:8000") == 1, "no nudges after the flip"
+
+        # Uncommanded-flip alarm: ta-1 reaches a new pointer with no mark
+        # (flipped outside the loop) -> one error log; ta-0's flip under its
+        # mark is commanded -> silent.
+        policy, _, control, _ = _policy()
+        fleet = _fleet(_member("ta-0", applied=1), _member("ta-1", applied=2))
+        await policy.update(fleet, 2, NOW)
+        assert list(await control.get.aio("marks")) == ["ta-0"]
+        with caplog.at_level(
+            logging.ERROR,
+            logger="cookbook.standalone.offline_evals.rollout_control",
+        ):
+            fleet = _fleet(_member("ta-0", applied=1), _member("ta-1", applied=3))
+            await policy.update(fleet, 3, NOW)
+            fleet = _fleet(_member("ta-0", applied=3), _member("ta-1", applied=3))
+            await policy.update(fleet, 3, NOW)
+        flips = [r for r in caplog.records if "without a" in r.message]
+        assert len(flips) == 1 and flips[0].levelname == "ERROR"
+        assert flips[0].args == ("ta-1", 2, 3)
+
+    asyncio.run(run())

--- a/cookbook/standalone/offline_evals/testing.py
+++ b/cookbook/standalone/offline_evals/testing.py
@@ -1,0 +1,27 @@
+"""In-memory stand-ins for the eval router's Modal resources (single-process)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+
+class _LocalDict:
+    """Duck-types a modal.Dict: ``get``/``put``/``items`` with ``.aio`` forms."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, Any] = {}
+        self.get = SimpleNamespace(aio=self._get)
+        self.put = SimpleNamespace(aio=self._put)
+        self.items = SimpleNamespace(aio=self._items)
+
+    async def _get(self, key: str, default: Any = None) -> Any:
+        return self._store.get(key, default)
+
+    async def _put(self, key: str, value: Any) -> None:
+        self._store[key] = value
+
+    async def _items(self) -> Any:
+        # modal.Dict.items is an async generator; mirror that shape.
+        for item in self._store.items():
+            yield item


### PR DESCRIPTION
Offline-evals series 2/5, stacked on #201. The router owns session lifecycle and reconciliation timing; the sidecar's body-pin 409 remains the correctness backstop, so routing bugs cost availability, never wrong weights.

## Summary

- session records live in the eval router's own Dict (version, last_seen, tombstoned), written on the existing placement writes — no new per-request RPCs
- `POST /sessions/{id}/end` tombstones a finished trajectory (idempotent); `session_ttl` (default 30 min) is the last-resort expiry for clients that never say goodbye
- the registry watches the store's `latest` pointer directly and drives every flip: a stale replica with zero live sessions is marked (excluding it from placement), drains to `active_requests == 0`, gets the stock `POST /wake`, and is cleared when its applied version flips; bounded re-nudges
- holds are enforced by routing policy: a mismatched pin reaching a held replica reconciles it via the stock 409 wake — the registry error-logs any replica that flips without being commanded
- pinned traffic packs onto the live holders of that version, lowest load first; the registry is a single writer, pinned to one container
- neutral `reconcile_interval` pass-through in common (stock default); eval configs set it large so the registry owns timing

## Validation

- `pytest src/ cookbook/ -q` at branch head (235 passed)
- tombstone idempotency, TTL expiry, the full retire walk against fakes, marked-replica placement exclusion, uncommanded-flip alarm, arg round-trip tests


