### PR TITLE
cookbook: opt-in fleet consolidation for pinned rollouts

### DIFF
--- a/cookbook/standalone/app.py
+++ b/cookbook/standalone/app.py
@@ -249,7 +249,7 @@ if getattr(exp, "OFFLINE_EVALS", False):
         """Polls Server replicas' server_info + queue depth; serves the snapshot at /loads.
 
         Also drives the rollout control loop (session liveness, pending-reconcile
-        marks, reconcile nudges) — correct only with a single registry container."""
+        marks, consolidation) — correct only with a single registry container."""
 
         @modal.enter()
         def enter(self) -> None:
@@ -270,6 +270,7 @@ if getattr(exp, "OFFLINE_EVALS", False):
                 session_routes=session_routes,
                 control=rollout_marks,
                 store=store,
+                rollout_concurrency=ROLLOUT_CONCURRENCY,
                 session_ttl=getattr(
                     exp, "SESSION_TTL_SECONDS", eval_router.DEFAULT_SESSION_TTL_SECONDS
                 ),

--- a/cookbook/standalone/offline_evals/eval_router.py
+++ b/cookbook/standalone/offline_evals/eval_router.py
@@ -265,13 +265,17 @@ def serve_eval_registry(
     control: Any,
     store: Any,
     session_ttl: float = DEFAULT_SESSION_TTL_SECONDS,
+    rollout_concurrency: int | None = None,
 ) -> None:
     """Start the version-aware load registry on a ``RouterRegistry`` container
     (@modal.enter). Polls go through the upstream class's own URL, derived here
     so recipes only name the class. The registry also drives the rollout control
     loop (rollout_control): it reads the store's ``latest`` pointer each poll and
     reconciles stale replicas toward it. ``session_ttl`` bounds how long an idle
-    session record counts as live; explicit tombstones are the primary signal."""
+    session record counts as live; explicit tombstones are the primary signal.
+    ``rollout_concurrency`` is the engine's per-replica overload threshold and
+    the capacity unit of consolidation; the default ``None`` disables
+    consolidation."""
     registry = EvalRegistryApp(
         app_name=app_name,
         upstream_cls=upstream_cls,
@@ -280,6 +284,7 @@ def serve_eval_registry(
         control=control,
         store=store,
         session_ttl=session_ttl,
+        rollout_concurrency=rollout_concurrency,
     )
     registry.start()
     replica._router_server = registry
@@ -332,6 +337,7 @@ class EvalRegistryApp(_RegistryApp):
         control: Any,
         store: Any,
         session_ttl: float = DEFAULT_SESSION_TTL_SECONDS,
+        rollout_concurrency: int | None = None,
     ) -> None:
         super().__init__(
             app_name=app_name, upstream_cls=upstream_cls, upstream_url=upstream_url
@@ -344,6 +350,7 @@ class EvalRegistryApp(_RegistryApp):
             session_routes=session_routes,
             control=control,
             session_ttl=session_ttl,
+            rollout_concurrency=rollout_concurrency,
             reconcile=self._post_wake,
         )
 

--- a/cookbook/standalone/offline_evals/rollout_control.py
+++ b/cookbook/standalone/offline_evals/rollout_control.py
@@ -32,6 +32,12 @@ logger = logging.getLogger(__name__)
 # are the primary end-of-session signal.
 DEFAULT_SESSION_TTL_SECONDS = 1800.0
 
+# Consolidation: a victim is marked only after the drain condition holds for
+# this many consecutive registry polls (hysteresis against blips).
+CONSOLIDATION_HYSTERESIS_POLLS = 5
+# Consolidate only when the old version's live sessions fit on the k-1
+# survivors with this safety margin below rollout_concurrency.
+CONSOLIDATION_SAFETY_FACTOR = 0.7
 # A mark is cleared only after this many consecutive polls where the replica
 # has reached the pointer (or left): a single /server_info blip must not
 # readmit a mid-reconcile replica.
@@ -42,6 +48,7 @@ RECONCILE_RENUDGE_POLLS = 10
 MAX_RECONCILE_NUDGES = 3
 
 KIND_RETIRE = "retire"  # zero-live replica catching up to the pointer
+KIND_CONSOLIDATE = "consolidate"  # drained old-version victim (one fleet-wide)
 
 _MARKS_KEY = "marks"
 
@@ -94,6 +101,57 @@ async def tombstone_session(session_routes: Any, session_id: str) -> None:
     await session_routes.put.aio(session_id, record)
 
 
+# ── consolidation ────────────────────────────────────────────────────────────
+
+
+def select_consolidation_victim(
+    containers: list[EvalContainerInfo],
+    live_counts: dict[str, int],
+    pointer_version: int,
+    rollout_concurrency: int,
+) -> tuple[int, str] | None:
+    """The consolidation candidate: ``(version, task_id)`` to drain, or None.
+
+    Oldest applied version V behind the pointer with k>=2 ready, unmarked
+    replicas holding live sessions. Drain when the live sessions at V fit on
+    the k-1 survivors under ``rollout_concurrency * CONSOLIDATION_SAFETY_FACTOR``
+    and every survivor's load is below ``rollout_concurrency``. Victim is
+    min(task_id).
+    """
+    by_version: dict[int, list[EvalContainerInfo]] = {}
+    for container in containers:
+        if (
+            container.applied_version is None
+            or container.draining
+            or not container.ready
+        ):
+            continue
+        if live_counts.get(container.task_id, 0) <= 0:
+            continue
+        by_version.setdefault(container.applied_version, []).append(container)
+
+    for version in sorted(by_version):
+        if version >= pointer_version:
+            continue  # at the pointer: consolidation destination, never a victim
+        group = by_version[version]
+        k = len(group)
+        if k < 2:
+            continue
+        victim = min(group, key=lambda c: c.task_id)
+        survivors = [c for c in group if c.task_id != victim.task_id]
+        total_live = sum(live_counts.get(c.task_id, 0) for c in group)
+        if total_live > (k - 1) * rollout_concurrency * CONSOLIDATION_SAFETY_FACTOR:
+            continue
+        if any(c.load_stale for c in survivors):
+            # A stale survivor load is unverifiable spare capacity — never
+            # approve a drain on a frozen (possibly zero) reading.
+            continue
+        if any(c.load >= rollout_concurrency for c in survivors):
+            continue
+        return version, victim.task_id
+    return None
+
+
 # ── the policy loop ──────────────────────────────────────────────────────────
 
 
@@ -107,12 +165,19 @@ class RolloutPolicy:
         session_routes: Any,
         control: Any,
         session_ttl: float,
+        rollout_concurrency: int | None,
         reconcile: Callable[[str], Awaitable[None]],
     ) -> None:
         self.session_routes = session_routes
         self.control = control
         self.session_ttl = session_ttl
+        # Engine overload threshold — the capacity unit of the consolidation
+        # condition. None disables consolidation (no victim is ever selected);
+        # the zero-live retire loop is always on.
+        self.rollout_concurrency = rollout_concurrency
         self._reconcile = reconcile
+        self._consolidation_pending: tuple[int, str] | None = None
+        self._consolidation_pending_polls = 0
         self._clear_polls: dict[str, int] = {}
         self._nudges: dict[str, dict[str, int]] = {}
         self._poll_index = 0
@@ -167,6 +232,34 @@ class RolloutPolicy:
                     )
         self._expiry_logged = expired
 
+    async def _repoint_sessions(
+        self,
+        sessions: dict[str, list[dict]],
+        victim_id: str,
+        survivor: EvalContainerInfo,
+        now: float,
+    ) -> None:
+        """Migrate the victim's live sessions onto the survivor: rewrite their
+        route entries so the next request lands there. Eager by design —
+        migrated stragglers re-prefill on their survivor."""
+        for session_id, record in sessions.items():
+            if not session_is_live(record, now, self.session_ttl):
+                continue
+            if record[0]["task_id"] != victim_id:
+                continue
+            for entry in record:
+                if entry["task_id"] == victim_id:
+                    entry["task_id"] = survivor.task_id
+                    entry["version"] = survivor.applied_version
+                    entry["last_seen"] = now
+            await self.session_routes.put.aio(session_id, record)
+            logger.info(
+                "rollout: re-pointed session %s from victim %s to survivor %s",
+                session_id,
+                victim_id,
+                survivor.task_id,
+            )
+
     async def update(
         self,
         containers: list[EvalContainerInfo],
@@ -176,10 +269,11 @@ class RolloutPolicy:
         """One control-loop pass over this poll's container snapshot.
 
         Annotates the snapshot (``live_sessions`` from the session records,
-        ``draining`` for marked replicas), marks stale zero-live replicas
-        pending-reconcile in the shared Dict, nudges marked replicas whose
-        active_requests drained to zero, and clears marks once applied_version
-        reaches the pointer (MARK_CLEAR_HYSTERESIS_POLLS consecutive polls)."""
+        ``draining`` for marked replicas), marks stale zero-live replicas and
+        at most one consolidation victim pending-reconcile in the shared Dict,
+        nudges marked replicas whose active_requests drained to zero, and
+        clears marks once applied_version reaches the pointer
+        (MARK_CLEAR_HYSTERESIS_POLLS consecutive polls)."""
         self._poll_index += 1
         if pointer_version is None:
             return  # no pointer read yet: nothing to reconcile toward
@@ -196,6 +290,51 @@ class RolloutPolicy:
             container.live_sessions = live.get(container.task_id, 0)
         by_id = {container.task_id: container for container in containers}
         changed = False
+
+        # Consolidation (opt-in): one fleet-wide victim at a time.
+        if self.rollout_concurrency is not None and not any(
+            mark.get("kind") == KIND_CONSOLIDATE for mark in marks.values()
+        ):
+            candidate = select_consolidation_victim(
+                containers, live, pointer_version, self.rollout_concurrency
+            )
+            if candidate is None:
+                self._consolidation_pending = None
+                self._consolidation_pending_polls = 0
+            else:
+                if candidate == self._consolidation_pending:
+                    self._consolidation_pending_polls += 1
+                else:
+                    self._consolidation_pending = candidate
+                    self._consolidation_pending_polls = 1
+                if self._consolidation_pending_polls >= CONSOLIDATION_HYSTERESIS_POLLS:
+                    version, victim_id = candidate
+                    marks[victim_id] = {
+                        "version": version,
+                        "kind": KIND_CONSOLIDATE,
+                        "marked_at": now,
+                    }
+                    changed = True
+                    self._consolidation_pending = None
+                    self._consolidation_pending_polls = 0
+                    survivor = min(
+                        (
+                            c
+                            for c in by_id.values()
+                            if c.applied_version == version and c.task_id != victim_id
+                        ),
+                        key=lambda c: c.load,
+                    )
+                    logger.info(
+                        "rollout: consolidating v%d: victim %s drains to %s",
+                        version,
+                        victim_id,
+                        survivor.task_id,
+                    )
+                    await self._repoint_sessions(sessions, victim_id, survivor, now)
+        else:
+            self._consolidation_pending = None
+            self._consolidation_pending_polls = 0
 
         # Retire: every stale replica with zero live sessions can catch up.
         for container in containers:

--- a/cookbook/standalone/offline_evals/rollout_control_test.py
+++ b/cookbook/standalone/offline_evals/rollout_control_test.py
@@ -1,6 +1,6 @@
-"""Rollout control loop: session liveness, tombstones/TTL, and the retire flip
-walk (mark, exclusion, nudge, clear) — all against in-memory fakes (no Modal,
-no cloud)."""
+"""Rollout control loop: session liveness, tombstones/TTL, the retire flip
+walk (mark, exclusion, nudge, clear), and consolidation arithmetic + migration
+— all against in-memory fakes (no Modal, no cloud)."""
 
 from __future__ import annotations
 
@@ -12,11 +12,14 @@ from cookbook.standalone.offline_evals.eval_router import (
     route_session,
 )
 from cookbook.standalone.offline_evals.rollout_control import (
+    CONSOLIDATION_HYSTERESIS_POLLS,
+    KIND_CONSOLIDATE,
     KIND_RETIRE,
     MARK_CLEAR_HYSTERESIS_POLLS,
     MAX_RECONCILE_NUDGES,
     RolloutPolicy,
     live_session_counts,
+    select_consolidation_victim,
     tombstone_session,
 )
 from cookbook.standalone.offline_evals.testing import _LocalDict
@@ -62,6 +65,7 @@ def _policy(
     *,
     session_routes: _LocalDict | None = None,
     control: _LocalDict | None = None,
+    concurrency: int | None = None,
     ttl: float = TTL,
 ) -> tuple[RolloutPolicy, _LocalDict, _LocalDict, list[str]]:
     session_routes = session_routes if session_routes is not None else _LocalDict()
@@ -75,6 +79,7 @@ def _policy(
         session_routes=session_routes,
         control=control,
         session_ttl=ttl,
+        rollout_concurrency=concurrency,
         reconcile=reconcile,
     )
     return policy, session_routes, control, calls
@@ -206,5 +211,129 @@ def test_retire_flip_walk(caplog) -> None:
         flips = [r for r in caplog.records if "without a" in r.message]
         assert len(flips) == 1 and flips[0].levelname == "ERROR"
         assert flips[0].args == ("ta-1", 2, 3)
+
+    asyncio.run(run())
+
+
+def test_consolidation_walk() -> None:
+    """Trigger arithmetic (drain bar, min-task_id victim, blockers, oldest
+    group) then the walk: disabled by default, hysteresis, persisted mark,
+    re-point migration, one-victim invariant, reconcile after drain, clear on
+    flip."""
+
+    def holders() -> list[EvalContainerInfo]:
+        return [_member("ta-0", applied=1), _member("ta-1", applied=1)]
+
+    # k=2, concurrency=10: the drain bar is (k-1) * 10 * 0.7 = 7 live sessions.
+    assert select_consolidation_victim(holders(), {"ta-0": 3, "ta-1": 4}, 2, 10) == (
+        1,
+        "ta-0",
+    )
+    assert select_consolidation_victim(holders(), {"ta-0": 3, "ta-1": 5}, 2, 10) is None
+    # Victim is min(task_id).
+    fleet = [_member("ta-b", applied=1), _member("ta-a", applied=1)]
+    assert select_consolidation_victim(fleet, {"ta-a": 1, "ta-b": 1}, 2, 10) == (
+        1,
+        "ta-a",
+    )
+    # A survivor at the overload bar, or with a stale load reading, blocks.
+    fleet = [_member("ta-0", applied=1), _member("ta-1", load=10, applied=1)]
+    assert select_consolidation_victim(fleet, {"ta-0": 1, "ta-1": 1}, 2, 10) is None
+    fleet = [_member("ta-0", applied=1), _member("ta-1", applied=1, load_stale=True)]
+    assert select_consolidation_victim(fleet, {"ta-0": 1, "ta-1": 1}, 2, 10) is None
+    # k=1 groups are skipped; a version at the pointer is never a victim;
+    # replicas with zero live sessions are retired, not consolidated.
+    assert select_consolidation_victim([_member("ta-0")], {"ta-0": 1}, 2, 10) is None
+    fleet = [_member("ta-0", applied=2), _member("ta-1", applied=2)]
+    assert select_consolidation_victim(fleet, {"ta-0": 1, "ta-1": 1}, 2, 10) is None
+    assert select_consolidation_victim(holders(), {"ta-0": 0, "ta-1": 3}, 2, 10) is None
+    # Oldest eligible version wins: v1 over-full, v2 (behind pointer 3) drains.
+    fleet = [
+        _member("ta-0", applied=1),
+        _member("ta-1", applied=1),
+        _member("ta-2", applied=2),
+        _member("ta-3", applied=2),
+    ]
+    live = {"ta-0": 5, "ta-1": 5, "ta-2": 1, "ta-3": 1}
+    assert select_consolidation_victim(fleet, live, 3, 10) == (2, "ta-2")
+
+    async def run() -> None:
+        sessions, control = _LocalDict(), _LocalDict()
+        # 6 live sessions at v1 (3+3), bar for k=2/concurrency=10 is 7.
+        for i, task_id in enumerate(["ta-0"] * 3 + ["ta-1"] * 3):
+            await sessions.put.aio(f"s{i}", _record(task_id))
+
+        def fleet(active: int = 3) -> list[EvalContainerInfo]:
+            # The victim carries in-flight requests until the drain phase, so
+            # the nudge provably waits for active_requests == 0.
+            return _fleet(
+                _member("ta-0", load=0, applied=1, active=active),
+                _member("ta-1", load=1, applied=1),
+                _member("ta-2", applied=2),
+            )
+
+        # Disabled by default: without rollout_concurrency the same over-full
+        # group is never marked (the zero-live retire loop is always on, but
+        # every member here holds live sessions).
+        disabled, _, _, disabled_calls = _policy(
+            session_routes=sessions, control=control
+        )
+        for _ in range(CONSOLIDATION_HYSTERESIS_POLLS + 1):
+            await disabled.update(fleet(), 2, NOW)
+        assert (await control.get.aio("marks", {})) == {}, (
+            "None disables consolidation; live-holding replicas are never marked"
+        )
+        assert disabled_calls == []
+
+        policy, _, _, calls = _policy(
+            session_routes=sessions, control=control, concurrency=10
+        )
+
+        for _ in range(CONSOLIDATION_HYSTERESIS_POLLS - 1):
+            current = fleet()
+            await policy.update(current, 2, NOW)
+            assert not any(c.draining for c in current), "marked before hysteresis"
+            assert (await control.get.aio("marks", {})) == {}
+        current = fleet()
+        await policy.update(current, 2, NOW)
+        marks = await control.get.aio("marks")
+        assert marks["ta-0"]["kind"] == KIND_CONSOLIDATE
+        assert current[0].draining
+        # Re-point: the victim's live sessions moved to the lowest-load survivor.
+        for i in range(3):
+            record = await sessions.get.aio(f"s{i}")
+            assert record[0]["task_id"] == "ta-1"
+            assert record[0]["version"] == 1
+        for i in range(3, 6):
+            assert (await sessions.get.aio(f"s{i}"))[0]["task_id"] == "ta-1"
+
+        # One-victim invariant: a second eligible group (ta-1+ta-3 at v1) is not
+        # touched while ta-0's consolidation mark stands.
+        await sessions.put.aio("s6", _record("ta-3"))
+        for _ in range(CONSOLIDATION_HYSTERESIS_POLLS + 1):
+            current = fleet() + [_member("ta-3", applied=1)]
+            await policy.update(current, 2, NOW)
+        assert list(await control.get.aio("marks")) == ["ta-0"]
+        assert calls == [], "in-flight requests gate the victim's nudge"
+
+        # Drained: the next poll nudges the victim.
+        current = fleet(active=0)
+        await policy.update(current, 2, NOW)
+        assert calls == ["ta-0:8000"]
+
+        # A restarted policy (fresh state, same Dicts) keeps driving the mark.
+        restarted, _, _, _ = _policy(
+            session_routes=sessions, control=control, concurrency=10
+        )
+        current = fleet()
+        await restarted.update(current, 2, NOW)
+        assert current[0].draining, "the persisted mark survives a registry restart"
+
+        # Flip clears the mark after the hysteresis.
+        for _ in range(MARK_CLEAR_HYSTERESIS_POLLS):
+            current = fleet()
+            current[0].applied_version = 2
+            await restarted.update(current, 2, NOW)
+        assert (await control.get.aio("marks")) == {}
 
     asyncio.run(run())


### PR DESCRIPTION
Offline-evals series 3/5, stacked on #202. Policy lives in `cookbook/standalone/rollout_control.py`.

## Summary

- opt-in consolidation (`rollout_concurrency`; unset disables): when the oldest version's live sessions fit in one fewer replica (0.7 headroom, survivor load under threshold, sustained 5 polls), drain one victim at a time
- victim = min task id, one fleet-wide, persisted; its live sessions are re-pointed to survivors (they re-prefill there), then the standard mark -> drain -> reconcile -> clear walk runs
- capacity frees seconds after the arithmetic holds — no TTL wait

## Validation

- `pytest src/ cookbook/ -q` at branch head (236 passed)
- trigger arithmetic, victim choice, re-point migration, one-victim invariant, disabled-by-default tests



