### PR TITLE
cookbook: async publisher app with full-checkpoint publish API

### DIFF
--- a/cookbook/standalone/offline_evals/publish_app.py
+++ b/cookbook/standalone/offline_evals/publish_app.py
@@ -1,0 +1,391 @@
+"""Single-writer publisher: ``/publish``, ``/job``, ``/status``.
+
+Materialization is async (``.spawn`` a Modal function) because a synchronous
+multi-hundred-GB copy inside the FastAPI handler dies at Modal ingress
+(~18 min 502) and Flash then drains the container mid-copy. Separate app
+from the inference pool so it scales independently.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
+import modal
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from cookbook.common import storage
+from cookbook.common.constants import CHECKPOINTS_PATH, MINUTES, STITCH_PATH
+from cookbook.standalone.offline_evals.publish_materialize import (
+    _ensure_safetensors_index,
+    _prepare_version_dir,
+    _updates_dir,
+    _version_dir,
+)
+from stitch.stores.base import Store
+
+logger = logging.getLogger(__name__)
+
+EXPERIMENT = os.environ["EXPERIMENT_CONFIG"]
+exp = importlib.import_module(f"cookbook.standalone.configs.{EXPERIMENT}")
+# Must match the pool's run (app.py requires it too): the store namespace targets
+# the pool's Servers, and a default here would silently target the wrong app.
+RUN_ID = os.environ["RUN_ID"]
+APP_NAME = f"{exp.APP_NAME}-publisher-{RUN_ID}"
+POOL_APP_NAME = f"{exp.APP_NAME}-{RUN_ID}"
+POOL_CLS_NAME = "Server"
+RUN_DIR = STITCH_PATH / RUN_ID
+STORE_DEPLOYMENT = storage.StoreDeployment.from_environment()
+STORE_SECRETS = STORE_DEPLOYMENT.modal_secrets()
+# Port the publisher's uvicorn binds; must match the @app.server(port=...) below —
+# Modal Flash waits for this port and kills the container if nothing listens.
+PUBLISHER_PORT = 8001
+
+publisher_image = (
+    modal.Image.debian_slim()
+    .pip_install(
+        "fastapi",
+        "httpx",
+        # numpy is safe_open's header-read framework; the image has no torch.
+        "numpy",
+        "safetensors>=0.4.0",
+        "uvicorn",
+    )
+    .env({"EXPERIMENT_CONFIG": EXPERIMENT, "RUN_ID": RUN_ID})
+    .add_local_python_source("stitch")
+    .add_local_python_source("cookbook")
+    .add_local_dir(
+        "tools",
+        remote_path="/root/tools",
+        ignore=["**/__pycache__", "**/*.pyc"],
+    )
+)
+
+app = modal.App(APP_NAME)
+
+run_volume = modal.Volume.from_name(
+    exp.EXPERIMENT_VOLUME_NAME, create_if_missing=True, version=2
+)
+# Prep writes model snapshots here; the publisher only reads them.
+checkpoint_volume = modal.Volume.from_name(
+    exp.CHECKPOINT_VOLUME_NAME, create_if_missing=True, version=2
+)
+
+
+def _run_volume_mounts() -> dict[str, modal.Volume]:
+    """The run store's volume mount — empty when the store backend isn't a Modal volume."""
+    if STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME:
+        return {str(STITCH_PATH): run_volume}
+    return {}
+
+
+class PublishRequest(BaseModel):
+    run_id: str
+    version: int
+    source: str  # local path to the model directory
+
+
+class StatusResponse(BaseModel):
+    latest_version: int | None
+    staged_versions: list[int]
+
+
+def _build_store(run_id: str) -> Store:
+    """Build the run's store exactly the way the pool does (same root and namespace)."""
+    STORE_DEPLOYMENT.bootstrap_credentials()
+    # Namespace on the POOL app name so the S3 root matches the pool's store.
+    store_config = STORE_DEPLOYMENT.hook_config(POOL_APP_NAME)
+    return storage.create_store(
+        store_config["stitch_store_backend"],
+        local_root=RUN_DIR,
+        run_id=run_id,
+        volume_name=exp.EXPERIMENT_VOLUME_NAME,
+        s3_root=store_config.get("stitch_s3_root"),
+        s3_endpoint_url=store_config.get("stitch_s3_endpoint_url"),
+    )
+
+
+def _is_already_published(store: Store, version: int) -> bool:
+    """No-op check keyed on the store pointer, refreshed first for cross-host visibility.
+
+    Keyed on the pointer — NOT on version_dir existence — so a staged dir left
+    behind by a failed job never masks a publish that still needs to run.
+    """
+    store.refresh()
+    pointer = store.read_pointer()
+    return pointer is not None and pointer.version >= version
+
+
+def _function_call_from_id(job_id: str) -> modal.FunctionCall:
+    """Look up a spawned job by id (module-level so tests can stub it)."""
+    return modal.FunctionCall.from_id(job_id)
+
+
+def _job_state(job_id: str) -> dict[str, Any]:
+    """Non-blocking poll of a spawned materialization job.
+
+    get(timeout=0) raises TimeoutError while the job is still running and
+    re-raises the remote exception when the job failed.
+    """
+    try:
+        call = _function_call_from_id(job_id)
+        result = call.get(timeout=0)
+    # modal 1.5.4 raises *builtins* TimeoutError from get(timeout=0) while the
+    # spawn is still running.
+    except TimeoutError:
+        return {"job_id": job_id, "status": "pending"}
+    except Exception as exc:  # noqa: BLE001 — remote failure surfaces here
+        return {"job_id": job_id, "status": "failure", "error": repr(exc)}
+    return {"job_id": job_id, "status": "success", "result": result}
+
+
+@app.function(
+    image=publisher_image,
+    volumes=_run_volume_mounts(),
+    secrets=STORE_SECRETS,
+    cpu=2,
+    memory=2048,
+    timeout=30 * MINUTES,
+    max_containers=1,
+)
+def publish_version(run_id: str, model_dir: Path) -> None:
+    """Materialize a model directory into the versioned updates store.
+
+    Called locally by the publisher after /publish request validation. The version
+    and full/delta kind come from the directory's HF index (stitch derives them).
+
+    The pool is never woken here: replicas self-reconcile on their sidecar
+    poll, and any routing-driven rollout watches the store pointer — the
+    pointer is the propagation path.
+    """
+    import stitch.publish
+
+    store = _build_store(run_id)
+
+    stitch.publish.publish_version(store, None, str(model_dir), run_id=run_id)
+
+
+@app.function(
+    image=publisher_image,
+    volumes={
+        str(CHECKPOINTS_PATH): checkpoint_volume.read_only(),
+        **_run_volume_mounts(),
+    },
+    secrets=STORE_SECRETS,
+    # The copy is page-cache/IO bound; cpu>=4 keeps ~1GB/s volume throughput and
+    # the 4h timeout covers a ~756GB source with headroom. max_containers=1
+    # serializes jobs even if the HTTP-side 409 guard is bypassed (recycle).
+    cpu=4,
+    memory=8192,
+    timeout=4 * 60 * MINUTES,
+    max_containers=1,
+)
+def materialize_version(
+    run_id: str, version: int, source: str, publish: bool
+) -> dict[str, Any]:
+    """Async materialization job: copy, index-stamp, optionally publish.
+
+    Runs off the Flash server container so a multi-hundred-GB copy survives
+    ingress timeouts and publisher-container drains.
+    """
+    source_path = Path(source)
+    version_dir = _version_dir(RUN_DIR, version)
+    if source_path.resolve() != version_dir.resolve():
+        action = _prepare_version_dir(version_dir, source_path)
+        logger.info(
+            "materialized source for version %d: %s (%s)", version, version_dir, action
+        )
+
+    _ensure_safetensors_index(version_dir, version)
+
+    if publish:
+        publish_version.local(run_id=run_id, model_dir=version_dir)
+        logger.info("published version %d via stitch", version)
+
+    return {"version": version, "path": str(version_dir), "published": publish}
+
+
+class PublisherServer:
+    """FastAPI app plus uvicorn lifecycle; instantiable without a container."""
+
+    def __init__(
+        self,
+        *,
+        store: Store,
+        run_dir: Path,
+        port: int = PUBLISHER_PORT,
+    ) -> None:
+        self.store = store
+        self.run_dir = run_dir
+        self.updates_dir = _updates_dir(run_dir)
+        self.port = port
+        # In-memory single-writer guard. A Flash recycle resets it; the store
+        # pointer's rewind guard is the durable backstop.
+        self._current_job_id: str | None = None
+
+    def _job_busy(self) -> bool:
+        """True while a spawned job is still running."""
+        if self._current_job_id is None:
+            return False
+        if _job_state(self._current_job_id)["status"] == "pending":
+            return True
+        self._current_job_id = None
+        return False
+
+    def _spawn_materialize(
+        self, *, run_id: str, version: int, source: str, publish: bool
+    ) -> str:
+        """Spawn the async materialization job; 409 while another job runs."""
+        if self._job_busy():
+            raise HTTPException(
+                status_code=409,
+                detail=f"materialization job {self._current_job_id} still running",
+            )
+        call = materialize_version.spawn(
+            run_id=run_id, version=version, source=source, publish=publish
+        )
+        self._current_job_id = call.object_id
+        logger.info(
+            "spawned materialization job %s (version=%d)", call.object_id, version
+        )
+        return call.object_id
+
+    def build_app(self) -> Any:
+        fastapi_app = FastAPI()
+
+        @fastapi_app.post("/publish")
+        async def publish(request: PublishRequest) -> Any:
+            """Validate and spawn materialize+publish; 200 no-op if the pointer is already past ``version``."""
+            version_dir = _version_dir(self.run_dir, request.version)
+
+            # Pointer-keyed no-op: a fabricated dir must NOT mask publishing.
+            if _is_already_published(self.store, request.version):
+                logger.info(
+                    "store pointer already at or past version %d; returning no-op",
+                    request.version,
+                )
+                return {
+                    "status": "no-op",
+                    "reason": "store pointer already at or past version",
+                    "version": request.version,
+                    "path": str(version_dir),
+                }
+
+            source_path = Path(request.source)
+            if not source_path.exists():
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"source directory not found: {source_path}",
+                )
+
+            job_id = self._spawn_materialize(
+                run_id=request.run_id,
+                version=request.version,
+                source=request.source,
+                publish=True,
+            )
+            return JSONResponse(
+                status_code=202,
+                content={
+                    "status": "accepted",
+                    "job_id": job_id,
+                    "version": request.version,
+                    "path": str(version_dir),
+                },
+            )
+
+        @fastapi_app.get("/job/{job_id}")
+        async def job(job_id: str) -> dict[str, Any]:
+            """GET /job/{job_id} -> pending | success | failure (non-blocking)."""
+            return _job_state(job_id)
+
+        @fastapi_app.get("/status")
+        async def status() -> StatusResponse:
+            """GET /status
+
+            latest_version is the store POINTER; the on-disk dir listing is
+            exposed separately as staged_versions, so a partial dir left by a
+            recycled mid-copy container can never masquerade as latest.
+            """
+            pointer = self.store.read_pointer()
+
+            staged: list[int] = []
+            if self.updates_dir.exists():
+                for d in sorted(self.updates_dir.iterdir()):
+                    if d.is_dir() and d.name.startswith("weight_v"):
+                        try:
+                            staged.append(int(d.name.replace("weight_v", "")))
+                        except ValueError:
+                            pass
+
+            return StatusResponse(
+                latest_version=pointer.version if pointer is not None else None,
+                staged_versions=staged,
+            )
+
+        return fastapi_app
+
+    def start(self) -> None:
+        import uvicorn
+
+        config = uvicorn.Config(
+            self.build_app(), host="0.0.0.0", port=self.port, timeout_keep_alive=300
+        )
+        self.uvicorn_server = uvicorn.Server(config)
+        self.server_thread = threading.Thread(
+            target=self.uvicorn_server.run, daemon=True
+        )
+        self.server_thread.start()
+
+    def stop(self) -> None:
+        self.uvicorn_server.should_exit = True
+        self.server_thread.join()
+
+
+@app.server(
+    image=publisher_image,
+    cpu=2,
+    memory=2048,
+    volumes={
+        str(CHECKPOINTS_PATH): checkpoint_volume.read_only(),
+        **_run_volume_mounts(),
+    },
+    secrets=STORE_SECRETS,
+    # Single-writer: exactly one publisher, kept warm so /publish never cold-starts.
+    min_containers=1,
+    max_containers=1,
+    startup_timeout=10 * MINUTES,
+    port=PUBLISHER_PORT,
+    unauthenticated=True,
+)
+class Publisher:
+    """Single-writer publisher server."""
+
+    @modal.enter()
+    def startup(self) -> None:
+        STORE_DEPLOYMENT.bootstrap_credentials()
+        _updates_dir(RUN_DIR).mkdir(parents=True, exist_ok=True)
+        store = _build_store(RUN_ID)
+        # Flash kills the container if nothing binds `port` during startup, so the
+        # HTTP listener must come up here in @modal.enter, not lazily.
+        self._server = PublisherServer(
+            store=store, run_dir=RUN_DIR, port=PUBLISHER_PORT
+        )
+        self._server.start()
+        logger.info(
+            "Publisher serving on port %d, updates directory: %s",
+            PUBLISHER_PORT,
+            self._server.updates_dir,
+        )
+
+    @modal.exit()
+    def shutdown(self) -> None:
+        server = getattr(self, "_server", None)
+        if server is not None:
+            server.stop()

--- a/cookbook/standalone/offline_evals/publish_app_test.py
+++ b/cookbook/standalone/offline_evals/publish_app_test.py
@@ -1,0 +1,273 @@
+"""Publisher: index generation, pointer-keyed no-op."""
+
+import os
+
+os.environ.setdefault("EXPERIMENT_CONFIG", "glm5_2_fp8")
+os.environ.setdefault("RUN_ID", "publish-app-test")
+
+import json
+import struct
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cookbook.standalone.offline_evals import publish_app
+from stitch.types import VersionRef
+
+
+def _write_tiny_safetensors(
+    path: Path, tensors: tuple[str, ...] = ("w1", "w2")
+) -> None:
+    """Write a real (tiny) safetensors container: 8-byte LE header length, JSON
+    header, then zero-filled tensor data."""
+    header: dict[str, dict] = {}
+    offset = 0
+    for name in tensors:
+        nbytes = 4  # one F32 scalar per tensor
+        header[name] = {
+            "dtype": "F32",
+            "shape": [1],
+            "data_offsets": [offset, offset + nbytes],
+        }
+        offset += nbytes
+    blob = json.dumps(header).encode()
+    path.write_bytes(struct.pack("<Q", len(blob)) + blob + b"\x00" * offset)
+
+
+class _FakeStore:
+    """Records call order so the test can prove refresh precedes read_pointer."""
+
+    def __init__(self, pointer: VersionRef | None) -> None:
+        self.pointer = pointer
+        self.calls: list[str] = []
+
+    def refresh(self) -> None:
+        self.calls.append("refresh")
+
+    def read_pointer(self) -> VersionRef | None:
+        self.calls.append("read_pointer")
+        return self.pointer
+
+
+# ── Invalid-target cleanup ───────────────────────────────────────────────────
+
+
+def _make_source(path: Path, shards: tuple[str, ...] = ("model.safetensors",)) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    for shard in shards:
+        _write_tiny_safetensors(path / shard)
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": {}})
+    )
+    (path / "config.json").write_text("{}")
+    return path
+
+
+def test_prepare_version_dir(tmp_path: Path) -> None:
+    # fresh copy
+    source = _make_source(tmp_path / "source")
+    target = tmp_path / "weight_v000001"
+    assert publish_app._prepare_version_dir(target, source) == "copied"
+    assert (target / "model.safetensors.index.json").exists()
+
+    # missing index recopied (a dir with shards but no index was recycled mid-copy)
+    target = tmp_path / "weight_v000002"
+    target.mkdir()
+    _write_tiny_safetensors(target / "model.safetensors")
+    (target / "stale-marker").write_text("partial")  # proof the dir was replaced
+    assert publish_app._prepare_version_dir(target, source) == "copied"
+    assert not (target / "stale-marker").exists()
+
+    # incomplete shard set recopied (index present but a source shard missing)
+    source2 = _make_source(
+        tmp_path / "source2",
+        shards=("model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"),
+    )
+    target = tmp_path / "weight_v000003"
+    target.mkdir()
+    _write_tiny_safetensors(target / "model-00001-of-00002.safetensors")
+    (target / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": {}})
+    )
+    assert publish_app._prepare_version_dir(target, source2) == "copied"
+    assert (target / "model-00002-of-00002.safetensors").exists()
+
+    # valid target kept
+    target = _make_source(tmp_path / "weight_v000004")
+    (target / "extra-note").write_text("keep me")
+    assert publish_app._prepare_version_dir(target, source) == "kept"
+    assert (target / "extra-note").exists()
+
+
+class _FakeSpawn:
+    """Stands in for the materialize_version Modal function's .spawn()."""
+
+    def __init__(self, job_id: str = "fc-test-1") -> None:
+        self.job_id = job_id
+        self.calls: list[dict] = []
+
+    def spawn(self, **kwargs: object) -> SimpleNamespace:
+        self.calls.append(kwargs)
+        return SimpleNamespace(object_id=self.job_id)
+
+
+class _FakeFunctionCall:
+    """Stands in for modal.FunctionCall.get(timeout=0) across job states."""
+
+    def __init__(self, state: str, result: dict | None = None) -> None:
+        self.state = state
+        self.result = result or {}
+
+    def get(self, timeout: float = 0) -> dict:
+        if self.state == "pending":
+            raise TimeoutError(
+                "still running"
+            )  # builtins, as modal 1.5.4 actually raises
+        if self.state == "failure":
+            raise RuntimeError("remote boom")
+        return self.result
+
+
+def _patch_job_poll(
+    monkeypatch: pytest.MonkeyPatch, calls: dict[str, _FakeFunctionCall]
+) -> None:
+    monkeypatch.setattr(
+        publish_app, "_function_call_from_id", lambda job_id: calls[job_id]
+    )
+
+
+_server_seq = 0
+
+
+def _make_server(
+    tmp_path: Path,
+    pointer: VersionRef | None = None,
+    *,
+    label: str | None = None,
+) -> publish_app.PublisherServer:
+    global _server_seq
+    if label is None:
+        _server_seq += 1
+        label = f"run-{_server_seq}"
+    run_dir = tmp_path / label
+    (run_dir / "updates").mkdir(parents=True, exist_ok=True)
+    return publish_app.PublisherServer(
+        store=_FakeStore(pointer),
+        run_dir=run_dir,
+        port=0,
+    )
+
+
+def _client(server: publish_app.PublisherServer) -> TestClient:
+    return TestClient(server.build_app())
+
+
+def _publish(client: TestClient, version: int, source: str, **extra: object):
+    return client.post(
+        "/publish",
+        json={
+            "run_id": publish_app.RUN_ID,
+            "version": version,
+            "source": source,
+            **extra,
+        },
+    )
+
+
+def _assert_spawned(fake: _FakeSpawn, **expected: object) -> None:
+    assert fake.calls == [{"run_id": publish_app.RUN_ID, **expected}]
+
+
+def test_publisher_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """publish -> job -> status lifecycle: status variants, pointer-keyed no-op,
+    spawn/409, and job states."""
+
+    # /status variants: latest_version is the store pointer, staged_versions the
+    # weight_v* dirs on disk.
+    for pointer, dirs, expected in (
+        (
+            VersionRef("run", 3),
+            ["weight_v000000", "weight_v000003", "not-a-version"],
+            {"latest_version": 3, "staged_versions": [0, 3]},
+        ),
+        (
+            VersionRef("run", 0),
+            ["weight_v000000", "weight_v000001"],
+            {"latest_version": 0, "staged_versions": [0, 1]},
+        ),
+        (None, [], {"latest_version": None, "staged_versions": []}),
+    ):
+        server = _make_server(tmp_path, pointer=pointer)
+        for name in dirs:
+            (server.updates_dir / name).mkdir()
+        resp = _client(server).get("/status")
+        assert resp.status_code == 200
+        assert resp.json() == expected, "latest is the pointer, not a partial dir"
+
+    def _fail(*args: object, **kwargs: object) -> None:
+        raise AssertionError("materialize job must not spawn on a no-op")
+
+    monkeypatch.setattr(publish_app, "materialize_version", _fail)
+    client = _client(_make_server(tmp_path, pointer=VersionRef("run", 5)))
+    resp = _publish(client, 3, "/nonexistent")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "no-op"
+    assert resp.json()["version"] == 3
+
+    # The no-op decision is keyed on the store pointer (refresh precedes read).
+    store = _FakeStore(VersionRef("run", 5))
+    # older than or equal to the pointer is a no-op; newer publishes
+    for version, expected in ((3, True), (5, True), (6, False)):
+        assert publish_app._is_already_published(store, version) is expected
+    assert store.calls == ["refresh", "read_pointer"] * 3
+    assert publish_app._is_already_published(_FakeStore(None), 1) is False, (
+        "with no pointer nothing is a no-op"
+    )
+
+    client = _client(_make_server(tmp_path))
+    resp = _publish(client, 1, "/nonexistent")
+    assert resp.status_code == 400
+    assert "source directory not found" in resp.json()["detail"]
+
+    source = _make_source(tmp_path / "source")
+    fake_spawn = _FakeSpawn(job_id="fc-pub-1")
+    monkeypatch.setattr(publish_app, "materialize_version", fake_spawn)
+    server = _make_server(tmp_path)
+    client = _client(server)
+    resp = _publish(client, 1, str(source))
+    assert resp.status_code == 202
+    assert resp.json()["status"] == "accepted"
+    assert resp.json()["job_id"] == "fc-pub-1"
+    _assert_spawned(fake_spawn, version=1, source=str(source), publish=True)
+
+    monkeypatch.setattr(publish_app, "materialize_version", _FakeSpawn())
+    calls = {"fc-test-1": _FakeFunctionCall("pending")}
+    _patch_job_poll(monkeypatch, calls)
+    client = _client(_make_server(tmp_path))
+    resp = _publish(client, 1, str(source))
+    assert resp.status_code == 202
+    resp = _publish(client, 2, str(source))
+    assert resp.status_code == 409
+    assert "still running" in resp.json()["detail"]
+    calls["fc-test-1"].state = "success"
+    resp = _publish(client, 2, str(source))
+    assert resp.status_code == 202
+
+    _patch_job_poll(
+        monkeypatch,
+        {
+            "fc-pending": _FakeFunctionCall("pending"),
+            "fc-success": _FakeFunctionCall("success", {"version": 1, "path": "/x"}),
+            "fc-failure": _FakeFunctionCall("failure"),
+        },
+    )
+    client = _client(_make_server(tmp_path))
+    assert client.get("/job/fc-pending").json()["status"] == "pending"
+    ok = client.get("/job/fc-success").json()
+    assert ok["status"] == "success"
+    assert ok["result"] == {"version": 1, "path": "/x"}
+    bad = client.get("/job/fc-failure").json()
+    assert bad["status"] == "failure"
+    assert "remote boom" in bad["error"]

--- a/cookbook/standalone/offline_evals/publish_materialize.py
+++ b/cookbook/standalone/offline_evals/publish_materialize.py
@@ -1,0 +1,95 @@
+"""Checkpoint materialization: target validity, version-dir preparation, index generation.
+
+The pure dir-layout/copy/index unit behind the publisher app
+(``cookbook.standalone.offline_evals.publish_app``) and its spawned jobs.
+"""
+
+import json
+import logging
+import shutil
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _updates_dir(run_dir: Path) -> Path:
+    return run_dir / "updates"
+
+
+def _version_dir(run_dir: Path, version: int) -> Path:
+    return _updates_dir(run_dir) / f"weight_v{version:06d}"
+
+
+def _target_is_valid(version_dir: Path, source_dir: Path) -> bool:
+    """True when ``version_dir`` is a complete materialization of ``source_dir``."""
+    index_path = version_dir / "model.safetensors.index.json"
+    if not index_path.is_file():
+        return False
+    source_shards = {p.name: p for p in source_dir.glob("*.safetensors")}
+    target_shards = {p.name: p for p in version_dir.glob("*.safetensors")}
+    return source_shards.keys() <= target_shards.keys()
+
+
+def _prepare_version_dir(version_dir: Path, source_dir: Path) -> str:
+    """Materialize ``source_dir`` into ``version_dir``. A partial dir is removed,
+    not resumed (copytree resume is not safe). Returns ``kept`` or ``copied``.
+    """
+    if version_dir.exists():
+        if _target_is_valid(version_dir, source_dir):
+            logger.info(
+                "version dir %s already fully materialized; keeping", version_dir
+            )
+            return "kept"
+        logger.warning(
+            "removing invalid partial version dir %s (missing index or shards)",
+            version_dir,
+        )
+        shutil.rmtree(version_dir)
+    version_dir.mkdir(parents=True)
+    for item in source_dir.iterdir():
+        dest = version_dir / item.name
+        if item.is_dir():
+            shutil.copytree(item, dest, dirs_exist_ok=True)
+        else:
+            shutil.copy2(item, dest)
+    return "copied"
+
+
+def _ensure_safetensors_index(model_dir: Path, version: int) -> None:
+    """Ensure model.safetensors.index.json exists with metadata.version=version.
+
+    If the directory has safetensors files but no index, generate one from tensor names.
+    Small single-file models won't have an index; create a minimal one. Any failure
+    raises — a missing/wrong index makes stitch.publish derive a wrong manifest, so
+    the request must fail loudly and never publish unversioned weights.
+    """
+    index_path = model_dir / "model.safetensors.index.json"
+    if index_path.exists():
+        data = json.loads(index_path.read_text())
+        data.setdefault("metadata", {})["version"] = version
+        index_path.write_text(json.dumps(data, indent=2))
+        return
+
+    safetensors_files = sorted(model_dir.glob("*.safetensors"))
+    if not safetensors_files:
+        raise FileNotFoundError(
+            f"no safetensors files found in {model_dir}; cannot generate index"
+        )
+
+    from safetensors import safe_open
+
+    main_file = next(
+        (f for f in safetensors_files if f.name == "model.safetensors"),
+        safetensors_files[0],
+    )
+    # framework="numpy": only the header (tensor names) is read, and the publisher
+    # image ships numpy but not torch.
+    with safe_open(str(main_file), framework="numpy") as f:
+        keys = list(f.keys())
+
+    index = {
+        "metadata": {"version": version},
+        "weight_map": {key: main_file.name for key in keys},
+    }
+    index_path.write_text(json.dumps(index, indent=2))
+    logger.info("generated safetensors index for %s (version=%d)", model_dir, version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
     "modal>=1.5.4.dev11",
     "fastapi",
     "httpx",
+    "safetensors>=0.4.0",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -1078,6 +1078,7 @@ dev = [
     { name = "modal" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "safetensors" },
 ]
 
 [package.metadata]
@@ -1097,6 +1098,31 @@ dev = [
     { name = "modal", specifier = ">=1.5.4.dev11" },
     { name = "pytest" },
     { name = "ruff", specifier = "==0.15.1" },
+    { name = "safetensors", specifier = ">=0.4.0" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Offline-evals series 4/5, stacked on #203.

## Summary

- add a single-writer publisher app to the standalone recipe: `POST /publish` materializes a checkpoint into the next store version, advances the pointer, wakes the pool (inert under manual reconcile mode by design)
- materialization runs as a spawned background job (`GET /job/{id}`); synchronous multi-hundred-GB copies die at the ingress limit
- `GET /status` reports from the store pointer, never the directory listing
- generate a safetensors index when the source ships none

## Validation

- `pytest src/ cookbook/ -q` at branch head (238 passed)
- publisher lifecycle walk (publish -> job -> status)
- behavior carried from a live-validated predecessor (full-checkpoint and delta publishes on real pools)




