### PR TITLE
cookbook: publisher hardening with cpu-mode and delta-lineage guards

### DIFF
--- a/cookbook/standalone/offline_evals/publish_app.py
+++ b/cookbook/standalone/offline_evals/publish_app.py
@@ -12,17 +12,20 @@ import importlib
 import logging
 import os
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import modal
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
+from modal import exception as modal_exc
 from pydantic import BaseModel
 
 from cookbook.common import storage
 from cookbook.common.constants import CHECKPOINTS_PATH, MINUTES, STITCH_PATH
 from cookbook.standalone.offline_evals.publish_materialize import (
+    _delta_index_metadata,
     _ensure_safetensors_index,
     _prepare_version_dir,
     _updates_dir,
@@ -88,7 +91,8 @@ def _run_volume_mounts() -> dict[str, modal.Volume]:
 class PublishRequest(BaseModel):
     run_id: str
     version: int
-    source: str  # local path to the model directory
+    source: str  # local path to the model directory; full-vs-delta derives
+    # from its index's `delta_encoding` key
 
 
 class StatusResponse(BaseModel):
@@ -98,6 +102,14 @@ class StatusResponse(BaseModel):
 
 def _build_store(run_id: str) -> Store:
     """Build the run's store exactly the way the pool does (same root and namespace)."""
+    if run_id != RUN_ID:
+        # A store for a foreign run shares this publisher's local root and S3
+        # namespace, so its pointer writes would land on the LIVE run — and a
+        # cross-run pointer move bypasses the rewind guard as a "reset".
+        raise ValueError(
+            f"refusing to build a store for run_id {run_id!r}; "
+            f"this publisher owns run {RUN_ID!r}"
+        )
     STORE_DEPLOYMENT.bootstrap_credentials()
     # Namespace on the POOL app name so the S3 root matches the pool's store.
     store_config = STORE_DEPLOYMENT.hook_config(POOL_APP_NAME)
@@ -111,6 +123,20 @@ def _build_store(run_id: str) -> Store:
     )
 
 
+def _require_own_run_id(run_id: str) -> None:
+    """Reject requests addressed at a foreign run (HTTP 400).
+
+    Every job spawned here writes THIS run's volume and pointer; a body run_id
+    that doesn't match the publisher's env RUN_ID would rewrite the live run's
+    pointer from a foreign request (and bypass the rewind guard as a reset).
+    """
+    if run_id != RUN_ID:
+        raise HTTPException(
+            status_code=400,
+            detail=f"run_id {run_id!r} does not match this publisher's run {RUN_ID!r}",
+        )
+
+
 def _is_already_published(store: Store, version: int) -> bool:
     """No-op check keyed on the store pointer, refreshed first for cross-host visibility.
 
@@ -122,25 +148,97 @@ def _is_already_published(store: Store, version: int) -> bool:
     return pointer is not None and pointer.version >= version
 
 
+def _reject_full_publish_in_cpu_mode(version_dir: Path, version: int) -> None:
+    """Refuse a FULL publish when the run is in cpu (delta-only) update mode.
+
+    cpu mode applies XOR deltas in place; a FULL publish wedges the run
+    (replicas ERROR-loop post-pointer). A dir is FULL when its index has no
+    ``delta_encoding`` — including a MISSING index (the materialize job's
+    ``_ensure_safetensors_index`` would generate a non-delta one). Shared by the
+    /publish handler (pre-spawn, on the source) and the materialize job
+    (post-index, pre-pointer) so the two checks cannot drift.
+    """
+    if getattr(exp, "SGLANG_DELTA_UPDATE_MODE", "disk") != "cpu":
+        return
+    if _delta_index_metadata(version_dir) is not None:
+        return
+    index_path = version_dir / "model.safetensors.index.json"
+    raise RuntimeError(
+        f"cpu update mode is delta-only: refusing to publish FULL version {version} "
+        f"(no delta_encoding in {index_path}); publish a delta or use a disk-mode run"
+    )
+
+
+def _reject_broken_delta_lineage(store: Store, version_dir: Path, version: int) -> None:
+    """Refuse a delta whose ``base_version`` is not the current store pointer.
+
+    The engine applies deltas as a strict chain and walks every intermediate
+    version — and cpu mode has no FULL catch-up — so one delta published on the
+    wrong base wedges every stage after it. The pointer is the only valid base
+    at publish time. Shared by the /publish handler (pre-spawn, on the source)
+    and the materialize job (pre-pointer) so the two checks cannot drift.
+    """
+    meta = _delta_index_metadata(version_dir)
+    if meta is None:
+        return  # FULL sources carry no lineage
+    store.refresh()
+    pointer = store.read_pointer()
+    pointer_version = pointer.version if pointer is not None else None
+    try:
+        base_version = int(meta.get("base_version"))
+    except (TypeError, ValueError):
+        base_version = None
+    if base_version is None or base_version != pointer_version:
+        raise RuntimeError(
+            f"delta version {version} declares base_version="
+            f"{meta.get('base_version')!r} but the store pointer is "
+            f"{pointer_version}; a delta must be based on the current pointer "
+            "(the chain is applied in order and a broken link cannot be "
+            "repaired in place)"
+        )
+
+
 def _function_call_from_id(job_id: str) -> modal.FunctionCall:
     """Look up a spawned job by id (module-level so tests can stub it)."""
     return modal.FunctionCall.from_id(job_id)
 
 
+# get() surfaces a REMOTE job failure as one of these modal wrappers, or as the
+# deserialized remote exception itself (an arbitrary non-modal class). Any OTHER
+# modal exception is a client-side query error (connection, auth, unknown call
+# id) — transient, not a job failure.
+_REMOTE_FAILURE_ERRORS = (
+    modal_exc.RemoteError,
+    modal_exc.ExecutionError,
+    modal_exc.InternalFailure,
+    modal_exc.FunctionTimeoutError,
+    modal_exc.UserCodeException,
+)
+
+
 def _job_state(job_id: str) -> dict[str, Any]:
     """Non-blocking poll of a spawned materialization job.
 
-    get(timeout=0) raises TimeoutError while the job is still running and
-    re-raises the remote exception when the job failed.
+    get(timeout=0) raises modal TimeoutError while the job is still running and
+    re-raises the remote exception when the job failed. Transient query errors
+    (lookup or poll) report 'unknown' — NOT 'failure' — so polling clients keep
+    polling a healthy job.
     """
     try:
         call = _function_call_from_id(job_id)
+    except Exception as exc:  # noqa: BLE001
+        return {"job_id": job_id, "status": "unknown", "error": repr(exc)}
+    try:
         result = call.get(timeout=0)
     # modal 1.5.4 raises *builtins* TimeoutError from get(timeout=0) while the
-    # spawn is still running.
-    except TimeoutError:
+    # spawn is still running; keep the modal class too in case that changes.
+    except (TimeoutError, modal_exc.TimeoutError):
         return {"job_id": job_id, "status": "pending"}
-    except Exception as exc:  # noqa: BLE001 — remote failure surfaces here
+    except _REMOTE_FAILURE_ERRORS as exc:
+        return {"job_id": job_id, "status": "failure", "error": repr(exc)}
+    except modal_exc.Error as exc:
+        return {"job_id": job_id, "status": "unknown", "error": repr(exc)}
+    except Exception as exc:  # noqa: BLE001 — deserialized remote exception
         return {"job_id": job_id, "status": "failure", "error": repr(exc)}
     return {"job_id": job_id, "status": "success", "result": result}
 
@@ -196,6 +294,10 @@ def materialize_version(
     """
     source_path = Path(source)
     version_dir = _version_dir(RUN_DIR, version)
+    if STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME:
+        # See dirs staged by OTHER containers (e.g. a prior staging job)
+        # before deciding whether the target already exists or is valid.
+        run_volume.reload()
     if source_path.resolve() != version_dir.resolve():
         action = _prepare_version_dir(version_dir, source_path)
         logger.info(
@@ -205,10 +307,25 @@ def materialize_version(
     _ensure_safetensors_index(version_dir, version)
 
     if publish:
+        # Defense in depth: /publish checks the source pre-spawn, but a FULL dir
+        # here (e.g. the index generated above) or a stale base must never move
+        # the pointer.
+        _reject_full_publish_in_cpu_mode(version_dir, version)
+        if _delta_index_metadata(version_dir) is not None:
+            _reject_broken_delta_lineage(_build_store(run_id), version_dir, version)
         publish_version.local(run_id=run_id, model_dir=version_dir)
         logger.info("published version %d via stitch", version)
+    elif STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME:
+        # Make the staged dir visible to the later /publish job's container.
+        run_volume.commit()
 
     return {"version": version, "path": str(version_dir), "published": publish}
+
+
+def _default_volume_reloader() -> None:
+    """Reload the run volume's view (same guard as ``materialize_version``)."""
+    if STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME:
+        run_volume.reload()
 
 
 class PublisherServer:
@@ -220,20 +337,34 @@ class PublisherServer:
         store: Store,
         run_dir: Path,
         port: int = PUBLISHER_PORT,
+        volume_reloader: Callable[[], None] | None = None,
     ) -> None:
         self.store = store
         self.run_dir = run_dir
         self.updates_dir = _updates_dir(run_dir)
         self.port = port
+        self._volume_reloader = volume_reloader or _default_volume_reloader
         # In-memory single-writer guard. A Flash recycle resets it; the store
         # pointer's rewind guard is the durable backstop.
         self._current_job_id: str | None = None
+
+    def _refresh_volume_state(self) -> None:
+        """Reload the volume view and refresh the store BEFORE reading volume state.
+
+        The long-lived server container never reloads its volume view on its
+        own; without this, dirs staged by spawned job containers are invisible
+        to /publish and /status.
+        """
+        self._volume_reloader()
+        self.store.refresh()
 
     def _job_busy(self) -> bool:
         """True while a spawned job is still running."""
         if self._current_job_id is None:
             return False
-        if _job_state(self._current_job_id)["status"] == "pending":
+        # 'unknown' (transient poll/lookup error) keeps the guard: the job may
+        # still be running, and clearing the guard could admit a second writer.
+        if _job_state(self._current_job_id)["status"] in ("pending", "unknown"):
             return True
         self._current_job_id = None
         return False
@@ -262,6 +393,8 @@ class PublisherServer:
         @fastapi_app.post("/publish")
         async def publish(request: PublishRequest) -> Any:
             """Validate and spawn materialize+publish; 200 no-op if the pointer is already past ``version``."""
+            self._refresh_volume_state()
+            _require_own_run_id(request.run_id)
             version_dir = _version_dir(self.run_dir, request.version)
 
             # Pointer-keyed no-op: a fabricated dir must NOT mask publishing.
@@ -283,6 +416,12 @@ class PublisherServer:
                     status_code=400,
                     detail=f"source directory not found: {source_path}",
                 )
+
+            try:
+                _reject_full_publish_in_cpu_mode(source_path, request.version)
+                _reject_broken_delta_lineage(self.store, source_path, request.version)
+            except RuntimeError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
 
             job_id = self._spawn_materialize(
                 run_id=request.run_id,
@@ -309,10 +448,12 @@ class PublisherServer:
         async def status() -> StatusResponse:
             """GET /status
 
-            latest_version is the store POINTER; the on-disk dir listing is
-            exposed separately as staged_versions, so a partial dir left by a
-            recycled mid-copy container can never masquerade as latest.
+            latest_version is the store POINTER (refreshed first for cross-host
+            visibility); the on-disk dir listing is exposed separately as
+            staged_versions, so a partial dir left by a recycled mid-copy
+            container can never masquerade as latest.
             """
+            self._refresh_volume_state()
             pointer = self.store.read_pointer()
 
             staged: list[int] = []

--- a/cookbook/standalone/offline_evals/publish_app_test.py
+++ b/cookbook/standalone/offline_evals/publish_app_test.py
@@ -1,4 +1,4 @@
-"""Publisher: index generation, pointer-keyed no-op."""
+"""Publisher: index generation, pointer-keyed no-op, fleet-mixed gate."""
 
 import os
 
@@ -7,13 +7,17 @@ os.environ.setdefault("RUN_ID", "publish-app-test")
 
 import json
 import struct
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
+from modal.exception import ConnectionError as ModalConnectionError
+from modal.exception import TimeoutError as ModalTimeoutError
 
 from cookbook.standalone.offline_evals import publish_app
+from cookbook.standalone.offline_evals.publish_materialize import _target_is_valid
 from stitch.types import VersionRef
 
 
@@ -100,6 +104,18 @@ def test_prepare_version_dir(tmp_path: Path) -> None:
     assert publish_app._prepare_version_dir(target, source) == "kept"
     assert (target / "extra-note").exists()
 
+    # truncated shard with the right name is not a valid target -> recopied
+    target = tmp_path / "weight_v000005"
+    target.mkdir()
+    source_shard = source / "model.safetensors"
+    (target / "model.safetensors").write_bytes(source_shard.read_bytes()[:-4])
+    (target / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": {}})
+    )
+    assert _target_is_valid(target, source) is False
+    assert publish_app._prepare_version_dir(target, source) == "copied"
+    assert (target / "model.safetensors").stat().st_size == source_shard.stat().st_size
+
 
 class _FakeSpawn:
     """Stands in for the materialize_version Modal function's .spawn()."""
@@ -127,6 +143,10 @@ class _FakeFunctionCall:
             )  # builtins, as modal 1.5.4 actually raises
         if self.state == "failure":
             raise RuntimeError("remote boom")
+        if self.state == "query-error":
+            raise ModalConnectionError("transient poll error")
+        if self.state == "modal-timeout":
+            raise ModalTimeoutError("still running")
         return self.result
 
 
@@ -146,6 +166,8 @@ def _make_server(
     pointer: VersionRef | None = None,
     *,
     label: str | None = None,
+    volume_reloader: Callable[[], None] | None = None,
+    store: "_FakeStore | None" = None,
 ) -> publish_app.PublisherServer:
     global _server_seq
     if label is None:
@@ -154,9 +176,11 @@ def _make_server(
     run_dir = tmp_path / label
     (run_dir / "updates").mkdir(parents=True, exist_ok=True)
     return publish_app.PublisherServer(
-        store=_FakeStore(pointer),
+        store=store or _FakeStore(pointer),
         run_dir=run_dir,
         port=0,
+        # Unit tests must never invoke the real run_volume.reload() (needs Modal auth).
+        volume_reloader=volume_reloader or (lambda: None),
     )
 
 
@@ -180,9 +204,208 @@ def _assert_spawned(fake: _FakeSpawn, **expected: object) -> None:
     assert fake.calls == [{"run_id": publish_app.RUN_ID, **expected}]
 
 
+def _assert_published(published: list[dict], tmp_path: Path, version: int) -> None:
+    assert published == [
+        {
+            "run_id": publish_app.RUN_ID,
+            "model_dir": publish_app._version_dir(tmp_path / "run", version),
+        }
+    ]
+
+
+# /server_info shapes in this world: the sidecar reports the applied identity
+# string (``[run_id/]weight_vNNNNNN``), not a bare integer.
+
+
+def _make_publish_source(tmp_path: Path) -> Path:
+    source = tmp_path / "source"
+    source.mkdir(exist_ok=True)
+    _write_tiny_safetensors(source / "model.safetensors")
+    return source
+
+
+# ── cpu-mode FULL guard ──────────────────────────────────────────────────────
+
+
+def _make_delta_dir(
+    path: Path,
+    *,
+    version: int = 2,
+    base_version: int = 1,
+    shards: tuple[str, ...] = ("model-00001-of-00002.safetensors",),
+    index_shards: tuple[str, ...] = ("model-00001-of-00002.safetensors",),
+) -> Path:
+    """A staged DELTA dir: index metadata carries delta_encoding; weight_map lists
+    only the delta's own shards (a subset of any full checkpoint's shard set)."""
+    path.mkdir(parents=True, exist_ok=True)
+    for shard in shards:
+        _write_tiny_safetensors(path / shard)
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "version": version,
+                    "base_version": base_version,
+                    "delta_encoding": "xor",
+                    "compression_format": "zstd",
+                    "checksum_format": "xxh3-128",
+                },
+                "weight_map": {f"w{i}": shard for i, shard in enumerate(index_shards)},
+            }
+        )
+    )
+    return path
+
+
+def _patch_materialize_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, events: list[str]
+) -> list[dict]:
+    """Point materialize_version at a tmp RUN_DIR backed by a recording volume;
+    returns the list that publish_version.local kwargs are appended to."""
+    monkeypatch.setattr(
+        publish_app,
+        "run_volume",
+        SimpleNamespace(
+            reload=lambda: events.append("reload"),
+            commit=lambda: events.append("commit"),
+        ),
+    )
+    monkeypatch.setattr(publish_app, "RUN_DIR", tmp_path / "run")
+    monkeypatch.setattr(
+        publish_app,
+        "STORE_DEPLOYMENT",
+        SimpleNamespace(backend=publish_app.storage.MODAL_VOLUME),
+    )
+    published: list[dict] = []
+    monkeypatch.setattr(
+        publish_app,
+        "publish_version",
+        SimpleNamespace(local=lambda **kwargs: published.append(kwargs)),
+    )
+    return published
+
+
+def test_cpu_mode_full_publish_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cpu update mode is delta-only: the /publish handler rejects a FULL source
+    pre-spawn (400, no job spawned) but accepts a delta based on the current
+    pointer; a delta on any other base is rejected (a broken chain link cannot
+    be repaired in place). The spawned materialize job re-checks both guards
+    post-index, pre-pointer (RuntimeError, no publish, no staging commit) so
+    handler and job cannot drift."""
+    real_materialize = publish_app.materialize_version
+
+    # cpu mode rejects FULL sources pre-spawn but accepts a delta source.
+    monkeypatch.setattr(publish_app.exp, "SGLANG_DELTA_UPDATE_MODE", "cpu")
+    fake_spawn = _FakeSpawn("fc-cpu")
+    monkeypatch.setattr(publish_app, "materialize_version", fake_spawn)
+    client = _client(_make_server(tmp_path))
+
+    # Missing index is treated as FULL (the job would generate a non-delta index).
+    source_no_index = _make_publish_source(tmp_path)
+    resp = _publish(client, 1, str(source_no_index))
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert "cpu update mode is delta-only" in detail
+    assert "FULL version 1" in detail
+    assert "model.safetensors.index.json" in detail
+    assert fake_spawn.calls == []
+
+    # An existing index without delta_encoding is also FULL.
+    source_full_index = _make_source(tmp_path / "source-full-index")
+    resp = _publish(client, 2, str(source_full_index))
+    assert resp.status_code == 400
+    assert "FULL version 2" in resp.json()["detail"]
+    assert fake_spawn.calls == []
+
+    # A delta based on the current pointer passes both guards and spawns.
+    client = _client(_make_server(tmp_path, pointer=VersionRef("run", 2)))
+    source_delta = _make_delta_dir(tmp_path / "source-delta", version=3, base_version=2)
+    resp = _publish(client, 3, str(source_delta))
+    assert resp.status_code == 202
+    _assert_spawned(fake_spawn, version=3, source=str(source_delta), publish=True)
+
+    # A delta on any other base is rejected pre-spawn: the chain is applied in
+    # order, so a wrong-base link would wedge every stage after it.
+    poisoned = _make_delta_dir(tmp_path / "source-poisoned", version=3, base_version=0)
+    resp = _publish(client, 3, str(poisoned))
+    assert resp.status_code == 400
+    assert "base_version=0" in resp.json()["detail"]
+    assert "pointer is 2" in resp.json()["detail"]
+    assert fake_spawn.calls[1:] == [], "no job spawns on a broken-lineage delta"
+
+    # The spawned job re-checks after index stamping and before publish_version.
+    monkeypatch.setattr(publish_app, "materialize_version", real_materialize)
+    events: list[str] = []
+    published = _patch_materialize_env(monkeypatch, tmp_path, events)
+
+    full_source = _make_publish_source(tmp_path)
+    with pytest.raises(RuntimeError, match="cpu update mode is delta-only"):
+        publish_app.materialize_version.local(
+            run_id=publish_app.RUN_ID,
+            version=1,
+            source=str(full_source),
+            publish=True,
+        )
+    assert published == []
+    assert events == ["reload"], "no staging commit should run on the rejected publish"
+
+    monkeypatch.setattr(
+        publish_app, "_build_store", lambda run_id: _FakeStore(VersionRef("run", 1))
+    )
+    poisoned_source = _make_delta_dir(
+        tmp_path / "job-poisoned", version=3, base_version=0
+    )
+    with pytest.raises(RuntimeError, match="based on the current pointer"):
+        publish_app.materialize_version.local(
+            run_id=publish_app.RUN_ID,
+            version=3,
+            source=str(poisoned_source),
+            publish=True,
+        )
+    assert published == []
+
+    delta_source = _make_delta_dir(tmp_path / "delta-source", version=2, base_version=1)
+    result = publish_app.materialize_version.local(
+        run_id=publish_app.RUN_ID,
+        version=2,
+        source=str(delta_source),
+        publish=True,
+    )
+    assert result["published"] is True
+    _assert_published(published, tmp_path, 2)
+
+
+# ── Server-path volume reload ────────────────────────────────────────────────
+
+
+def _make_recording_server(
+    tmp_path: Path,
+    *,
+    label: str,
+    staged_on_reload: tuple[int, ...] = (),
+) -> tuple[publish_app.PublisherServer, "_FakeStore"]:
+    """Server whose reloader records order and exposes dirs staged elsewhere."""
+    store = _FakeStore(None)
+
+    def reloader() -> None:
+        store.calls.append("reload")
+        for version in staged_on_reload:
+            (tmp_path / label / "updates" / f"weight_v{version:06d}").mkdir(
+                exist_ok=True
+            )
+
+    server = _make_server(tmp_path, label=label, volume_reloader=reloader, store=store)
+    return server, store
+
+
 def test_publisher_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """publish -> job -> status lifecycle: status variants, pointer-keyed no-op,
-    spawn/409, and job states."""
+    spawn/409, job states, volume-reload ordering, and the mixed-fleet gate."""
+
+    # Lifecycle semantics run in disk mode; the cpu-mode FULL guard has its own test.
+    monkeypatch.setattr(publish_app.exp, "SGLANG_DELTA_UPDATE_MODE", "disk")
 
     # /status variants: latest_version is the store pointer, staged_versions the
     # weight_v* dirs on disk.
@@ -255,6 +478,30 @@ def test_publisher_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     resp = _publish(client, 2, str(source))
     assert resp.status_code == 202
 
+    # Server paths reload the volume before reading state (a sibling container
+    # may have staged dirs since this container last looked).
+    monkeypatch.setattr(publish_app, "materialize_version", _FakeSpawn("fc-reload-pub"))
+    server, store = _make_recording_server(tmp_path, label="reload-publish")
+    client = _client(server)
+    resp = _publish(client, 1, str(source))
+    assert resp.status_code == 202
+    assert store.calls == ["reload", "refresh", "refresh", "read_pointer"], (
+        "/publish reloads, then the no-op check refreshes and reads the pointer"
+    )
+
+    server, store = _make_recording_server(
+        tmp_path, label="reload-status", staged_on_reload=(7,)
+    )
+    client = _client(server)
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert resp.json()["staged_versions"] == [7], (
+        "/status reload exposes a dir staged by another container"
+    )
+    assert store.calls == ["reload", "refresh", "read_pointer"], (
+        "/status reloads before reading the pointer"
+    )
+
     _patch_job_poll(
         monkeypatch,
         {
@@ -271,3 +518,64 @@ def test_publisher_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     bad = client.get("/job/fc-failure").json()
     assert bad["status"] == "failure"
     assert "remote boom" in bad["error"]
+
+    # /job reads no volume state, so it must not invoke the reloader.
+    server, store = _make_recording_server(tmp_path, label="reload-job")
+    _patch_job_poll(monkeypatch, {"fc-job": _FakeFunctionCall("pending")})
+    client = _client(server)
+    resp = client.get("/job/fc-job")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pending"
+    assert store.calls == [], "/job never reloads the volume"
+
+
+def test_publisher_guards(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Foreign run_id rejected before spawn; volume reload/commit ordering;
+    poll timeouts and errors keep the single-writer guard."""
+    monkeypatch.setattr(publish_app.exp, "SGLANG_DELTA_UPDATE_MODE", "disk")
+    real_materialize = publish_app.materialize_version
+
+    with pytest.raises(ValueError, match="refusing to build a store"):
+        publish_app._build_store("someone-elses-run")
+
+    source = _make_publish_source(tmp_path)
+    fake_spawn = _FakeSpawn()
+    monkeypatch.setattr(publish_app, "materialize_version", fake_spawn)
+    client = _client(_make_server(tmp_path))
+    resp = _publish(client, 2, str(source), run_id="someone-elses-run")
+    assert resp.status_code == 400
+    assert "does not match" in resp.json()["detail"]
+    assert fake_spawn.calls == []
+
+    events: list[str] = []
+    published = _patch_materialize_env(monkeypatch, tmp_path, events)
+    source_dir = _make_source(tmp_path / "src-mat")
+    monkeypatch.setattr(publish_app, "materialize_version", real_materialize)
+    result = publish_app.materialize_version.local(
+        run_id=publish_app.RUN_ID, version=1, source=str(source_dir), publish=False
+    )
+    assert result["published"] is False
+    assert events == ["reload", "commit"], "staging path reloads then commits"
+
+    events.clear()
+    result = publish_app.materialize_version.local(
+        run_id=publish_app.RUN_ID, version=2, source=str(source_dir), publish=True
+    )
+    assert result["published"] is True
+    assert events == ["reload"], "publish path reloads without staging commit"
+    _assert_published(published, tmp_path, 2)
+
+    calls = {"fc-modal-to": _FakeFunctionCall("modal-timeout")}
+    _patch_job_poll(monkeypatch, calls)
+    assert publish_app._job_state("fc-modal-to")["status"] == "pending"
+
+    monkeypatch.setattr(publish_app, "materialize_version", _FakeSpawn())
+    calls = {"fc-test-1": _FakeFunctionCall("pending")}
+    _patch_job_poll(monkeypatch, calls)
+    client = _client(_make_server(tmp_path))
+    resp = _publish(client, 1, str(source))
+    assert resp.status_code == 202
+    calls["fc-test-1"].state = "query-error"
+    resp = _publish(client, 2, str(source))
+    assert resp.status_code == 409, "unknown poll keeps the single-writer guard"
+    assert "still running" in resp.json()["detail"]

--- a/cookbook/standalone/offline_evals/publish_materialize.py
+++ b/cookbook/standalone/offline_evals/publish_materialize.py
@@ -8,6 +8,7 @@ import json
 import logging
 import shutil
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,19 @@ def _version_dir(run_dir: Path, version: int) -> Path:
     return _updates_dir(run_dir) / f"weight_v{version:06d}"
 
 
+def _delta_index_metadata(version_dir: Path) -> dict[str, Any] | None:
+    """Index metadata when ``version_dir`` is a delta (``delta_encoding`` set), else None."""
+    index_path = version_dir / "model.safetensors.index.json"
+    if not index_path.is_file():
+        return None
+    try:
+        index = json.loads(index_path.read_text())
+    except json.JSONDecodeError:
+        return None
+    meta = index.get("metadata") or {}
+    return meta if meta.get("delta_encoding") else None
+
+
 def _target_is_valid(version_dir: Path, source_dir: Path) -> bool:
     """True when ``version_dir`` is a complete materialization of ``source_dir``."""
     index_path = version_dir / "model.safetensors.index.json"
@@ -27,7 +41,14 @@ def _target_is_valid(version_dir: Path, source_dir: Path) -> bool:
         return False
     source_shards = {p.name: p for p in source_dir.glob("*.safetensors")}
     target_shards = {p.name: p for p in version_dir.glob("*.safetensors")}
-    return source_shards.keys() <= target_shards.keys()
+    if not source_shards.keys() <= target_shards.keys():
+        return False
+    # Names alone are not enough: a container recycled mid-copy leaves a
+    # TRUNCATED shard with the right name. Compare sizes against the source.
+    return all(
+        target_shards[name].stat().st_size == shard.stat().st_size
+        for name, shard in source_shards.items()
+    )
 
 
 def _prepare_version_dir(version_dir: Path, source_dir: Path) -> str:


### PR DESCRIPTION
Offline-evals series 5/5, stacked on #204.

## Summary

- validate the request `run_id` against the deployment's before any spawn
- refresh the run volume at the start of every request path that reads it
- validate shard sizes against the source so a truncated copy cannot publish
- report transient job-poll errors as `unknown` without dropping the single-writer guard
- reject FULL publications into cpu-mode pools at the handler and again in the job, before the pointer moves
- reject a delta whose `base_version` is not the current store pointer (handler and job): the chain is applied in order and walks every intermediate, so one wrong-base delta would wedge every stage after it

## Validation

- `pytest src/ cookbook/ -q` at branch head (240 passed)
- guard walks incl. poisoned-base phases both sides; the volume-staleness case was reproduced live before the fix
- live-validated end to end (29k+ requests across two fleets, zero pin violations)
