### PR TITLE
[POC] cookbook: example configs for router-driven rollout pools

### DIFF
--- a/cookbook/standalone/configs/qwen3_0p6b.py
+++ b/cookbook/standalone/configs/qwen3_0p6b.py
@@ -1,0 +1,57 @@
+"""Standalone Qwen3-0.6B rollout pool: a small open model for cheap end-to-end runs.
+
+Three pinned replicas behind the offline-evals router (version-pinned placement
+plus the registry-driven rollout control loop), cpu delta updates so a publish
+is a small host-RAM staging step rather than a full reload. Use this config to
+exercise the whole launch/publish/eval flow without waiting on a large model.
+"""
+
+from __future__ import annotations
+
+from cookbook.common.config import ModalConfig
+from cookbook.common.constants import CHECKPOINTS_PATH
+
+APP_NAME = "stitch-standalone-qwen3-0p6b"
+EXPERIMENT_VOLUME_NAME = "stitch-standalone-qwen3-0p6b"
+CHECKPOINT_VOLUME_NAME = "inference-checkpoints"
+LOCAL_CHECKPOINT_PATH = None
+
+SOURCE_MODEL = "Qwen/Qwen3-0.6B"
+SOURCE_REVISION = "main"
+BASE_CHECKPOINT_PATH = CHECKPOINTS_PATH / "qwen3-0p6b"
+
+ROLLOUT_GPUS_PER_ENGINE = 1
+ROLLOUT_INPUTS_PER_ENGINE = 8
+
+SIDECAR_COMMIT_MODE = "in_place"
+SIDECAR_FLUSH_CACHE_ON_COMMIT = True
+# Opt into the offline-evals router wiring (cookbook/standalone/offline_evals/).
+OFFLINE_EVALS = True
+# The registry owns reconciliation timing: replicas never self-reconcile on the
+# sidecar's poll, only on the registry's wake.
+SIDECAR_RECONCILE_INTERVAL = 365 * 24 * 3600.0
+SGLANG_DELTA_UPDATE_MODE = "cpu"
+
+SGLANG_SERVER_ARGS = {
+    "--tp": str(ROLLOUT_GPUS_PER_ENGINE),
+    "--load-format": "auto",
+    "--dtype": "auto",
+    "--context-length": "8192",
+    # cpu delta updates stage incoming weights in host RAM.
+    "--enable-cpu-weight-cache": "",
+    "--cpu-weight-cache-max-compile-group-gb": "8",
+}
+
+modal = ModalConfig(
+    gpu="L40S",
+    routing_region="us-west",
+    rollout_min_containers=3,
+    rollout_max_containers=3,
+    # Doubles as the consolidation capacity unit: the router consolidates
+    # replicas only while the survivors can absorb this many inputs each.
+    rollout_target_inputs=ROLLOUT_INPUTS_PER_ENGINE,
+    rollout_ephemeral_disk_mib=512 * 1024,
+    rollout_memory_mib=(64 * 1024, 128 * 1024),
+    router_registry_min_containers=1,
+    router_min_containers=1,
+)

--- a/cookbook/standalone/configs_test.py
+++ b/cookbook/standalone/configs_test.py
@@ -1,0 +1,68 @@
+"""Import smoke tests for standalone experiment configs."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+CONFIG_MODULES = ("glm5_2_fp8", "glm5_2_fp8_tp4", "qwen3_0p6b")
+
+# Attributes cookbook.standalone.app reads directly off the experiment module.
+REQUIRED_ATTRS = (
+    "modal",
+    "APP_NAME",
+    "EXPERIMENT_VOLUME_NAME",
+    "CHECKPOINT_VOLUME_NAME",
+    "LOCAL_CHECKPOINT_PATH",
+    "SOURCE_MODEL",
+    "SOURCE_REVISION",
+    "BASE_CHECKPOINT_PATH",
+    "ROLLOUT_GPUS_PER_ENGINE",
+    "SIDECAR_COMMIT_MODE",
+    "SIDECAR_FLUSH_CACHE_ON_COMMIT",
+    "SGLANG_DELTA_UPDATE_MODE",
+    "SGLANG_SERVER_ARGS",
+)
+
+
+@pytest.mark.parametrize("name", CONFIG_MODULES)
+def test_config_imports_with_required_attrs(name: str) -> None:
+    exp = importlib.import_module(f"cookbook.standalone.configs.{name}")
+
+    for attr in REQUIRED_ATTRS:
+        assert hasattr(exp, attr), f"{name} is missing {attr}"
+    # app.py refuses to boot without the consolidation/autoscaler capacity unit.
+    assert exp.modal.rollout_target_inputs is not None
+
+
+def test_qwen3_0p6b_poc_shape() -> None:
+    exp = importlib.import_module("cookbook.standalone.configs.qwen3_0p6b")
+
+    # Cheap end-to-end pool: one small GPU per engine, three pinned replicas.
+    assert exp.modal.gpu == "L40S"
+    assert exp.ROLLOUT_GPUS_PER_ENGINE == 1
+    assert exp.modal.rollout_min_containers == 3
+    assert exp.modal.rollout_max_containers == 3
+    # Offline-evals wiring opted in; the registry owns reconciliation timing.
+    assert exp.OFFLINE_EVALS is True
+    assert exp.SIDECAR_RECONCILE_INTERVAL == 365 * 24 * 3600.0
+    assert exp.SGLANG_DELTA_UPDATE_MODE == "cpu"
+    assert "--enable-cpu-weight-cache" in exp.SGLANG_SERVER_ARGS
+
+
+def test_qwen3_0p6b_app_wiring(monkeypatch) -> None:
+    monkeypatch.setenv("EXPERIMENT_CONFIG", "qwen3_0p6b")
+    monkeypatch.setenv("RUN_ID", "run-42")
+    monkeypatch.delenv("STITCH_STORE_BACKEND", raising=False)
+    sys.modules.pop("cookbook.standalone.app", None)
+
+    app = importlib.import_module("cookbook.standalone.app")
+
+    assert app.APP_NAME == "stitch-standalone-qwen3-0p6b-run-42"
+    # The config's rollout_target_inputs is the router's consolidation capacity.
+    assert app.ROLLOUT_CONCURRENCY == 8
+    assert app.SGLANG_SERVER_ARGS["--max-running-requests"] == "8"
+    # OFFLINE_EVALS is set: the offline-evals wiring is active.
+    assert hasattr(app, "rollout_marks")


### PR DESCRIPTION
[POC] series 2/4, stacked on #206.

## Summary

- small-model example config for cheap end-to-end runs of the router-driven flow (manual reconcile mode, consolidation knob set)

## Validation

- `pytest src/ cookbook/ -q` at branch head (252 passed); config import smoke




