### PR TITLE
[POC] cookbook: eval orchestration walkthrough and runbook

### DIFF
--- a/cookbook/standalone/offline_evals/POC.md
+++ b/cookbook/standalone/offline_evals/POC.md
@@ -1,0 +1,168 @@
+# Standalone publish & pin POC — deployment & eval guide
+
+Continuous offline evals on one persistent pool: back-to-back checkpoint
+evals, each pinned to its own version while the router rolls the fleet
+forward. Exact commands to deploy the standalone pool, publisher, and eval
+client, from the repo root. The example config is `qwen3_0p6b` (Qwen3-0.6B,
+3×L40S, cpu delta updates) so the whole flow runs cheaply end to end.
+
+## Prerequisites
+
+- `uv` with Modal credentials configured
+- A Modal workspace you can deploy apps into
+- `EXPERIMENT_CONFIG=qwen3_0p6b` and a `RUN_ID` of your choice (the examples
+  use `RUN_ID=eval-run-1`); both env vars scope every app name and store path
+
+## Step 0: Prepare the base model (once per config)
+
+The publisher's delta fabrication anchors at the config's base checkpoint
+(`BASE_CHECKPOINT_PATH`, i.e. v0). Prep downloads and stages it:
+
+```bash
+EXPERIMENT_CONFIG=qwen3_0p6b \
+  uv run --extra modal modal run -d -m cookbook.standalone.prep_app::download_base
+```
+
+## Step 1: Deploy the inference pool (router + servers)
+
+```bash
+EXPERIMENT_CONFIG=qwen3_0p6b RUN_ID=eval-run-1 \
+  uv run --extra modal python -m cookbook.standalone.launch
+```
+
+This spins up 3 GPU Server replicas (L40S, 1 GPU each) plus the CPU-only
+RouterRegistry and Router, and prints the Router URL at the end. Save it. The
+Registry URL follows the same pattern and can be looked up with:
+
+```bash
+uv run --extra modal python -c \
+  "import modal; print(modal.Cls.from_name('stitch-standalone-qwen3-0p6b-eval-run-1', 'RouterRegistry').get_url())"
+```
+
+## Step 2: Deploy the publisher (single writer)
+
+In a separate terminal, with the same env:
+
+```bash
+EXPERIMENT_CONFIG=qwen3_0p6b RUN_ID=eval-run-1 \
+  uv run --extra modal python -c \
+  "from cookbook.standalone.offline_evals.publish_app import app; app.deploy()"
+```
+
+One publisher container (max 1, single concurrent input) mounting the same run
+volume as the pool. Save its URL for the eval client.
+
+Publisher endpoints:
+
+| Endpoint | Body / response |
+| --- | --- |
+| `POST /fabricate` | `{run_id, from_version, new_version}` → 202 `{status, job_id, version, path}`; copies the staged `from_version` dir under the new version id |
+| `POST /fabricate_delta` | `{run_id, base_version, new_version, num_tensors=4}` → 202 `{status, job_id, version, base_version, path}`; writes a small synthetic XOR delta (embed/lm_head tensors excluded) against the anchor |
+| `POST /publish` | `{run_id, version, source}` → 202 `{job_id, version, path}`; 200 `{status: "no-op"}` when the pointer is already ≥ version; 409 while a materialization job is still running; 400 on a foreign run id, a missing source, a FULL publish in cpu delta mode, or a delta not based on the current pointer |
+| `GET /job/{job_id}` | `{job_id, status: pending\|success\|failure\|unknown, result?, error?}` |
+| `GET /status` | `{latest_version, staged_versions}` — `latest_version` is the store pointer |
+
+Router / registry endpoints the client uses:
+
+| Endpoint | Contract |
+| --- | --- |
+| `POST /v1/chat/completions` | Proxied to a replica. Pin with `weight_version.exact_version` in the body AND the `stitch-exact-version` header (one value), plus one `Modal-Session-Id` per trajectory. 2xx responses carry `weight_version_start`/`weight_version_end` stamps |
+| `POST /sessions/{session_id}/end` | Session tombstone: idempotent, always 200. Ends the trajectory's pin immediately |
+| `GET /loads` (registry) | `[{task_id, upstream, load, load_stale, ready, applied_version, draining, live_sessions, active_requests}]` |
+
+## Step 3: Run the eval client
+
+The `qwen3_0p6b` config runs cpu delta mode, which is delta-only: the run is
+born at v0 (the prepped base checkpoint) and every publish is a delta, so the
+client runs with `--delta --base-version 0`:
+
+```bash
+uv run python -m cookbook.standalone.offline_evals.eval_client \
+  --router-url <ROUTER_URL> \
+  --publisher-url <PUBLISHER_URL> \
+  --registry-url <REGISTRY_URL> \
+  --run-id eval-run-1 \
+  --delta --base-version 0 \
+  --evals 3 --eval-minutes 2 --straggler-minutes 15 \
+  --sessions 6 --stragglers 2 --think-seconds 0.1 \
+  --results /tmp/eval-run-1-results.jsonl
+```
+
+`--registry-url` is optional; it enables `/loads` fleet-snapshot recording.
+
+The client runs back-to-back evals with straggler overlap:
+
+1. Sessions pinned to v0 open against the router.
+2. At each eval boundary the client calls `POST /fabricate_delta
+   {base_version: current pin, new_version: next}` and then `POST /publish`
+   for the staged dir. The boundary counts only once `GET /status` shows
+   the pointer at the new version.
+3. New sessions pin to the new version while the previous eval's straggler
+   sessions keep running on the old version until their straggler deadline.
+
+## The two core assertions
+
+Checked from the recorded metrics when the run completes (any failure aborts
+with details):
+
+1. **Pinning**: every 200 response carries both version stamps, and both equal
+   the request's pinned version. A missing stamp is a failure, not a skip.
+2. **Boundary overlap**: in every `[publish accepted, +straggler window]`
+   interval, at least one 200 was served at the old version AND at least one
+   at the new version — both versions serve concurrently during the rollout.
+
+## The session tombstone contract
+
+Each trajectory uses exactly one `Modal-Session-Id`. When the trajectory ends —
+completed or given up — the client makes a best-effort `POST
+/sessions/{session_id}/end` (one retry) so the router releases the pin
+immediately. The router's TTL is only the backstop for clients that never
+call it; sessions are expected to end by tombstone.
+
+## Expected observations
+
+1. **No version mismatch**: every request pinned to version N is served by
+   weight version N (stamps start == end == N).
+2. **Concurrent versions**: during overlap windows, old-version stragglers and
+   new-version sessions serve at the same time.
+3. **Transient 409/503 ride-out**: while a rollout is staging, pinned requests
+   may 409 (retried with capped exponential backoff) or 503 (retried after the
+   server's `Retry-After`); sessions resume once a matching replica is
+   available. Resolved streaks are recorded as gaps, not failures.
+
+## Warmup delta (cpu update mode)
+
+The first cpu-mode delta triggers a full CPU-image compile; at large-model
+scale a compile takes minutes and runs under generation pause on every replica
+simultaneously. Publish a small warmup delta right after the pool is ready and
+BEFORE opening traffic, wait for fleet convergence, then run evals with
+`--base-version <warmup version>`. The engine recompiles on each subsequent
+delta.
+
+## Operational notes
+
+Holds are enforced by routing policy: a mismatched pin reaching a held
+replica reconciles it via the stock 409 wake; the registry logs an error
+whenever a replica flips without being commanded.
+
+## Troubleshooting
+
+**Pool or publisher won't start**: check `modal app logs <app-name>`; confirm
+Step 0 completed and the run volume exists (`modal volume list`).
+
+**Eval client gets 404 on /v1/chat/completions**: confirm the Router URL and
+that the pool app is running (`modal app list`).
+
+**Straggler sessions end prematurely**: the straggler window is too short for
+the rollout's staging/compile gap — increase `--straggler-minutes` (the
+overlap assertion's window is the same duration) or slow the request rate with
+`--think-seconds`.
+
+## Teardown
+
+Stop the two apps deployed above when the run is done:
+
+```bash
+modal app stop stitch-standalone-qwen3-0p6b-eval-run-1 --yes
+modal app stop stitch-standalone-qwen3-0p6b-publisher-eval-run-1 --yes
+```

--- a/cookbook/standalone/offline_evals/eval_client.py
+++ b/cookbook/standalone/offline_evals/eval_client.py
@@ -1,4 +1,5 @@
-"""Eval client: concurrent version-pinned sessions against the router.
+"""Eval client: concurrent version-pinned sessions against the router, with
+fabricate/publish at eval boundaries and overlap assertions at the end.
 
 The pin contract: one ``pinned_version`` per eval drives both the
 ``weight_version.exact_version`` request body field and the
@@ -42,6 +43,9 @@ DEFAULT_RETRY_AFTER_SECONDS = 1.0
 # Deadline arithmetic leaves sub-nanosecond float dust in the remaining budget
 # after a capped sleep; treat anything below a microsecond as exhausted.
 BUDGET_EPSILON_SECONDS = 1e-6
+FLEET_POLL_INTERVAL_SECONDS = 10.0
+JOB_POLL_INTERVAL_SECONDS = 10.0
+PUBLISH_TIMEOUT_SECONDS = 7200.0
 
 
 def session_409_backoff_seconds(attempt: int) -> float:
@@ -74,6 +78,8 @@ class EvalClient:
     def __init__(
         self,
         router_url: str,
+        publisher_url: str,
+        run_id: str,
         num_evals: int,
         eval_minutes: int,
         straggler_minutes: int,
@@ -82,10 +88,18 @@ class EvalClient:
         think_seconds: float,
         base_version: int,
         results_path: Path,
+        registry_url: str | None = None,
+        delta: bool = False,
+        fleet_poll_interval: float = FLEET_POLL_INTERVAL_SECONDS,
+        publish_timeout_seconds: float = PUBLISH_TIMEOUT_SECONDS,
+        job_poll_interval: float = JOB_POLL_INTERVAL_SECONDS,
         request_timeout: float = 420.0,
         session_409_budget_seconds: float | None = None,
     ):
         self.router_url = router_url.rstrip("/")
+        self.publisher_url = publisher_url.rstrip("/")
+        self.registry_url = registry_url.rstrip("/") if registry_url else None
+        self.run_id = run_id
         self.num_evals = num_evals
         self.eval_duration = eval_minutes * 60
         self.straggler_duration = straggler_minutes * 60
@@ -93,7 +107,11 @@ class EvalClient:
         self.num_stragglers = num_stragglers
         self.think_seconds = think_seconds
         self.base_version = base_version
+        self.delta = delta
         self.results_path = results_path
+        self.fleet_poll_interval = fleet_poll_interval
+        self.publish_timeout_seconds = publish_timeout_seconds
+        self.job_poll_interval = job_poll_interval
         # Straggler requests must survive a paused engine: a first cpu-mode delta
         # stage pauses generation for the full image compile (minutes).
         self.request_timeout = request_timeout
@@ -112,6 +130,12 @@ class EvalClient:
         self.stamp_violations: list[dict[str, Any]] = []
         self.eval_stats: dict[int, dict[str, Any]] = {}
         self.version_stats: dict[int, int] = {}
+        self.publish_accepted_at: dict[int, float] = {}
+        # Raw registry /loads snapshots; kept OUT of self.metrics so the metrics
+        # and assertion code (which iterates RequestMetrics only) never sees them.
+        self.fleet_snapshots: list[dict[str, Any]] = []
+        self._drained_task_ids: set[str] = set()
+        self.boundary_rollout: dict[int, dict[str, Any]] = {}
         self._eval_loop_completed = False
         self._results_file: TextIOWrapper | None = None
         self._results_finalized = False
@@ -137,6 +161,153 @@ class EvalClient:
 
     def print_event(self, event: str) -> None:
         print(f"[t+{self.elapsed_str()}] {event}")
+
+    async def _post_and_poll_job(
+        self,
+        session: aiohttp.ClientSession,
+        path: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """POST a publisher job (202 + job_id) and poll ``/job/{id}``.
+
+        A 200 no-op is immediate success.
+        """
+        deadline = time.time() + self.publish_timeout_seconds
+        while True:
+            try:
+                async with session.post(
+                    f"{self.publisher_url}{path}",
+                    json=payload,
+                    timeout=aiohttp.ClientTimeout(total=60),
+                ) as resp:
+                    data = await resp.json() if resp.status in (200, 202, 409) else {}
+                    if resp.status == 200 and data.get("status") == "no-op":
+                        return data
+                    if resp.status == 202:
+                        job_id = data.get("job_id")
+                        if not job_id:
+                            logger.error("%s response missing job_id", path)
+                            return None
+                        break
+                    logger.error("%s failed: %d %s", path, resp.status, data)
+                    return None
+            except Exception as exc:
+                logger.error("%s error: %r", path, exc)
+                return None
+
+        while True:
+            await asyncio.sleep(self.job_poll_interval)
+            # Check the deadline on every iteration, including after non-200
+            # responses, poll errors, and non-terminal statuses (e.g. "unknown")
+            # that `continue` below, so an outage can't loop forever.
+            if time.time() >= deadline:
+                logger.error(
+                    "job %s (%s) not done after %.0fs; giving up",
+                    job_id,
+                    path,
+                    self.publish_timeout_seconds,
+                )
+                return None
+            try:
+                async with session.get(
+                    f"{self.publisher_url}/job/{job_id}",
+                    timeout=aiohttp.ClientTimeout(total=30),
+                ) as resp:
+                    if resp.status != 200:
+                        continue
+                    data = await resp.json()
+            except Exception:
+                continue
+            status = data.get("status")
+            if status == "success":
+                return data.get("result") or {}
+            if status == "failure":
+                logger.error("job %s (%s) failed: %s", job_id, path, data.get("error"))
+                return None
+            if time.time() >= deadline:
+                logger.error(
+                    "job %s (%s) still %s after %.0fs; giving up",
+                    job_id,
+                    path,
+                    status,
+                    self.publish_timeout_seconds,
+                )
+                return None
+
+    async def _pointer_at_least(
+        self, session: aiohttp.ClientSession, version: int
+    ) -> bool:
+        """True when /status's store pointer has advanced to `version`."""
+        try:
+            async with session.get(
+                f"{self.publisher_url}/status",
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status != 200:
+                    logger.error("/status got status %d", resp.status)
+                    return False
+                data = await resp.json()
+        except Exception as exc:
+            logger.error("/status error: %r", exc)
+            return False
+        latest = data.get("latest_version")
+        return latest is not None and latest >= version
+
+    async def fabricate_and_publish(self, version: int) -> bool:
+        """Fabricate ``version`` then publish it. True only if the job succeeds
+        and ``/status`` shows the pointer at ``version``. ``--delta`` fabricates
+        a XOR delta on the current pin (version-1); otherwise copies the base.
+        """
+        async with aiohttp.ClientSession() as session:
+            if self.delta:
+                fab = await self._post_and_poll_job(
+                    session,
+                    "/fabricate_delta",
+                    {
+                        "run_id": self.run_id,
+                        "base_version": version - 1,
+                        "new_version": version,
+                    },
+                )
+            else:
+                fab = await self._post_and_poll_job(
+                    session,
+                    "/fabricate",
+                    {
+                        "run_id": self.run_id,
+                        "from_version": self.base_version,
+                        "new_version": version,
+                    },
+                )
+            if fab is None:
+                return False
+            model_dir = fab.get("path")
+            if not model_dir:
+                logger.error("fabricate v%d result missing path", version)
+                return False
+
+            pub = await self._post_and_poll_job(
+                session,
+                "/publish",
+                {
+                    "run_id": self.run_id,
+                    "version": version,
+                    "source": model_dir,
+                },
+            )
+            if pub is None:
+                return False
+
+            # The boundary is real only when the pointer actually moved.
+            if not await self._pointer_at_least(session, version):
+                logger.error(
+                    "publish v%d job succeeded but the store pointer has not advanced",
+                    version,
+                )
+                return False
+
+        logger.info("fabricated and published version %d", version)
+        return True
 
     async def _send_request(
         self, session: aiohttp.ClientSession, session_id: str, pinned_version: int
@@ -425,14 +596,27 @@ class EvalClient:
 
         The results JSONL is opened (truncated) up front and every record is
         flushed as it is produced, so an abort leaves a valid file with all
-        records so far; the finally block always appends a terminal summary
-        carrying an ``aborted`` flag.
+        records so far; the finally block always appends the boundary-rollout
+        records and a terminal summary carrying an ``aborted`` flag.
         """
         pending_stragglers: list[asyncio.Task] = []
         self._open_results_file()
+        fleet_task: asyncio.Task | None = (
+            asyncio.create_task(self.poll_fleet()) if self.registry_url else None
+        )
         try:
             for eval_num in range(1, self.num_evals + 1):
                 pinned_version = self.base_version + eval_num - 1
+
+                if eval_num > 1:
+                    ok = await self.fabricate_and_publish(pinned_version)
+                    if not ok:
+                        raise RuntimeError(
+                            f"fabricate/publish of version {pinned_version} failed; "
+                            f"aborting run before eval {eval_num}"
+                        )
+                    self.publish_accepted_at[eval_num] = time.time()
+                    self.print_event(f"checkpoint {pinned_version} published")
 
                 main_tasks, straggler_tasks, main_deadline = self._start_sessions(
                     eval_num, pinned_version
@@ -451,6 +635,7 @@ class EvalClient:
                 await asyncio.gather(*pending_stragglers)
 
             self._eval_loop_completed = True
+            self.verify_assertions()
 
         except Exception as exc:
             logger.error("eval run failed: %r", exc, exc_info=True)
@@ -462,7 +647,110 @@ class EvalClient:
                 self.compute_stats()
             except Exception:
                 logger.exception("compute_stats failed while finalizing results")
+            try:
+                self.compute_boundary_rollout()
+            except Exception:
+                logger.exception(
+                    "compute_boundary_rollout failed while finalizing results"
+                )
             self.write_results()
+            if fleet_task is not None:
+                fleet_task.cancel()
+                await asyncio.gather(fleet_task, return_exceptions=True)
+
+    async def poll_fleet(self) -> None:
+        """Poll the registry's /loads and append fleet_snapshot records.
+
+        Snapshots carry the per-replica applied_version/draining timeline; they are
+        stored separately from request metrics and merged into the results JSONL
+        at write time under the 'fleet_snapshot' record type.
+        """
+        assert self.registry_url is not None
+        async with aiohttp.ClientSession() as session:
+            while True:
+                try:
+                    async with session.get(
+                        f"{self.registry_url}/loads",
+                        timeout=aiohttp.ClientTimeout(total=10),
+                    ) as resp:
+                        if resp.status == 200:
+                            self._record_fleet_snapshot(await resp.json())
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    pass
+                await asyncio.sleep(self.fleet_poll_interval)
+
+    def _record_fleet_snapshot(self, loads: list[dict[str, Any]]) -> None:
+        """Append a fleet_snapshot record, plus a drain_event the first time each
+        container entry shows draining truthy (one record per task_id, ever)."""
+        now = time.time()
+        self.fleet_snapshots.append({"fleet_snapshot": loads, "timestamp": now})
+        self._emit_record(self.fleet_snapshots[-1])
+        for replica in loads:
+            task_id = replica.get("task_id")
+            if (
+                replica.get("draining")
+                and task_id is not None
+                and task_id not in self._drained_task_ids
+            ):
+                self._drained_task_ids.add(task_id)
+                self.fleet_snapshots.append(
+                    {
+                        "drain_event": {
+                            "task_id": task_id,
+                            "applied_version": replica.get("applied_version"),
+                            "live_sessions": replica.get("live_sessions"),
+                            "active_requests": replica.get("active_requests"),
+                        },
+                        "timestamp": now,
+                    }
+                )
+                self._emit_record(self.fleet_snapshots[-1])
+                self.print_event(
+                    f"container {task_id} draining "
+                    f"(applied={replica.get('applied_version')} "
+                    f"live_sessions={replica.get('live_sessions')} "
+                    f"active_requests={replica.get('active_requests')})"
+                )
+
+    def compute_boundary_rollout(self) -> None:
+        """Per boundary, the earliest fleet snapshot showing the new version applied.
+
+        Recorded, NOT asserted: when the overlap assertion fails this distinguishes
+        'fleet never rolled' from 'rolled but no traffic routed'. Snapshots are
+        appended in time order, so the first match is the earliest.
+        """
+        for next_eval in range(2, self.num_evals + 1):
+            new_version = self.base_version + next_eval - 1
+            first_applied_at: float | None = None
+            for snapshot in self.fleet_snapshots:
+                if "fleet_snapshot" not in snapshot:
+                    continue
+                if any(
+                    replica.get("applied_version") == new_version
+                    for replica in snapshot["fleet_snapshot"]
+                ):
+                    first_applied_at = snapshot["timestamp"]
+                    break
+            published_at = self.publish_accepted_at.get(next_eval)
+            first_new_version_200_at: float | None = None
+            if published_at is not None:
+                for m in self.metrics:
+                    if (
+                        m.status_code == 200
+                        and m.weight_version_start == new_version
+                        and m.timestamp >= published_at
+                    ):
+                        first_new_version_200_at = m.timestamp
+                        break
+            self.boundary_rollout[new_version] = {
+                "old_version": new_version - 1,
+                "new_version": new_version,
+                "publish_accepted_at": published_at,
+                "fleet_first_applied_at": first_applied_at,
+                "first_new_version_200_at": first_new_version_200_at,
+            }
 
     def compute_stats(self) -> None:
         per_eval: dict[int, dict[str, Any]] = {}
@@ -509,12 +797,83 @@ class EvalClient:
         logger.info("per-eval stats: %s", per_eval)
         logger.info("per-version stats: %s", per_version)
 
-    def write_results(self) -> None:
-        """Emit the terminal summary record, then print the stdout summary.
+    def verify_assertions(self) -> None:
+        """Verify pinning held on every 200 and both versions served at each boundary.
 
-        Request metrics and conflict gaps are already written incrementally as
-        they are produced (see run() and eval_session), so records appear in
-        arrival order rather than sorted by timestamp — incremental writes are
+        Raises AssertionError with full details if any check fails.
+        """
+        failures: list[str] = []
+
+        # 1) Every 200 response must carry BOTH version stamps, equal to the pin.
+        #    A None stamp on a 200 is a failure, not a skip.
+        for m in self.metrics:
+            if m.status_code != 200:
+                continue
+            if m.weight_version_start is None or m.weight_version_end is None:
+                failures.append(
+                    f"200 response missing version stamp: eval={m.eval_num} "
+                    f"session={m.session_id[:8]} req={m.request_num} "
+                    f"pinned={m.pinned_version} start={m.weight_version_start} "
+                    f"end={m.weight_version_end}"
+                )
+            elif (
+                m.weight_version_start != m.pinned_version
+                or m.weight_version_end != m.pinned_version
+            ):
+                failures.append(
+                    f"pin violated: eval={m.eval_num} session={m.session_id[:8]} "
+                    f"req={m.request_num} pinned={m.pinned_version} "
+                    f"served start={m.weight_version_start} end={m.weight_version_end}"
+                )
+
+        # Overlap window: >=1 success at N_k and >=1 at N_{k+1}.
+        for next_eval in range(2, self.num_evals + 1):
+            old_version = self.base_version + next_eval - 2
+            new_version = self.base_version + next_eval - 1
+            t0 = self.publish_accepted_at.get(next_eval)
+            if t0 is None:
+                failures.append(
+                    f"boundary v{old_version}->v{new_version}: no accepted publish "
+                    f"timestamp recorded for v{new_version}"
+                )
+                continue
+            t1 = t0 + self.straggler_duration
+            window_successes = [
+                m
+                for m in self.metrics
+                if m.status_code == 200 and t0 <= m.timestamp <= t1
+            ]
+            if not any(m.weight_version_start == old_version for m in window_successes):
+                failures.append(
+                    f"boundary v{old_version}->v{new_version}: no 200 served at "
+                    f"v{old_version} in overlap window [{t0:.3f}, {t1:.3f}] "
+                    f"({self.straggler_duration:.1f}s straggler window)"
+                )
+            if not any(m.weight_version_start == new_version for m in window_successes):
+                failures.append(
+                    f"boundary v{old_version}->v{new_version}: no 200 served at "
+                    f"v{new_version} in overlap window [{t0:.3f}, {t1:.3f}] "
+                    f"({self.straggler_duration:.1f}s straggler window)"
+                )
+
+        if failures:
+            details = "\n".join(f"  - {f}" for f in failures)
+            print(f"\n[SUMMARY] ASSERTIONS FAILED ({len(failures)}):\n{details}")
+            raise AssertionError(f"eval assertions FAILED:\n{details}")
+
+        logger.info(
+            "ASSERTIONS PASSED: every 200 served its pinned version (start and end), "
+            "and every boundary had both versions serving concurrently"
+        )
+
+    def write_results(self) -> None:
+        """Emit the boundary-rollout and terminal summary records, then print the
+        stdout summary.
+
+        Request metrics, fleet snapshots/drain events, and conflict gaps are
+        already written incrementally as they are produced (see run(),
+        eval_session, _record_fleet_snapshot), so records appear in arrival
+        order rather than sorted by timestamp — incremental writes are
         naturally chronological. When called without a preceding run() (e.g.
         tests), the in-memory records are flushed first so the file is complete.
         """
@@ -525,12 +884,21 @@ class EvalClient:
             self._open_results_file()
             for metric in self.metrics:
                 self._emit_record(asdict(metric))
+            for snapshot in self.fleet_snapshots:
+                self._emit_record(snapshot)
             for gap in self.conflict_gaps:
                 self._emit_record({"conflict_gap": gap, "timestamp": gap["ended_at"]})
             for violation in self.stamp_violations:
                 self._emit_record(
                     {"stamp_violation": violation, "timestamp": violation["timestamp"]}
                 )
+        for info in self.boundary_rollout.values():
+            self._emit_record(
+                {
+                    "boundary_rollout": info,
+                    "timestamp": info["publish_accepted_at"] or self.start_time,
+                }
+            )
         self._emit_record(
             {
                 "summary": {
@@ -576,11 +944,43 @@ class EvalClient:
                     f"{gap['duration_s']:.1f}s, {gap['attempts']} attempts, "
                     f"still {gap['status']} at budget end"
                 )
+        for new_version, info in sorted(self.boundary_rollout.items()):
+            prefix = f"  boundary v{info['old_version']}->v{new_version}:"
+            published_at = info["publish_accepted_at"]
+            for at, seen, missing in (
+                (
+                    info["fleet_first_applied_at"],
+                    f"v{new_version} first seen applied in fleet",
+                    f"fleet never showed v{new_version} applied (no fleet snapshot)",
+                ),
+                (
+                    info["first_new_version_200_at"],
+                    f"first v{new_version} 200",
+                    f"no 200 served at v{new_version} after publish accept",
+                ),
+            ):
+                if at is None:
+                    print(f"{prefix} {missing}")
+                    continue
+                delay = (
+                    f"{at - published_at:.1f}s after publish accept"
+                    if published_at is not None
+                    else "publish accept time unknown"
+                )
+                print(f"{prefix} {seen} at t+{at - self.start_time:.1f}s ({delay})")
 
 
 async def main() -> None:
     parser = argparse.ArgumentParser(description="Version-pinned eval client")
     parser.add_argument("--router-url", required=True, help="Router endpoint URL")
+    parser.add_argument("--publisher-url", required=True, help="Publisher endpoint URL")
+    parser.add_argument(
+        "--registry-url",
+        default=None,
+        help="Router-registry endpoint URL; if set, poll /loads every 10s and "
+        "record fleet_snapshot records (applied_version/draining timeline)",
+    )
+    parser.add_argument("--run-id", required=True, help="Stitch run ID")
     parser.add_argument("--evals", type=int, default=3, help="Number of evals")
     parser.add_argument(
         "--eval-minutes", type=float, default=20, help="Minutes per eval"
@@ -607,7 +1007,18 @@ async def main() -> None:
         "--base-version", type=int, default=1, help="Base version number"
     )
     parser.add_argument(
+        "--delta",
+        action="store_true",
+        help="Boundaries call /fabricate_delta (base = current pin), not /fabricate",
+    )
+    parser.add_argument(
         "--results", type=Path, default=Path("eval_results.jsonl"), help="Results file"
+    )
+    parser.add_argument(
+        "--publish-timeout-seconds",
+        type=float,
+        default=PUBLISH_TIMEOUT_SECONDS,
+        help="Max seconds to poll a fabricate/publish job before aborting",
     )
     parser.add_argument(
         "--request-timeout",
@@ -628,6 +1039,9 @@ async def main() -> None:
 
     client = EvalClient(
         router_url=args.router_url,
+        publisher_url=args.publisher_url,
+        registry_url=args.registry_url,
+        run_id=args.run_id,
         num_evals=args.evals,
         eval_minutes=args.eval_minutes,
         straggler_minutes=args.straggler_minutes,
@@ -635,7 +1049,9 @@ async def main() -> None:
         num_stragglers=args.stragglers,
         think_seconds=args.think_seconds,
         base_version=args.base_version,
+        delta=args.delta,
         results_path=args.results,
+        publish_timeout_seconds=args.publish_timeout_seconds,
         request_timeout=args.request_timeout,
         session_409_budget_seconds=args.session_409_budget_seconds,
     )

--- a/cookbook/standalone/offline_evals/eval_client_test.py
+++ b/cookbook/standalone/offline_evals/eval_client_test.py
@@ -1,6 +1,7 @@
-"""Unit tests for the eval client, with mocked HTTP and sub-second durations:
-pinned sessions, 409 backoff / 503 Retry-After retry accounting, conflict-gap
-records, per-response stamp assertions, and the session tombstone contract."""
+"""Unit tests for the eval client orchestration, with mocked HTTP and
+sub-second durations: overlapping evals, 409 backoff / 503 Retry-After
+retry accounting, conflict-gap records, per-response stamp assertions,
+the session tombstone contract, and boundary assertion behavior."""
 
 import asyncio
 import json
@@ -49,24 +50,114 @@ class _FakeSession:
 
 
 class _Harness:
-    """Fake Router. Chat completions succeed, stamped with the pin; session
-    tombstones are accepted and recorded."""
+    """Fake Router + Publisher. Chat completions succeed, stamped with the
+    pin; session tombstones are accepted and recorded.
+
+    Publisher endpoints are async: POST returns 202 {job_id}, GET /job/{id}
+    reports pending (job_pending_polls times) then success/failure, and
+    GET /status reports the store pointer from the published list.
+    """
 
     def __init__(
         self,
         conflicts_before_success: int = 0,
+        publish_ok: bool = True,
+        job_pending_polls: int = 0,
+        job_fails: bool = False,
+        job_never_completes: bool = False,
+        poll_non_200: bool = False,
         chat_responder: Callable[[dict], _FakeResponse] | None = None,
     ) -> None:
         self.conflicts_remaining = conflicts_before_success
+        self.publish_ok = publish_ok
+        self.job_pending_polls = job_pending_polls
+        self.job_fails = job_fails
+        self.job_never_completes = job_never_completes
+        self.poll_non_200 = poll_non_200
         # Optional full control over /v1/chat/completions responses (e.g. 409s
         # that end based on a fake clock rather than a fixed count).
         self.chat_responder = chat_responder
         self.ended_sessions: list[str] = []
 
+        self.fabricated: list[int] = []
+        self.delta_fabricated: list[dict] = []
+        self.published: list[int] = []
+        self.publish_bodies: list[dict] = []
+        self.jobs: dict[str, dict] = {}
+        self._job_seq = 0
+
+    def _new_job(self, result: dict) -> str:
+        self._job_seq += 1
+        job_id = f"fc-{self._job_seq}"
+        self.jobs[job_id] = {"result": result, "pending": self.job_pending_polls}
+        return job_id
+
     def handle_get(self, url: str) -> _FakeResponse:
+        if url.endswith("/loads"):
+            # Replicas report the latest published version (or the base).
+            applied = max(self.published) if self.published else 1
+            return _FakeResponse(
+                200,
+                [
+                    {
+                        "task_id": f"ta-{i}",
+                        "upstream": f"h{i}:8000",
+                        "load": 1,
+                        "load_stale": False,
+                        "ready": True,
+                        "applied_version": applied,
+                        "draining": False,
+                        "live_sessions": 0,
+                        "active_requests": 1,
+                    }
+                    for i in range(3)
+                ],
+            )
+        if "/job/" in url:
+            job_id = url.rsplit("/job/", 1)[1]
+            if self.poll_non_200:
+                return _FakeResponse(503, {})
+            job = self.jobs[job_id]
+            if self.job_never_completes or job["pending"] > 0:
+                job["pending"] -= 1
+                return _FakeResponse(200, {"job_id": job_id, "status": "pending"})
+            if self.job_fails:
+                return _FakeResponse(
+                    200, {"job_id": job_id, "status": "failure", "error": "boom"}
+                )
+            return _FakeResponse(
+                200,
+                {"job_id": job_id, "status": "success", "result": job["result"]},
+            )
+        if url.endswith("/status"):
+            latest = max(self.published) if self.published else None
+            return _FakeResponse(
+                200,
+                {"latest_version": latest, "staged_versions": sorted(self.published)},
+            )
         raise AssertionError(f"unexpected GET url: {url}")
 
     def handle(self, url: str, body: dict) -> _FakeResponse:
+        if url.endswith("/fabricate"):
+            self.fabricated.append(body["new_version"])
+            job_id = self._new_job({"path": f"/fake/weight_v{body['new_version']:06d}"})
+            return _FakeResponse(202, {"status": "accepted", "job_id": job_id})
+        if url.endswith("/fabricate_delta"):
+            self.delta_fabricated.append(
+                {
+                    "base_version": body["base_version"],
+                    "new_version": body["new_version"],
+                }
+            )
+            job_id = self._new_job({"path": f"/fake/weight_v{body['new_version']:06d}"})
+            return _FakeResponse(202, {"status": "accepted", "job_id": job_id})
+        if url.endswith("/publish"):
+            if not self.publish_ok:
+                return _FakeResponse(500, {"detail": "boom"})
+            self.publish_bodies.append(body)
+            self.published.append(body["version"])
+            job_id = self._new_job({"status": "published", "version": body["version"]})
+            return _FakeResponse(202, {"status": "accepted", "job_id": job_id})
         if url.endswith("/v1/chat/completions"):
             if self.chat_responder is not None:
                 return self.chat_responder(body)
@@ -98,6 +189,8 @@ def _make_client(
 ) -> ec.EvalClient:
     kwargs = dict(
         router_url="http://router",
+        publisher_url="http://publisher",
+        run_id="test-run",
         num_evals=num_evals,
         eval_minutes=0.005,  # 0.3s main phase
         straggler_minutes=0.01,  # 0.6s straggler window
@@ -106,6 +199,7 @@ def _make_client(
         think_seconds=0.01,
         base_version=1,
         results_path=tmp_path / "results.jsonl",
+        job_poll_interval=0.01,
     )
     kwargs.update(overrides)
     return ec.EvalClient(**kwargs)  # type: ignore[arg-type]
@@ -128,6 +222,10 @@ def _cli_construct(monkeypatch, extra_argv: list[str]) -> dict:
             "eval_client",
             "--router-url",
             "http://router",
+            "--publisher-url",
+            "http://publisher",
+            "--run-id",
+            "test-run",
             *extra_argv,
         ],
     )
@@ -135,11 +233,76 @@ def _cli_construct(monkeypatch, extra_argv: list[str]) -> dict:
     return constructed
 
 
-def test_eval_409_retry_and_all_straggler_main_phase(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """409s and retries are recorded per attempt; when every session is a
-    straggler the main phase is still time-based."""
+def test_eval_orchestration(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Overlap, abort-on-publish-failure, pending jobs, delta chain, retryable
+    409, and all-stragglers still last a full main phase."""
+    harness = _Harness()
+    _patch_http(monkeypatch, harness)
+    client = _make_client(tmp_path)
+    asyncio.run(client.run())
+    assert harness.published == [2]
+    eval1_ts = [m.timestamp for m in client.metrics if m.eval_num == 1]
+    eval2_ts = [m.timestamp for m in client.metrics if m.eval_num == 2]
+    assert eval1_ts and eval2_ts
+    assert min(eval2_ts) < max(eval1_ts), "eval 2 starts while eval 1 stragglers run"
+    t0 = client.publish_accepted_at[2]
+    window = [
+        m
+        for m in client.metrics
+        if m.status_code == 200 and t0 <= m.timestamp <= t0 + client.straggler_duration
+    ]
+    served = {m.weight_version_start for m in window}
+    assert {1, 2} <= served
+    assert client.results_path.exists()
+
+    for kwargs in (
+        {"publish_ok": False},
+        {"job_fails": True},
+        {"job_never_completes": True, "timeout": 0.05},
+        {"poll_non_200": True, "timeout": 0.05},
+    ):
+        timeout = kwargs.pop("timeout", None)
+        harness = _Harness(**kwargs)
+        _patch_http(monkeypatch, harness)
+        extra = {} if timeout is None else {"publish_timeout_seconds": timeout}
+        client = _make_client(tmp_path, **extra)
+        with pytest.raises(RuntimeError, match="aborting run before eval 2"):
+            asyncio.run(client.run())
+        assert all(m.eval_num == 1 for m in client.metrics), kwargs
+        if kwargs.get("publish_retryable_409s"):
+            assert harness.published == []
+
+    harness = _Harness(job_pending_polls=2)
+    _patch_http(monkeypatch, harness)
+    client = _make_client(tmp_path)
+    asyncio.run(client.run())
+    assert harness.published == [2]
+    assert client.publish_accepted_at[2] is not None
+
+    harness = _Harness()
+    _patch_http(monkeypatch, harness)
+    client = _make_client(tmp_path, num_evals=3, base_version=0, delta=True)
+    asyncio.run(client.run())
+    assert harness.delta_fabricated == [
+        {"base_version": 0, "new_version": 1},
+        {"base_version": 1, "new_version": 2},
+    ]
+    assert harness.fabricated == []
+    assert harness.published == [1, 2]
+    for body, version in zip(harness.publish_bodies, [1, 2], strict=True):
+        assert body["source"] == f"/fake/weight_v{version:06d}"
+        assert "delta" not in body
+    for next_eval in (2, 3):
+        t0 = client.publish_accepted_at[next_eval]
+        window = [
+            m
+            for m in client.metrics
+            if m.status_code == 200
+            and t0 <= m.timestamp <= t0 + client.straggler_duration
+        ]
+        served = {m.weight_version_start for m in window}
+        assert {next_eval - 2, next_eval - 1} <= served
+
     harness = _Harness(conflicts_before_success=1)
     _patch_http(monkeypatch, harness)
     client = _make_client(tmp_path, num_evals=1, num_sessions=1, num_stragglers=0)
@@ -192,6 +355,199 @@ def test_eval_timeouts_and_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     assert constructed["request_timeout"] == 240.0
     constructed = _cli_construct(monkeypatch, [])
     assert constructed["request_timeout"] == 420.0
+
+
+def _metric(
+    ts: float,
+    eval_num: int,
+    pinned: int,
+    status: int = 200,
+    start: int | None = None,
+    end: int | None = None,
+) -> ec.RequestMetrics:
+    return ec.RequestMetrics(
+        timestamp=ts,
+        session_id="sess",
+        eval_num=eval_num,
+        pinned_version=pinned,
+        request_num=1,
+        status_code=status,
+        latency_ms=1.0,
+        weight_version_start=start,
+        weight_version_end=end,
+        is_retry=False,
+    )
+
+
+def test_eval_assertions(tmp_path: Path) -> None:
+    client = _make_client(tmp_path, num_evals=1)
+    client.metrics.append(_metric(time.time(), 1, 1, start=None, end=None))
+    with pytest.raises(AssertionError, match="missing version stamp"):
+        client.verify_assertions()
+
+    client = _make_client(tmp_path, num_evals=1)
+    client.metrics.append(_metric(time.time(), 1, 1, start=2, end=2))
+    with pytest.raises(AssertionError, match="pin violated"):
+        client.verify_assertions()
+
+    client = _make_client(tmp_path, num_evals=2)
+    t0 = time.time()
+    client.publish_accepted_at[2] = t0
+    client.metrics.append(_metric(t0 + 0.05, 2, 2, start=2, end=2))
+    with pytest.raises(AssertionError, match=r"no 200 served at v1"):
+        client.verify_assertions()
+
+    client = _make_client(tmp_path, num_evals=2)
+    t0 = time.time()
+    client.publish_accepted_at[2] = t0
+    client.metrics.append(_metric(t0 + 0.05, 1, 1, start=1, end=1))
+    with pytest.raises(AssertionError, match=r"no 200 served at v2"):
+        client.verify_assertions()
+
+    client = _make_client(tmp_path, num_evals=2)
+    t0 = time.time()
+    client.publish_accepted_at[2] = t0
+    client.metrics.append(_metric(t0 + 0.05, 1, 1, start=1, end=1))
+    client.metrics.append(_metric(t0 + 0.06, 2, 2, start=2, end=2))
+    client.verify_assertions()
+
+
+def test_eval_records(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Fleet snapshots, drain events, boundary rollout, and session deadlines."""
+    harness = _Harness()
+    _patch_http(monkeypatch, harness)
+    client = _make_client(
+        tmp_path,
+        registry_url="http://registry",
+        fleet_poll_interval=0.01,
+    )
+    asyncio.run(client.run())
+    assert client.fleet_snapshots, "poller must have recorded snapshots"
+    records = [
+        json.loads(line) for line in client.results_path.read_text().splitlines()
+    ]
+    snapshots = [r for r in records if "fleet_snapshot" in r]
+    metrics = [
+        r
+        for r in records
+        if "fleet_snapshot" not in r
+        and "boundary_rollout" not in r
+        and "drain_event" not in r
+        and "conflict_gap" not in r
+        and "summary" not in r
+    ]
+    assert snapshots, "results file must contain fleet_snapshot records"
+    assert all("timestamp" in s for s in snapshots)
+    assert len(metrics) == len(client.metrics)
+    assert sum(s["request_count"] for s in client.eval_stats.values()) == len(metrics)
+    # The terminal summary record closes out a completed run.
+    assert records[-1]["summary"]["aborted"] is False
+    assert records[-1]["summary"]["conflict_gaps"] == []
+    assert records[-1]["summary"]["eval_stats"]
+    # Boundary rollout is recorded, not asserted.
+    assert client.boundary_rollout[2]["fleet_first_applied_at"] is not None
+    boundary_records = [r for r in records if "boundary_rollout" in r]
+    assert (
+        boundary_records and boundary_records[0]["boundary_rollout"]["new_version"] == 2
+    )
+
+    client = _make_client(tmp_path, num_evals=2)
+    t0 = time.time()
+    client.publish_accepted_at[2] = t0
+    client.fleet_snapshots.append(
+        {
+            "fleet_snapshot": [
+                {
+                    "task_id": "ta-0",
+                    "upstream": "h0:8000",
+                    "load": 0,
+                    "applied_version": 1,
+                }
+            ],
+            "timestamp": t0 + 0.01,
+        }
+    )
+    client.compute_boundary_rollout()
+    assert client.boundary_rollout[2]["fleet_first_applied_at"] is None
+    assert client.boundary_rollout[2]["publish_accepted_at"] == t0
+
+    client.metrics.append(_metric(t0 - 0.5, 2, 2, start=2, end=2))
+    client.metrics.append(_metric(t0 + 0.05, 2, 1, start=1, end=1))
+    client.metrics.append(_metric(t0 + 0.10, 2, 2, start=2, end=2))
+    client.compute_boundary_rollout()
+    assert client.boundary_rollout[2]["first_new_version_200_at"] == pytest.approx(
+        t0 + 0.10
+    )
+
+    client = _make_client(tmp_path, num_evals=2)
+    t0 = time.time()
+    client.publish_accepted_at[2] = t0
+    client.metrics.append(_metric(t0 + 0.05, 2, 1, start=1, end=1))
+    client.compute_boundary_rollout()
+    assert client.boundary_rollout[2]["first_new_version_200_at"] is None
+
+    client = _make_client(tmp_path, registry_url="http://registry")
+
+    def loads(draining: bool) -> list[dict]:
+        entry: dict = {
+            "task_id": "ta-0",
+            "upstream": "h0:8000",
+            "load": 1,
+            "applied_version": 1,
+        }
+        if draining:
+            entry.update({"draining": True, "live_sessions": 2, "active_requests": 5})
+        return [entry]
+
+    client._record_fleet_snapshot(loads(draining=False))
+    client._record_fleet_snapshot(loads(draining=True))
+    client._record_fleet_snapshot(loads(draining=True))
+    events = [r for r in client.fleet_snapshots if "drain_event" in r]
+    assert len(events) == 1
+    assert events[0]["drain_event"] == {
+        "task_id": "ta-0",
+        "applied_version": 1,
+        "live_sessions": 2,
+        "active_requests": 5,
+    }
+    assert "timestamp" in events[0]
+    client.write_results()
+    records = [
+        json.loads(line) for line in client.results_path.read_text().splitlines()
+    ]
+    assert sum(1 for r in records if "drain_event" in r) == 1
+
+    # Straggler sessions run to main_deadline + straggler window; main-phase
+    # sessions stop at main_deadline.
+    client = _make_client(tmp_path, num_sessions=3, num_stragglers=2)
+    recorded: list[float] = []
+
+    async def fake_eval_session(
+        self: ec.EvalClient,
+        eval_num: int,
+        session_id: str,
+        pinned_version: int,
+        straggler_deadline: float,
+    ) -> None:
+        recorded.append(straggler_deadline)
+
+    monkeypatch.setattr(ec.EvalClient, "eval_session", fake_eval_session)
+
+    async def start() -> float:
+        main_tasks, straggler_tasks, main_deadline = client._start_sessions(1, 1)
+        assert len(straggler_tasks) == 2
+        await asyncio.gather(*main_tasks, *straggler_tasks)
+        return main_deadline
+
+    main_deadline = asyncio.run(start())
+    assert len(recorded) == 3
+    assert recorded[0] == pytest.approx(main_deadline + client.straggler_duration), (
+        "stragglers run to the end of the straggler window"
+    )
+    assert recorded[1] == pytest.approx(main_deadline + client.straggler_duration)
+    assert recorded[2] == pytest.approx(main_deadline), (
+        "main-phase sessions stop at the main-phase deadline"
+    )
 
 
 def _install_fake_clock(monkeypatch: pytest.MonkeyPatch, t0: float) -> list[float]:
@@ -463,7 +819,8 @@ def test_stamp_violation_recorded_per_response(
     harness = _Harness(chat_responder=chat_responder)
     _patch_http(monkeypatch, harness)
     client = _make_client(tmp_path, num_evals=1, num_sessions=1, num_stragglers=0)
-    asyncio.run(client.run())
+    with pytest.raises(AssertionError, match="pin violated"):
+        asyncio.run(client.run())
     assert client.stamp_violations, "every 200 was off the pin"
     assert all(v["pinned_version"] == 1 for v in client.stamp_violations)
     assert all(v["weight_version_start"] == 0 for v in client.stamp_violations)
@@ -474,3 +831,28 @@ def test_stamp_violation_recorded_per_response(
     assert len(violation_records) == len(client.stamp_violations)
     summary = next(r for r in records if "summary" in r)["summary"]
     assert len(summary["stamp_violations"]) == len(client.stamp_violations)
+
+
+def test_abort_preserves_records_and_summary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failed fabricate/publish aborts the run, but the JSONL keeps every
+    record produced so far plus a terminal summary with aborted=true."""
+    harness = _Harness(publish_ok=False)
+    _patch_http(monkeypatch, harness)
+    client = _make_client(tmp_path)
+    with pytest.raises(RuntimeError, match="aborting run before eval 2"):
+        asyncio.run(client.run())
+    assert client.results_path.exists()
+    records = [
+        json.loads(line) for line in client.results_path.read_text().splitlines()
+    ]
+    metric_records = [r for r in records if "status_code" in r]
+    assert metric_records, "eval-1 request metrics must survive the abort"
+    assert all(r["eval_num"] == 1 for r in metric_records)
+    assert len(metric_records) == len(client.metrics)
+    summary = records[-1]["summary"]
+    assert summary["aborted"] is True
+    assert summary["eval_stats"]
+    assert "version_stats" in summary
+    assert summary["conflict_gaps"] == []

--- a/cookbook/standalone/offline_evals/publish_app.py
+++ b/cookbook/standalone/offline_evals/publish_app.py
@@ -540,9 +540,6 @@ def fabricate_delta_version(
     }
 
 
-
-
-
 def _default_volume_reloader() -> None:
     """Reload the run volume's view (same guard as ``materialize_version``)."""
     if STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME:


### PR DESCRIPTION
[POC] series 4/4, stacked on #208.

## Summary

- orchestrate back-to-back evals on one pool: publish the next version at each boundary, start the next eval immediately, let stragglers finish, snapshot the fleet
- assert the core promises: every 200 served exactly its pinned version; every boundary window served both versions concurrently
- POC.md runbook for the standalone flow: launch, publisher deploy, eval run, tombstones, teardown

## Validation

- `pytest src/ cookbook/ -q` at branch head (264 passed)
- assertions passed on the predecessor's live 3-replica runs




