### PR TITLE
cookbook: Modal-native trainer autoresume without a pool redeploy

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -106,9 +106,20 @@ ready. Repeating the command creates a separate run and checkpoint lineage.
 
 #### Resume a Miles run
 
-Use the same recipe and Modal environment as the source run. A resumable point
-is the latest saved Megatron checkpoint with a matching complete Hugging Face
-export. Resume it once with:
+Recovery is automatic: the Miles trainer runs under Modal retries, and every
+attempt re-derives its resume state from the run volume — the newest saved
+Megatron checkpoint whose Hugging Face export is complete and published. A
+preempted or crashed trainer resumes on its own, without a launcher attached
+and without redeploying the pool; replicas serving abandoned versions exit and
+their replacements boot from the restored checkpoint. If the checkpoint is
+v120, the run resumes at v120 and publishes a replacement v121 next. Resume
+requires the Modal Volume store, `update_weights_interval = 1`,
+`save_interval`, `save_hf`, and optimizer/RNG checkpointing — a fresh launch
+warns when its config is not resumable, and a fresh run becomes resumable
+after its first complete Megatron/Hugging Face checkpoint pair.
+
+For a run past its retry budget, or a manual takeover, spawn a successor
+trainer with the same recipe and Modal environment as the source run:
 
 ```bash
 export EXPERIMENT_CONFIG=your_config_name
@@ -118,25 +129,15 @@ uv run --extra modal python -m cookbook.miles_disagg.launch \
   --resume-from existing_run_id
 ```
 
-The launcher keeps the existing run ID, recreates its rollout deployment, and
-resets `latest` before replacement engines load the saved checkpoint. If the
-checkpoint is v120, the run resumes at v120 and publishes a replacement v121
-next. Resume currently requires the Modal Volume store and
-`update_weights_interval = 1`.
-
-Add automatic resume to a fresh or resumed launch with:
+This cancels the run's recorded trainer call and spawns a new one against the
+deployed pool, which resumes like any retry. The pool itself is never
+redeployed here; if it was stopped (or its infra must change first), deploy it
+explicitly under the same run ID and then resume:
 
 ```bash
-uv run --extra modal python -m cookbook.miles_disagg.launch \
-  --resume-from existing_run_id \
-  --auto-resume
+EXPERIMENT_CONFIG=your_config_name RUN_ID=existing_run_id \
+  uv run --extra modal modal deploy -m cookbook.miles_disagg.app
 ```
-
-`--auto-resume` stays attached to the trainer. An unexpected exit recreates the
-same run from its newest complete checkpoint and retries until the trainer
-returns normally. Stop it with Ctrl-C. It is off by default and requires
-`save_interval`, `save_hf`, and optimizer/RNG checkpointing. A fresh run becomes
-resumable after its first complete Megatron/Hugging Face checkpoint pair.
 
 With the Modal Volume store, complete Hugging Face checkpoints also accelerate
 elastic rollout startup. When a Miles recipe saves checkpoints and updates

--- a/cookbook/common/launch.py
+++ b/cookbook/common/launch.py
@@ -47,13 +47,45 @@ def materialize_node_local_yaml(
 
 
 def deploy_pool_and_spawn(run: Any) -> Any:
-    """Deploy a run's pool, wait for it to be ready, then spawn its trainer."""
+    """Deploy a run's pool, wait for its floor, then spawn its trainer."""
+    run.app.deploy()
+    return _await_floor_and_spawn(run)
+
+
+def spawn_on_pool(run: Any) -> Any:
+    """Spawn a run's trainer on its already-deployed pool. Never deploys: a
+    missing pool fails fast with the deploy command rather than silently
+    replace a live one."""
+    if not pool_reachable(run):
+        raise SystemExit(
+            f"No deployed pool for {run.APP_NAME!r}. Deploy it first:\n"
+            f"  EXPERIMENT_CONFIG={os.environ.get('EXPERIMENT_CONFIG', '<experiment>')} "
+            f"RUN_ID={os.environ['RUN_ID']} "
+            f"uv run --extra modal modal deploy -m {run.__name__}"
+        )
+    return _await_floor_and_spawn(run)
+
+
+def _await_floor_and_spawn(run: Any) -> Any:
     from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
     from stitch.service import await_pool_ready
 
-    run.app.deploy()
     await_pool_ready(
         ModalFlashLBPool(run.APP_NAME, "Server"),
         replica_floor=run.modal_cfg.rollout_min_containers,
     )
     return run.spawn_train()
+
+
+def pool_reachable(run: Any) -> bool:
+    """Whether the run's pool gateway resolves. Only a stopped or never-deployed
+    app counts as unreachable; anything else propagates."""
+    from modal.exception import NotFoundError
+
+    from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
+
+    try:
+        ModalFlashLBPool(run.APP_NAME, "Server").gateway_url()
+    except (NotFoundError, RuntimeError):
+        return False
+    return True

--- a/cookbook/common/ray_cluster.py
+++ b/cookbook/common/ray_cluster.py
@@ -86,6 +86,33 @@ def start_ray_head(my_ip: str, n_nodes: int, *, ray_port: int) -> None:
     raise RuntimeError(f"Timed out waiting for all {n_nodes} Ray nodes to join")
 
 
+def hold_worker_node(
+    master_addr: str,
+    *,
+    ray_port: int,
+    probe_interval: float = 15.0,
+    grace_probes: int = 4,
+) -> None:
+    """Block a worker while its Ray head answers.
+
+    A worker that returns exits its single-use container and takes its Ray node
+    with it, so a worker's lifetime has to be the whole attempt's. Returning
+    once the head has gone lets the container exit on its own instead.
+    """
+    misses = 0
+    while misses < grace_probes:
+        time.sleep(probe_interval)
+        try:
+            with socket.create_connection((master_addr, ray_port), timeout=5):
+                misses = 0
+        except OSError:
+            misses += 1
+    print(
+        f"Ray head {master_addr}:{ray_port} is gone; releasing this worker node",
+        flush=True,
+    )
+
+
 def start_ray_worker(my_ip: str, master_addr: str, *, ray_port: int) -> None:
     subprocess.run(
         [

--- a/cookbook/common/smoke.py
+++ b/cookbook/common/smoke.py
@@ -56,7 +56,8 @@ def smoke_flash_pool(
             print(f"Gateway completion: {data}")
             _check_completion(data, weight_version)
             for target in pool.discover_replicas():
-                info = _get_json(f"{target}/server_info", timeout=30)
+                url, headers = pool.replica_request(target, "/server_info")
+                info = _get_json(url, headers=headers, timeout=30)
                 print(f"{target} server_info={info}")
                 _check_version(_applied_version(info), weight_version, target)
             return
@@ -118,8 +119,9 @@ def _completion(model_name: str, expected: int | None = None) -> dict:
     return payload
 
 
-def _get_json(url: str, *, timeout: float) -> dict:
-    with urllib.request.urlopen(url, timeout=timeout) as resp:
+def _get_json(url: str, *, timeout: float, headers: dict | None = None) -> dict:
+    request = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(request, timeout=timeout) as resp:
         return json.load(resp)
 
 

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -489,11 +489,11 @@ class Trainer:
             ),
             boot_version=boot_version,
         )
-        # After a restore, replicas ahead of the claimed pointer exit on its
-        # wake and are replaced, so the ready floor counts converged capacity.
+        # Replicas ahead of the claimed pointer are exiting, so they are not floor.
         await_pool_ready(
             ModalFlashLBPool(APP_NAME, "Server"),
             replica_floor=modal_cfg.rollout_min_containers,
+            latest=VersionRef(RUN_ID, boot_version),
         )
 
         resume_log = (

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -53,7 +53,7 @@ from cookbook.miles_disagg.config import YAML_CONFIG_FIELDS, MilesConfig
 from cookbook.miles_disagg.resume import (
     RESUME_POINT_ENV,
     ResumePoint,
-    saved_checkpoint_version,
+    export_version,
     wait_for_restored_pointer,
 )
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
@@ -274,10 +274,7 @@ class Server:
                         rollout_id=saved_rollout_id
                     ):
                         continue
-                    saved_version = saved_checkpoint_version(
-                        saved_rollout_id,
-                        resumed=resume_point is not None,
-                    )
+                    saved_version = export_version(saved_rollout_id)
                     if boot_version <= saved_version <= latest.version:
                         checkpoints.append((saved_version, marker.parent))
                 if checkpoints:
@@ -422,6 +419,11 @@ class Trainer:
             list(getattr(exp, "MEGATRON_RUNTIME_PATCHES", [])),
             MEGATRON_PATH,
             "Megatron patch",
+        )
+        process.apply_git_patches(
+            list(trainer_image.MILES_RUNTIME_PATCHES),
+            MILES_ROOT,
+            "Miles patch",
         )
         self.rank = rank
         process.start_host_mem_monitor()  # per-node host-RAM trace

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -27,7 +27,6 @@ import shutil
 import subprocess
 import tempfile
 from datetime import UTC, datetime
-from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
@@ -51,7 +50,7 @@ from cookbook.common.constants import (
 from cookbook.miles_disagg import trainer_image
 from cookbook.miles_disagg.config import YAML_CONFIG_FIELDS, MilesConfig
 from cookbook.miles_disagg.resume import (
-    export_version,
+    newest_complete_export,
     prepare_attempt,
     record_trainer_call,
 )
@@ -209,54 +208,7 @@ class Server:
     def startup(self) -> None:
         STORE_DEPLOYMENT.bootstrap_credentials()
         store_config = STORE_DEPLOYMENT.hook_config(APP_NAME)
-        model_name = miles_cfg.hf_checkpoint
-        boot_version = 0
-        save_hf = getattr(miles_cfg, "save_hf", None)
-        # TODO: support larger update intervals once saved checkpoints expose the
-        # exact published weight version instead of only Miles' rollout ID.
-        update_every_step = getattr(miles_cfg, "update_weights_interval", 1) == 1
-        if (
-            STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME
-            and save_hf
-            and getattr(miles_cfg, "save_interval", None) is not None
-            and update_every_step
-        ):
-            relative_path = Path(save_hf.format(rollout_id=0))
-            if relative_path.is_absolute() or ".." in relative_path.parts:
-                raise ValueError("save_hf must be a run-relative path")
-
-            # Read complete HF exports and the published pointer from one Volume
-            # snapshot. A save ahead of latest is not eligible yet.
-            run_volume.reload()
-            store = storage.create_store(
-                store_config["stitch_store_backend"],
-                local_root=RUN_DIR,
-                run_id=RUN_ID,
-                volume_name=exp.EXPERIMENT_VOLUME_NAME,
-            )
-            latest = store.read_pointer()
-            if latest is not None:
-                if latest.run_id != RUN_ID:
-                    raise ValueError(
-                        f"latest belongs to run {latest.run_id!r}, not {RUN_ID!r}"
-                    )
-                checkpoints = []
-                for marker in (RUN_DIR / relative_path.parent).glob("*/.complete"):
-                    try:
-                        saved_rollout_id = VersionRef.parse(marker.parent.name).version
-                    except ValueError:
-                        continue
-                    if marker.parent != RUN_DIR / save_hf.format(
-                        rollout_id=saved_rollout_id
-                    ):
-                        continue
-                    saved_version = export_version(saved_rollout_id)
-                    if saved_version <= latest.version:
-                        checkpoints.append((saved_version, marker.parent))
-                if checkpoints:
-                    saved_version, checkpoint = max(checkpoints)
-                    model_name = str(checkpoint)
-                    boot_version = saved_version
+        model_name, boot_version = _boot_checkpoint(store_config)
         server.serve_startup(
             self,
             model_name=model_name,
@@ -279,6 +231,39 @@ class Server:
     @modal.exit()
     def stop(self) -> None:
         server.serve_stop(self)
+
+
+def _boot_checkpoint(store_config: dict) -> tuple[str, int]:
+    """The checkpoint a replica boots and the version it serves it as: the run's
+    newest complete export at or below ``latest``, else the base checkpoint."""
+    # TODO: support larger update intervals once saved checkpoints expose the
+    # exact published weight version instead of only Miles' rollout ID.
+    if (
+        STORE_DEPLOYMENT.backend != storage.MODAL_VOLUME
+        or not (save_hf := getattr(miles_cfg, "save_hf", None))
+        or getattr(miles_cfg, "save_interval", None) is None
+        or getattr(miles_cfg, "update_weights_interval", 1) != 1
+    ):
+        return miles_cfg.hf_checkpoint, 0
+
+    # Read the exports and the pointer from one Volume snapshot; a save ahead of
+    # latest is not eligible yet.
+    run_volume.reload()
+    store = storage.create_store(
+        store_config["stitch_store_backend"],
+        local_root=RUN_DIR,
+        run_id=RUN_ID,
+        volume_name=exp.EXPERIMENT_VOLUME_NAME,
+    )
+    latest = store.read_pointer()
+    if latest is None:
+        return miles_cfg.hf_checkpoint, 0
+    if latest.run_id != RUN_ID:
+        raise ValueError(f"latest belongs to run {latest.run_id!r}, not {RUN_ID!r}")
+    export = newest_complete_export(
+        RUN_DIR, save_hf=save_hf, latest_version=latest.version
+    )
+    return (str(export[1]), export[0]) if export else (miles_cfg.hf_checkpoint, 0)
 
 
 # ── Session-routing LB (cookbook/common/router.py) ─────────────────────────────

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -51,12 +51,9 @@ from cookbook.common.constants import (
 from cookbook.miles_disagg import trainer_image
 from cookbook.miles_disagg.config import YAML_CONFIG_FIELDS, MilesConfig
 from cookbook.miles_disagg.resume import (
-    RESUME_POINT_ENV,
-    ResumePoint,
     export_version,
     prepare_attempt,
     record_trainer_call,
-    wait_for_restored_pointer,
 )
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
 from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
@@ -73,17 +70,6 @@ MILES_LOCAL_DIR = os.environ.get(
 exp = importlib.import_module(f"cookbook.miles_disagg.configs.{EXPERIMENT}")
 modal_cfg = exp.modal
 miles_cfg = exp.miles
-
-
-def _resume_point() -> ResumePoint | None:
-    if payload := os.environ.get(RESUME_POINT_ENV):
-        return ResumePoint.from_json(payload)
-    return None
-
-
-def _rollout_boot_checkpoint() -> str:
-    point = _resume_point()
-    return point.rollout_checkpoint if point is not None else miles_cfg.hf_checkpoint
 
 
 # Minted once for a run and retained across resume. The same identity scopes the
@@ -115,7 +101,6 @@ image = trainer_image.build_trainer_image(
     image_run_commands=getattr(exp, "TRAINER_IMAGE_RUN_COMMANDS", ()),
     extra_env=STORE_DEPLOYMENT.image_environment,
 )
-# Server containers re-import this module, so persist this attempt's resume point.
 server_image = serving_image.build_serving_image(
     hf_cache_path=str(HF_CACHE_PATH),
     experiment=EXPERIMENT,
@@ -123,7 +108,6 @@ server_image = serving_image.build_serving_image(
     extra_packages=STORE_DEPLOYMENT.extra_packages,
     extra_env={
         **(getattr(exp, "SGLANG_SERVER_ENV", None) or {}),
-        RESUME_POINT_ENV: os.environ.get(RESUME_POINT_ENV, ""),
         **STORE_DEPLOYMENT.image_environment,
     },
     runtime=getattr(exp, "SGLANG_RUNTIME", serving_image.DEFAULT_SGLANG_RUNTIME),
@@ -172,7 +156,7 @@ train_volumes = {
 app = modal.App(APP_NAME)
 
 SGLANG_SERVER_ARGS = {
-    "--served-model-name": _rollout_boot_checkpoint(),
+    "--served-model-name": miles_cfg.hf_checkpoint,
     **(
         {}
         if "--cuda-graph-config" in exp.SGLANG_SERVER_ARGS
@@ -225,19 +209,8 @@ class Server:
     def startup(self) -> None:
         STORE_DEPLOYMENT.bootstrap_credentials()
         store_config = STORE_DEPLOYMENT.hook_config(APP_NAME)
-        resume_point = _resume_point()
-        if resume_point is not None:
-            wait_for_restored_pointer(
-                run_volume,
-                resume_point,
-                timeout=SERVER_STARTUP_TIMEOUT,
-            )
-        model_name = (
-            resume_point.rollout_checkpoint
-            if resume_point is not None
-            else miles_cfg.hf_checkpoint
-        )
-        boot_version = resume_point.version if resume_point is not None else 0
+        model_name = miles_cfg.hf_checkpoint
+        boot_version = 0
         save_hf = getattr(miles_cfg, "save_hf", None)
         # TODO: support larger update intervals once saved checkpoints expose the
         # exact published weight version instead of only Miles' rollout ID.
@@ -278,7 +251,7 @@ class Server:
                     ):
                         continue
                     saved_version = export_version(saved_rollout_id)
-                    if boot_version <= saved_version <= latest.version:
+                    if saved_version <= latest.version:
                         checkpoints.append((saved_version, marker.parent))
                 if checkpoints:
                     saved_version, checkpoint = max(checkpoints)

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -559,7 +559,8 @@ def spawn_train() -> Any:
 @app.local_entrypoint()
 def launch_train() -> None:
     """Spawn training on a pool that's already up for this RUN. ``cookbook.miles_disagg.launch``
-    deploys + spawns in one command; use this only to re-spawn against a running pool."""
+    deploys + spawns in one command, and its ``--resume-from`` cancels the live trainer call
+    before re-spawning; this raw entrypoint does neither."""
     from modal.exception import NotFoundError
 
     try:

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -54,10 +54,13 @@ from cookbook.miles_disagg.resume import (
     RESUME_POINT_ENV,
     ResumePoint,
     export_version,
+    prepare_attempt,
+    record_trainer_call,
     wait_for_restored_pointer,
 )
 from cookbook.miles_disagg.trainer_image import MEGATRON_PATH, MILES_ROOT
 from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
+from stitch.service import await_pool_ready
 from stitch.types import VersionRef
 
 EXPERIMENT = os.environ[
@@ -394,7 +397,12 @@ _MULTINODE = miles_cfg.n_train_nodes > 1
     ephemeral_disk=modal_cfg.trainer_ephemeral_disk_mib,
     timeout=24 * 60 * MINUTES,
     startup_timeout=20 * MINUTES,
-    scaledown_window=30 * MINUTES,
+    # Modal owns the retry loop; single-use containers make every attempt a
+    # complete fresh gang, so enter() reruns and Ray bootstraps clean.
+    retries=modal.Retries(
+        max_retries=10, initial_delay=10.0, backoff_coefficient=2.0, max_delay=60.0
+    ),
+    single_use_containers=True,
     include_source=False,
     **({"experimental_options": {"efa_enabled": True}} if _MULTINODE else {}),
 )
@@ -404,8 +412,7 @@ _MULTINODE = miles_cfg.n_train_nodes > 1
     else lambda c: c
 )
 class Trainer:
-    """miles actor cluster. Ray comes up once per container in enter(), so back-to-back
-    runs reuse it."""
+    """miles actor cluster, one gang per attempt."""
 
     @modal.enter()
     def start_ray(self) -> None:
@@ -415,6 +422,7 @@ class Trainer:
         rank, master_addr, my_ip = ray_cluster.get_modal_cluster_context(
             miles_cfg.n_train_nodes
         )
+        self.master_addr = master_addr
         process.apply_git_patches(
             list(getattr(exp, "MEGATRON_RUNTIME_PATCHES", [])),
             MEGATRON_PATH,
@@ -441,20 +449,31 @@ class Trainer:
         )
 
     @modal.method()
-    def train(self, payload: dict, resume_payload: str | None = None) -> None:
-        """Run one training job from a MilesConfig payload (see MilesConfig.to_payload)."""
+    def train(self, payload: dict) -> None:
+        """Run one training attempt from a MilesConfig payload (see MilesConfig.to_payload).
+
+        Reentrant, which is the point: the payload is attempt-invariant and each
+        attempt re-derives its resume state from the run volume, so a Modal retry
+        continues the run rather than replaying the first attempt's world. Resume
+        state needs the Modal Volume store; on other backends a retry past the
+        first publish fails its claim's rewind guard instead of relabeling
+        history.
+        """
         for volume in train_volumes.values():
             volume.reload()
 
-        resume_point = (
-            ResumePoint.from_json(resume_payload)
-            if resume_payload is not None
-            else None
-        )
         cfg = MilesConfig.from_payload(payload)
         launch.materialize_node_local_yaml(cfg, "te_precision_config_file")
         if self.rank != 0:
+            # Returning here would exit this container under its Ray node.
+            ray_cluster.hold_worker_node(self.master_addr, ray_port=RAY_PORT)
             return
+
+        resume_point = None
+        if STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME:
+            resume_point = prepare_attempt(
+                run_volume, run_id=RUN_ID, save_hf=getattr(cfg, "save_hf", None)
+            )
 
         cfg.rollout_endpoint_url = ModalFlashLBPool(APP_NAME, "Server").gateway_url()
         if resume_point is not None:
@@ -496,6 +515,12 @@ class Trainer:
                 update_weight_disk_dir=cfg.update_weight_disk_dir, **custom_config
             ),
             boot_version=boot_version,
+        )
+        # After a restore, replicas ahead of the claimed pointer exit on its
+        # wake and are replaced, so the ready floor counts converged capacity.
+        await_pool_ready(
+            ModalFlashLBPool(APP_NAME, "Server"),
+            replica_floor=modal_cfg.rollout_min_containers,
         )
 
         resume_log = (
@@ -549,12 +574,11 @@ def _build_train_cmd(cfg: MilesConfig) -> str:
 # ── Entrypoints (preparation lives in a separate app: cookbook.miles_disagg.prep_app) ──
 def spawn_train() -> Any:
     """Spawn the trainer on this run's already-deployed pool (config ships as data, so config
-    edits run without a redeploy; infra changes still require one)."""
+    edits run without a redeploy; infra changes still require one). The recorded call
+    id is what a takeover cancels."""
     trainer = modal.Cls.from_name(APP_NAME, "Trainer")()
-    call = trainer.train.spawn(
-        miles_cfg.to_payload(),
-        os.environ.get(RESUME_POINT_ENV),
-    )
+    call = trainer.train.spawn(miles_cfg.to_payload())
+    record_trainer_call(run_volume, RUN_ID, call.object_id)
     print(f"Spawned train on {APP_NAME}: {call.object_id}")
     return call
 

--- a/cookbook/miles_disagg/launch.py
+++ b/cookbook/miles_disagg/launch.py
@@ -84,15 +84,21 @@ def _cancel_recorded_trainer_call(run: Any) -> None:
     call = modal.FunctionCall.from_id(call_id)
     try:
         call.cancel(terminate_containers=True)
-    except Exception as exc:  # noqa: BLE001 — a long-gone call is fine
+        print(f"Cancelled trainer call {call_id}; waiting for it to stop", flush=True)
+    except Exception as exc:  # noqa: BLE001
+        # A live call refuses cancellation during a blip exactly as a long-gone
+        # one does, and only the settle check below tells them apart.
         print(f"note: could not cancel trainer call {call_id}: {exc}", flush=True)
-        return
-    print(f"Cancelled trainer call {call_id}; waiting for it to stop", flush=True)
     # A cancelled call yields no output through .get(); only the call graph
     # shows its inputs settling.
     deadline = time.monotonic() + _CANCEL_TIMEOUT
     while time.monotonic() < deadline:
-        if all(_input_settled(node) for node in call.get_call_graph()):
+        try:
+            graph = call.get_call_graph()
+        except Exception as exc:  # noqa: BLE001 — a forgotten call has stopped
+            print(f"note: trainer call {call_id} is gone ({exc})", flush=True)
+            return
+        if all(_input_settled(node) for node in graph):
             return
         time.sleep(10)
     raise SystemExit(

--- a/cookbook/miles_disagg/launch.py
+++ b/cookbook/miles_disagg/launch.py
@@ -1,16 +1,20 @@
-"""Launch an isolated Miles/Stitch run, optionally resuming its saved checkpoint.
+"""Launch a Miles/Stitch run whose trainer retries and resumes on its own.
 
-A run's pool is a deployed Flash app the trainer reaches by name, so the run id has to be in the
-app name before either half runs — which is why deploy and launch can't be one CLI call. This
-closes that: mint the id, deploy ``app.py``'s pool under it, wait for it to be ready, then spawn
-the trainer. A resume keeps that identity and recreates the rollout deployment
-from its latest complete trainer/rollout checkpoint.
+A fresh launch mints a run id, deploys the run's pool, waits for its floor, and
+spawns the trainer. Recovery is Modal's job, not this script's: the trainer
+retries with identical input and re-derives its resume state from the run
+volume (``cookbook.miles_disagg.resume``), so nothing here supervises a running
+trainer and a live pool is never redeployed.
 
-    EXPERIMENT_CONFIG=glm45_air_fp8 uv run --extra modal python -m cookbook.miles_disagg.launch
+``--resume-from RUN_ID`` reuses a run's identity for a takeover or a run past
+its retry budget: it cancels the recorded trainer call and spawns a successor
+on the deployed pool. If the pool is gone, deploy it first under the same id:
 
-A plain script, not a ``modal run`` entrypoint: ``App.deploy()`` only persists outside a ``modal
-run`` session (inside one the deployed app is torn down with the session). Minting the id here,
-before importing the pool module, also lets the pool's app name resolve from ``RUN_ID`` at import.
+    EXPERIMENT_CONFIG=<experiment> RUN_ID=<run> uv run --extra modal modal deploy -m cookbook.miles_disagg.app
+
+A plain script, not a ``modal run`` entrypoint: ``App.deploy()`` only persists
+outside a ``modal run`` session, and minting the id before importing the pool
+module lets its app name resolve from ``RUN_ID`` at import.
 """
 
 from __future__ import annotations
@@ -18,23 +22,13 @@ from __future__ import annotations
 import argparse
 import importlib
 import os
-import subprocess
-import sys
+import time
 import uuid
-from collections.abc import MutableMapping
 from typing import Any
 
-import modal
+from cookbook.miles_disagg.resume import read_trainer_call, validate_resumable_config
 
-from cookbook.miles_disagg.resume import (
-    RESUME_POINT_ENV,
-    ResumePoint,
-    ResumePointNotFound,
-    resolve_resume_point,
-    restore_resume_point,
-    validate_auto_resume_config,
-    validate_resume_config,
-)
+_CANCEL_TIMEOUT = 10 * 60
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -42,186 +36,88 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--resume-from",
         metavar="RUN_ID",
-        help="resume RUN_ID from its latest complete Megatron/HF checkpoint pair",
-    )
-    parser.add_argument(
-        "--auto-resume",
-        action="store_true",
-        help="wait for training and recover unexpected termination from its latest checkpoint",
-    )
-    parser.add_argument(
-        "--run-attempt",
-        action="store_true",
-        help=argparse.SUPPRESS,
+        help="reuse RUN_ID; its trainer resumes from the newest complete checkpoint pair",
     )
     return parser
 
 
 def main() -> None:
     args = _parser().parse_args()
-    if args.run_attempt:
-        _run_attempt(supervise=True)
-        return
-
     experiment = os.environ["EXPERIMENT_CONFIG"]
     exp = importlib.import_module(f"cookbook.miles_disagg.configs.{experiment}")
-    if args.auto_resume:
-        _run_auto_resume(exp, args.resume_from)
-        return
+
+    from cookbook.common import launch
 
     if args.resume_from is not None:
-        validate_resume_config(exp.miles)
-        resume_point = _resume_point_for_run(exp, args.resume_from)
-        run_id = args.resume_from
+        validate_resumable_config(exp.miles)
+        os.environ["RUN_ID"] = args.resume_from
+        run = importlib.import_module("cookbook.miles_disagg.app")
+        _cancel_recorded_trainer_call(run)
+        call = launch.spawn_on_pool(run)
     else:
-        resume_point = None
-        run_id = os.environ.get("RUN_ID") or uuid.uuid4().hex[:8]
-    _set_attempt_env(
-        os.environ,
-        run_id=run_id,
-        resume_point=resume_point,
-    )
-    _run_attempt(supervise=False)
-
-
-def _run_auto_resume(exp: Any, resume_from: str | None) -> None:
-    validate_auto_resume_config(exp.miles)
-    run_id = resume_from or os.environ.get("RUN_ID") or uuid.uuid4().hex[:8]
-    resume_point = (
-        _resume_point_for_run(exp, resume_from) if resume_from is not None else None
-    )
-    while True:
-        result = _run_supervised_attempt(
-            run_id=run_id,
-            resume_point=resume_point,
-        )
-        if result.returncode == 0:
-            return
-
-        resume_point = _resume_point_after_failure(exp, run_id, resume_point)
-        print(
-            f"Trainer stopped unexpectedly; resuming run {run_id} from "
-            f"checkpoint v{resume_point.version}",
-            flush=True,
-        )
-
-
-def _resume_point_for_run(exp: Any, run_id: str) -> ResumePoint:
-    from cookbook.common import storage
-
-    if storage.StoreDeployment.from_environment().backend != storage.MODAL_VOLUME:
-        raise ValueError("Miles resume currently requires the Modal Volume store")
-    volume = modal.Volume.from_name(exp.EXPERIMENT_VOLUME_NAME, version=2)
-    resume_point = resolve_resume_point(
-        volume,
-        source_run_id=run_id,
-        save_hf=exp.miles.save_hf,
-    )
+        explicit = os.environ.get("RUN_ID")
+        os.environ["RUN_ID"] = explicit or uuid.uuid4().hex[:8]
+        _warn_unless_resumable(exp.miles)
+        run = importlib.import_module("cookbook.miles_disagg.app")
+        if explicit is not None and launch.pool_reachable(run):
+            raise SystemExit(
+                f"run {explicit!r} already has a live pool ({run.APP_NAME}); "
+                f"resume it with --resume-from {explicit}, or stop it first: "
+                f"modal app stop {run.APP_NAME}"
+            )
+        call = launch.deploy_pool_and_spawn(run)
     print(
-        f"Resolved resume checkpoint: run_id={resume_point.source_run_id}, "
-        f"version={resume_point.version}, "
-        f"trainer={resume_point.trainer_checkpoint}, "
-        f"rollout={resume_point.rollout_checkpoint}",
-        flush=True,
+        f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; trainer call {call.object_id} "
+        f"retries and resumes on its own — stop the run with: modal app stop {run.APP_NAME}"
     )
-    return resume_point
 
 
-def _resume_point_after_failure(
-    exp: Any, failed_run_id: str, previous: ResumePoint | None
-) -> ResumePoint:
+def _cancel_recorded_trainer_call(run: Any) -> None:
+    """Cancel the run's live trainer call and wait for it to stop, so a takeover
+    never briefly runs two trainers against one run."""
+    import modal
+
+    volume = modal.Volume.from_name(run.exp.EXPERIMENT_VOLUME_NAME, version=2)
+    call_id = read_trainer_call(volume, os.environ["RUN_ID"])
+    if call_id is None:
+        return
+    call = modal.FunctionCall.from_id(call_id)
     try:
-        return _resume_point_for_run(exp, failed_run_id)
-    except ResumePointNotFound:
-        if previous is None:
-            raise
+        call.cancel(terminate_containers=True)
+    except Exception as exc:  # noqa: BLE001 — a long-gone call is fine
+        print(f"note: could not cancel trainer call {call_id}: {exc}", flush=True)
+        return
+    print(f"Cancelled trainer call {call_id}; waiting for it to stop", flush=True)
+    # A cancelled call yields no output through .get(); only the call graph
+    # shows its inputs settling.
+    deadline = time.monotonic() + _CANCEL_TIMEOUT
+    while time.monotonic() < deadline:
+        if all(_input_settled(node) for node in call.get_call_graph()):
+            return
+        time.sleep(10)
+    raise SystemExit(
+        f"trainer call {call_id} did not stop within {_CANCEL_TIMEOUT}s; "
+        "retry, or cancel it in the Modal dashboard first"
+    )
+
+
+def _input_settled(node: Any) -> bool:
+    from modal.types import InputStatus
+
+    return node.status != InputStatus.PENDING and all(
+        _input_settled(child) for child in getattr(node, "children", [])
+    )
+
+
+def _warn_unless_resumable(cfg: Any) -> None:
+    try:
+        validate_resumable_config(cfg)
+    except ValueError as exc:
         print(
-            f"Run {failed_run_id} produced no newer complete checkpoint; "
-            f"retrying checkpoint v{previous.version}",
+            f"WARNING: this config is not resumable ({exc}); "
+            "a trainer retry restarts from scratch",
             flush=True,
         )
-        return previous
-
-
-def _set_attempt_env(
-    env: MutableMapping[str, str],
-    *,
-    run_id: str,
-    resume_point: ResumePoint | None,
-) -> None:
-    env["RUN_ID"] = run_id
-    if resume_point is None:
-        env.pop(RESUME_POINT_ENV, None)
-        print(f"Launching fresh run {run_id}", flush=True)
-        return
-    if resume_point.source_run_id != run_id:
-        raise ValueError(
-            f"resume checkpoint belongs to run {resume_point.source_run_id!r}, "
-            f"not {run_id!r}"
-        )
-    env[RESUME_POINT_ENV] = resume_point.to_json()
-    print(
-        f"Resuming run {run_id} from checkpoint v{resume_point.version}; "
-        f"Stitch boot={run_id}/weight_v{resume_point.version:06d}",
-        flush=True,
-    )
-
-
-def _run_supervised_attempt(
-    *, run_id: str, resume_point: ResumePoint | None
-) -> subprocess.CompletedProcess:
-    env = os.environ.copy()
-    _set_attempt_env(env, run_id=run_id, resume_point=resume_point)
-
-    return subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "cookbook.miles_disagg.launch",
-            "--run-attempt",
-        ],
-        env=env,
-        check=False,
-    )
-
-
-def _run_attempt(*, supervise: bool) -> None:
-    from cookbook.common import launch
-    from stitch.pools.modal_flash_lb_temp import ModalFlashLBPool
-    from stitch.service import await_pool_ready
-
-    run = importlib.import_module("cookbook.miles_disagg.app")
-    resume_point = (
-        ResumePoint.from_json(payload)
-        if (payload := os.environ.get(RESUME_POINT_ENV))
-        else None
-    )
-    if resume_point is None:
-        trainer_call = launch.deploy_pool_and_spawn(run)
-    else:
-        # Replacement servers block before engine startup until this pointer is
-        # restored, so none can reconcile against the abandoned suffix.
-        run.app.deploy(strategy="recreate")
-        volume = modal.Volume.from_name(run.exp.EXPERIMENT_VOLUME_NAME, version=2)
-        target = restore_resume_point(volume, resume_point)
-        print(f"Restored {target.identity}; waiting for the recreated pool", flush=True)
-        await_pool_ready(
-            ModalFlashLBPool(run.APP_NAME, "Server"),
-            replica_floor=run.modal_cfg.rollout_min_containers,
-        )
-        trainer_call = run.spawn_train()
-
-    if not supervise:
-        print(
-            f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; "
-            f"stop it with: modal app stop {run.APP_NAME}"
-        )
-        return
-    print(
-        f"run {os.environ['RUN_ID']} up on {run.APP_NAME}; "
-        "the auto-resume launcher is supervising its trainer"
-    )
-    trainer_call.get()
 
 
 if __name__ == "__main__":

--- a/cookbook/miles_disagg/launch_test.py
+++ b/cookbook/miles_disagg/launch_test.py
@@ -171,3 +171,49 @@ def test_cancel_is_a_noop_before_the_first_spawn(monkeypatch) -> None:
     monkeypatch.setattr(launch, "read_trainer_call", lambda _volume, _run_id: None)
 
     launch._cancel_recorded_trainer_call(run)  # nothing recorded: no cancel
+
+
+def test_cancel_failure_still_waits_for_the_call_to_settle(monkeypatch) -> None:
+    from modal.types import InputStatus
+
+    events: list[str] = []
+    graphs = iter(
+        [
+            [SimpleNamespace(status=InputStatus.PENDING, children=[])],
+            [SimpleNamespace(status=InputStatus.TERMINATED, children=[])],
+        ]
+    )
+
+    class _Call:
+        def cancel(self, *, terminate_containers: bool) -> None:
+            raise RuntimeError("control plane blip")
+
+        def get_call_graph(self):
+            events.append("graph")
+            return next(graphs)
+
+    run = SimpleNamespace(exp=SimpleNamespace(EXPERIMENT_VOLUME_NAME="runs"))
+    monkeypatch.setenv("RUN_ID", "old-run")
+    monkeypatch.setattr(launch.time, "sleep", lambda _s: None)
+    _patch_modal_call(monkeypatch, _Call())
+    monkeypatch.setattr(launch, "read_trainer_call", lambda _volume, _run_id: "fc-old")
+
+    launch._cancel_recorded_trainer_call(run)
+
+    assert events == ["graph", "graph"]
+
+
+def test_cancel_returns_once_the_call_is_forgotten(monkeypatch) -> None:
+    class _Call:
+        def cancel(self, *, terminate_containers: bool) -> None:
+            raise RuntimeError("no such call")
+
+        def get_call_graph(self):
+            raise RuntimeError("no such call")
+
+    run = SimpleNamespace(exp=SimpleNamespace(EXPERIMENT_VOLUME_NAME="runs"))
+    monkeypatch.setenv("RUN_ID", "old-run")
+    _patch_modal_call(monkeypatch, _Call())
+    monkeypatch.setattr(launch, "read_trainer_call", lambda _volume, _run_id: "fc-old")
+
+    launch._cancel_recorded_trainer_call(run)  # a forgotten call has stopped

--- a/cookbook/miles_disagg/launch_test.py
+++ b/cookbook/miles_disagg/launch_test.py
@@ -22,7 +22,7 @@ def test_supervised_attempt_preserves_run_id(monkeypatch) -> None:
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(launch.subprocess, "run", run)
-    point = ResumePoint(9, "old", "/trainer", "/rollout")
+    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
 
     launch._run_supervised_attempt(run_id="old", resume_point=point)
 
@@ -34,7 +34,7 @@ def test_supervised_attempt_preserves_run_id(monkeypatch) -> None:
 
 def test_auto_resume_uses_checkpoint_from_failed_attempt(monkeypatch) -> None:
     launches = []
-    point = ResumePoint(19, "first-re", "/trainer", "/rollout")
+    point = ResumePoint(19, 18, "first-re", "/trainer", "/rollout")
     monkeypatch.delenv("RUN_ID", raising=False)
     monkeypatch.setattr(launch.uuid, "uuid4", lambda: SimpleNamespace(hex="first-rest"))
     monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
@@ -55,7 +55,7 @@ def test_auto_resume_uses_checkpoint_from_failed_attempt(monkeypatch) -> None:
 
 
 def test_auto_resume_starts_from_requested_checkpoint(monkeypatch) -> None:
-    point = ResumePoint(9, "old", "/trainer", "/rollout")
+    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
     launches = []
     monkeypatch.setattr(launch.uuid, "uuid4", lambda: SimpleNamespace(hex="new"))
     monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
@@ -89,7 +89,7 @@ def test_auto_resume_honors_explicit_run_id(monkeypatch) -> None:
 
 def test_set_attempt_env_uses_one_resume_payload() -> None:
     env = {"STITCH_UNUSED": "value"}
-    point = ResumePoint(9, "old", "/trainer", "/rollout")
+    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
 
     launch._set_attempt_env(env, run_id="old", resume_point=point)
 
@@ -109,7 +109,7 @@ def test_set_attempt_env_clears_a_stale_resume_point() -> None:
 
 
 def test_set_attempt_env_rejects_cross_run_resume() -> None:
-    point = ResumePoint(9, "old", "/trainer", "/rollout")
+    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
 
     with pytest.raises(ValueError, match="belongs to run"):
         launch._set_attempt_env({}, run_id="new", resume_point=point)
@@ -117,7 +117,7 @@ def test_set_attempt_env_rejects_cross_run_resume() -> None:
 
 def test_manual_launch_runs_directly_without_attempt_subprocess(monkeypatch) -> None:
     exp = SimpleNamespace(miles=object())
-    point = ResumePoint(9, "old", "/trainer", "/rollout")
+    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
     configured = {}
     ran = []
     monkeypatch.setattr(
@@ -203,7 +203,7 @@ def test_supervised_attempt_leaves_pool_deployed_when_trainer_fails(
 
 def test_resume_restores_pointer_before_pool_readiness(monkeypatch) -> None:
     events = []
-    point = ResumePoint(9, "run", "/trainer", "/rollout")
+    point = ResumePoint(9, 8, "run", "/trainer", "/rollout")
     volume = object()
     run = SimpleNamespace(
         APP_NAME="app-run",
@@ -250,7 +250,7 @@ def test_resume_restores_pointer_before_pool_readiness(monkeypatch) -> None:
 def test_auto_resume_reuses_previous_checkpoint_when_attempt_has_no_new_checkpoint(
     monkeypatch,
 ) -> None:
-    previous = ResumePoint(9, "old", "/trainer", "/rollout")
+    previous = ResumePoint(9, 8, "old", "/trainer", "/rollout")
 
     def missing(_exp, _run_id):
         raise ResumePointNotFound("no checkpoint")

--- a/cookbook/miles_disagg/launch_test.py
+++ b/cookbook/miles_disagg/launch_test.py
@@ -1,270 +1,173 @@
 from __future__ import annotations
 
-import subprocess
 from types import SimpleNamespace
 
 import pytest
 
 from cookbook.common import launch as common_launch
 from cookbook.miles_disagg import launch
-from cookbook.miles_disagg.resume import (
-    RESUME_POINT_ENV,
-    ResumePoint,
-    ResumePointNotFound,
-)
 
 
-def test_supervised_attempt_preserves_run_id(monkeypatch) -> None:
-    captured = {}
-
-    def run(command, *, env, check):
-        captured.update(command=command, env=env, check=check)
-        return subprocess.CompletedProcess(command, 0)
-
-    monkeypatch.setattr(launch.subprocess, "run", run)
-    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
-
-    launch._run_supervised_attempt(run_id="old", resume_point=point)
-
-    assert captured["env"]["RUN_ID"] == "old"
-    assert ResumePoint.from_json(captured["env"][RESUME_POINT_ENV]) == point
-    assert captured["command"][-1] == "--run-attempt"
-    assert captured["check"] is False
+def _resumable() -> SimpleNamespace:
+    return SimpleNamespace(
+        save_interval=20,
+        save_hf="hf_checkpoints/weight_v{rollout_id:06d}",
+    )
 
 
-def test_auto_resume_uses_checkpoint_from_failed_attempt(monkeypatch) -> None:
-    launches = []
-    point = ResumePoint(19, 18, "first-re", "/trainer", "/rollout")
+def _launch(
+    monkeypatch,
+    *,
+    argv_resume_from: str | None,
+    miles: object | None = None,
+    pool_reachable: bool = False,
+) -> tuple[dict, list[str]]:
+    """Run launch.main() with the config and app modules stubbed out."""
+    spawned: dict = {}
+    prints: list[str] = []
+    exp = SimpleNamespace(miles=miles if miles is not None else _resumable())
+    run = SimpleNamespace(APP_NAME="app-run")
+
+    def import_module(name: str):
+        return exp if name.endswith(".configs.test") else run
+
+    def spawn(actual_run):
+        spawned["run"] = actual_run
+        spawned["run_id"] = launch.os.environ["RUN_ID"]
+        return SimpleNamespace(object_id="fc-1")
+
+    monkeypatch.setenv("EXPERIMENT_CONFIG", "test")
+    monkeypatch.setattr(launch.importlib, "import_module", import_module)
+    monkeypatch.setattr(common_launch, "deploy_pool_and_spawn", spawn)
+    monkeypatch.setattr(common_launch, "spawn_on_pool", spawn)
+    monkeypatch.setattr(common_launch, "pool_reachable", lambda _run: pool_reachable)
+    monkeypatch.setattr(
+        launch,
+        "_cancel_recorded_trainer_call",
+        lambda run: spawned.update(cancelled=True),
+    )
+    monkeypatch.setattr(
+        launch,
+        "_parser",
+        lambda: SimpleNamespace(
+            parse_args=lambda: SimpleNamespace(resume_from=argv_resume_from)
+        ),
+    )
+    monkeypatch.setattr(
+        "builtins.print",
+        lambda *args, **kwargs: prints.append(" ".join(map(str, args))),
+    )
+
+    launch.main()
+    return spawned, prints
+
+
+def test_fresh_launch_mints_a_run_id(monkeypatch) -> None:
     monkeypatch.delenv("RUN_ID", raising=False)
-    monkeypatch.setattr(launch.uuid, "uuid4", lambda: SimpleNamespace(hex="first-rest"))
-    monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
-    monkeypatch.setattr(launch, "_resume_point_for_run", lambda _exp, run_id: point)
+    monkeypatch.setattr(
+        launch.uuid, "uuid4", lambda: SimpleNamespace(hex="feedc0dedeadbeef")
+    )
 
-    def launch_attempt(**kwargs):
-        launches.append(kwargs)
-        return subprocess.CompletedProcess([], 1 if len(launches) == 1 else 0)
+    spawned, _prints = _launch(monkeypatch, argv_resume_from=None)
 
-    monkeypatch.setattr(launch, "_run_supervised_attempt", launch_attempt)
-
-    launch._run_auto_resume(SimpleNamespace(miles=object()), None)
-
-    assert launches == [
-        {"run_id": "first-re", "resume_point": None},
-        {"run_id": "first-re", "resume_point": point},
-    ]
+    assert spawned["run_id"] == "feedc0de"
+    assert spawned["run"].APP_NAME == "app-run"
+    assert "cancelled" not in spawned
 
 
-def test_auto_resume_starts_from_requested_checkpoint(monkeypatch) -> None:
-    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
-    launches = []
-    monkeypatch.setattr(launch.uuid, "uuid4", lambda: SimpleNamespace(hex="new"))
-    monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
-    monkeypatch.setattr(launch, "_resume_point_for_run", lambda _exp, _run_id: point)
-
-    def launch_attempt(**kwargs):
-        launches.append(kwargs)
-        return subprocess.CompletedProcess([], 0)
-
-    monkeypatch.setattr(launch, "_run_supervised_attempt", launch_attempt)
-
-    launch._run_auto_resume(SimpleNamespace(miles=object()), "old")
-
-    assert launches == [{"run_id": "old", "resume_point": point}]
-
-
-def test_auto_resume_honors_explicit_run_id(monkeypatch) -> None:
-    launches = []
+def test_fresh_launch_honors_explicit_run_id(monkeypatch) -> None:
     monkeypatch.setenv("RUN_ID", "hero-run")
-    monkeypatch.setattr(launch, "validate_auto_resume_config", lambda _cfg: None)
-    monkeypatch.setattr(
-        launch,
-        "_run_supervised_attempt",
-        lambda **kwargs: launches.append(kwargs) or subprocess.CompletedProcess([], 0),
-    )
 
-    launch._run_auto_resume(SimpleNamespace(miles=object()), None)
+    spawned, _prints = _launch(monkeypatch, argv_resume_from=None)
 
-    assert launches == [{"run_id": "hero-run", "resume_point": None}]
+    assert spawned["run_id"] == "hero-run"
 
 
-def test_set_attempt_env_uses_one_resume_payload() -> None:
-    env = {"STITCH_UNUSED": "value"}
-    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
-
-    launch._set_attempt_env(env, run_id="old", resume_point=point)
-
-    assert env == {
-        "STITCH_UNUSED": "value",
-        "RUN_ID": "old",
-        RESUME_POINT_ENV: point.to_json(),
-    }
-
-
-def test_set_attempt_env_clears_a_stale_resume_point() -> None:
-    env = {RESUME_POINT_ENV: "stale"}
-
-    launch._set_attempt_env(env, run_id="fresh", resume_point=None)
-
-    assert env == {"RUN_ID": "fresh"}
-
-
-def test_set_attempt_env_rejects_cross_run_resume() -> None:
-    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
-
-    with pytest.raises(ValueError, match="belongs to run"):
-        launch._set_attempt_env({}, run_id="new", resume_point=point)
-
-
-def test_manual_launch_runs_directly_without_attempt_subprocess(monkeypatch) -> None:
-    exp = SimpleNamespace(miles=object())
-    point = ResumePoint(9, 8, "old", "/trainer", "/rollout")
-    configured = {}
-    ran = []
-    monkeypatch.setattr(
-        launch,
-        "_parser",
-        lambda: SimpleNamespace(
-            parse_args=lambda: SimpleNamespace(
-                run_attempt=False,
-                auto_resume=False,
-                resume_from="old",
-            )
-        ),
-    )
-    monkeypatch.setenv("EXPERIMENT_CONFIG", "test")
-    monkeypatch.setattr(launch.importlib, "import_module", lambda _name: exp)
-    monkeypatch.setattr(launch, "validate_resume_config", lambda _cfg: None)
-    monkeypatch.setattr(launch, "_resume_point_for_run", lambda _exp, _run_id: point)
-    monkeypatch.setattr(
-        launch,
-        "_set_attempt_env",
-        lambda _env, **kwargs: configured.update(kwargs),
-    )
-    monkeypatch.setattr(
-        launch, "_run_attempt", lambda *, supervise: ran.append(supervise)
-    )
-    monkeypatch.setattr(
-        launch.uuid, "uuid4", lambda: SimpleNamespace(hex="newrunid-rest")
-    )
-
-    launch.main()
-
-    assert configured == {"run_id": "old", "resume_point": point}
-    assert ran == [False]
-
-
-def test_fresh_manual_launch_honors_explicit_run_id(monkeypatch) -> None:
-    configured = {}
-    monkeypatch.setattr(
-        launch,
-        "_parser",
-        lambda: SimpleNamespace(
-            parse_args=lambda: SimpleNamespace(
-                run_attempt=False,
-                auto_resume=False,
-                resume_from=None,
-            )
-        ),
-    )
-    monkeypatch.setenv("EXPERIMENT_CONFIG", "test")
+def test_fresh_launch_refuses_to_roll_over_a_live_pool(monkeypatch) -> None:
     monkeypatch.setenv("RUN_ID", "hero-run")
-    monkeypatch.setattr(
-        launch.importlib,
-        "import_module",
-        lambda _name: SimpleNamespace(miles=object()),
-    )
-    monkeypatch.setattr(
-        launch,
-        "_set_attempt_env",
-        lambda _env, **kwargs: configured.update(kwargs),
-    )
-    monkeypatch.setattr(launch, "_run_attempt", lambda *, supervise: None)
 
-    launch.main()
-
-    assert configured == {"run_id": "hero-run", "resume_point": None}
+    with pytest.raises(SystemExit, match="resume it with --resume-from"):
+        _launch(monkeypatch, argv_resume_from=None, pool_reachable=True)
 
 
-def test_supervised_attempt_leaves_pool_deployed_when_trainer_fails(
+def test_resume_cancels_the_recorded_call_and_reuses_the_run_id(monkeypatch) -> None:
+    monkeypatch.delenv("RUN_ID", raising=False)
+
+    spawned, _prints = _launch(monkeypatch, argv_resume_from="old-run")
+
+    assert spawned["run_id"] == "old-run"
+    assert spawned["cancelled"] is True
+
+
+def test_resume_requires_a_resumable_config(monkeypatch) -> None:
+    with pytest.raises(ValueError, match="requires save_hf"):
+        _launch(
+            monkeypatch,
+            argv_resume_from="old-run",
+            miles=SimpleNamespace(save_interval=20, save_hf=None),
+        )
+
+
+def test_fresh_launch_warns_but_proceeds_without_a_resumable_config(
     monkeypatch,
 ) -> None:
-    run = SimpleNamespace(APP_NAME="app")
-    monkeypatch.setattr(launch.importlib, "import_module", lambda _name: run)
-    monkeypatch.delenv(RESUME_POINT_ENV, raising=False)
+    monkeypatch.setenv("RUN_ID", "smoke")
 
-    def fail(_run):
-        raise RuntimeError("not ready")
-
-    monkeypatch.setattr(common_launch, "deploy_pool_and_spawn", fail)
-
-    with pytest.raises(RuntimeError, match="not ready"):
-        launch._run_attempt(supervise=True)
-
-
-def test_resume_restores_pointer_before_pool_readiness(monkeypatch) -> None:
-    events = []
-    point = ResumePoint(9, 8, "run", "/trainer", "/rollout")
-    volume = object()
-    run = SimpleNamespace(
-        APP_NAME="app-run",
-        modal_cfg=SimpleNamespace(rollout_min_containers=2),
-        exp=SimpleNamespace(EXPERIMENT_VOLUME_NAME="runs"),
-        app=SimpleNamespace(
-            deploy=lambda *, strategy: events.append(("deploy", strategy))
-        ),
-        spawn_train=lambda: events.append(("spawn",)) or object(),
-    )
-    monkeypatch.setenv("RUN_ID", "run")
-    monkeypatch.setenv(RESUME_POINT_ENV, point.to_json())
-    monkeypatch.setattr(launch.importlib, "import_module", lambda _name: run)
-    monkeypatch.setattr(
-        launch.modal.Volume, "from_name", lambda *_args, **_kwargs: volume
-    )
-    monkeypatch.setattr(
-        launch,
-        "restore_resume_point",
-        lambda actual_volume, actual_point: (
-            events.append(("restore", actual_volume, actual_point))
-            or SimpleNamespace(identity="run/weight_v000009")
-        ),
+    spawned, prints = _launch(
+        monkeypatch,
+        argv_resume_from=None,
+        miles=SimpleNamespace(save_interval=None, save_hf=None),
     )
 
-    import stitch.service
+    assert spawned["run_id"] == "smoke"
+    assert any("not resumable" in line for line in prints)
+
+
+def _patch_modal_call(monkeypatch, call: object) -> None:
+    import modal
 
     monkeypatch.setattr(
-        stitch.service,
-        "await_pool_ready",
-        lambda _pool, **_kwargs: events.append(("ready",)),
+        modal.Volume, "from_name", classmethod(lambda *_args, **_kwargs: object())
+    )
+    monkeypatch.setattr(
+        modal.FunctionCall, "from_id", classmethod(lambda *_args, **_kwargs: call)
     )
 
-    launch._run_attempt(supervise=False)
 
-    assert events == [
-        ("deploy", "recreate"),
-        ("restore", volume, point),
-        ("ready",),
-        ("spawn",),
-    ]
+def test_cancel_waits_until_the_call_settles(monkeypatch) -> None:
+    from modal.types import InputStatus
+
+    events: list[str] = []
+    graphs = iter(
+        [
+            [SimpleNamespace(status=InputStatus.PENDING, children=[])],
+            [SimpleNamespace(status=InputStatus.FAILURE, children=[])],
+        ]
+    )
+
+    class _Call:
+        def cancel(self, *, terminate_containers: bool) -> None:
+            events.append(f"cancel(terminate={terminate_containers})")
+
+        def get_call_graph(self):
+            events.append("graph")
+            return next(graphs)
+
+    run = SimpleNamespace(exp=SimpleNamespace(EXPERIMENT_VOLUME_NAME="runs"))
+    monkeypatch.setenv("RUN_ID", "old-run")
+    monkeypatch.setattr(launch.time, "sleep", lambda _s: None)
+    _patch_modal_call(monkeypatch, _Call())
+    monkeypatch.setattr(launch, "read_trainer_call", lambda _volume, _run_id: "fc-old")
+
+    launch._cancel_recorded_trainer_call(run)
+
+    assert events == ["cancel(terminate=True)", "graph", "graph"]
 
 
-def test_auto_resume_reuses_previous_checkpoint_when_attempt_has_no_new_checkpoint(
-    monkeypatch,
-) -> None:
-    previous = ResumePoint(9, 8, "old", "/trainer", "/rollout")
+def test_cancel_is_a_noop_before_the_first_spawn(monkeypatch) -> None:
+    run = SimpleNamespace(exp=SimpleNamespace(EXPERIMENT_VOLUME_NAME="runs"))
+    monkeypatch.setenv("RUN_ID", "old-run")
+    _patch_modal_call(monkeypatch, None)
+    monkeypatch.setattr(launch, "read_trainer_call", lambda _volume, _run_id: None)
 
-    def missing(_exp, _run_id):
-        raise ResumePointNotFound("no checkpoint")
-
-    monkeypatch.setattr(launch, "_resume_point_for_run", missing)
-
-    assert launch._resume_point_after_failure(object(), "failed", previous) == previous
-
-
-def test_auto_resume_requires_a_checkpoint_before_first_retry(monkeypatch) -> None:
-    def missing(_exp, _run_id):
-        raise ResumePointNotFound("no checkpoint")
-
-    monkeypatch.setattr(launch, "_resume_point_for_run", missing)
-
-    with pytest.raises(ValueError, match="no checkpoint"):
-        launch._resume_point_after_failure(object(), "failed", None)
+    launch._cancel_recorded_trainer_call(run)  # nothing recorded: no cancel

--- a/cookbook/miles_disagg/patches/miles-seed-baseline-scalars.patch
+++ b/cookbook/miles_disagg/patches/miles-seed-baseline-scalars.patch
@@ -1,0 +1,14 @@
+diff --git a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
+index 42619b1d..f3f1408e 100644
+--- a/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
++++ b/miles/backends/megatron_utils/update_weight/update_weight_from_distributed/delta.py
+@@ -170,7 +170,8 @@ class UpdateWeightFromDiskDelta(DistBucketedWeightUpdateMixin):
+                 except KeyError as exc:
+                     raise ValueError(f"Trainer emitted unsupported dtype {tensor.dtype} for {name!r}") from exc
+                 if resumed_external:
+-                    baseline = tensor.detach().cpu().contiguous().view(torch.uint8).numpy().reshape(-1).copy()
++                    # Flatten first: a 0-dim tensor cannot dtype-view.
++                    baseline = tensor.detach().reshape(-1).cpu().contiguous().view(torch.uint8).numpy().copy()
+                 else:
+                     try:
+                         baseline = read_hf(

--- a/cookbook/miles_disagg/patches/miles-stable-weight-versions.patch
+++ b/cookbook/miles_disagg/patches/miles-stable-weight-versions.patch
@@ -1,0 +1,21 @@
+diff --git a/miles/backends/megatron_utils/actor.py b/miles/backends/megatron_utils/actor.py
+index 9a4c9650..980446e6 100644
+--- a/miles/backends/megatron_utils/actor.py
++++ b/miles/backends/megatron_utils/actor.py
+@@ -276,10 +276,12 @@ class MegatronTrainRayActor(TrainRayActor):
+ 
+                 update_weight_cls = UpdateWeightFromDiskDelta
+                 if getattr(args, "rollout_endpoint_url", None):
+-                    # The opaque fleet boots the loaded checkpoint under its
+-                    # checkpoint iteration. Continue that service-owned version
+-                    # namespace; the next delta publication increments it.
+-                    update_weight_kwargs["initial_weight_version"] = max(0, loaded_rollout_id)
++                    # The opaque fleet boots a loaded checkpoint under the version
++                    # it was published as: iteration + 1. A fresh actor reports
++                    # iteration 0 and starts the namespace at 0.
++                    update_weight_kwargs["initial_weight_version"] = (
++                        loaded_rollout_id + 1 if loaded_rollout_id > 0 else 0
++                    )
+             else:
+                 # Mooncake loads its RDMA shared libraries at import time.
+                 # Broadcast and disk-delta must not depend on a compatible

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import re
-import time
 from dataclasses import asdict, dataclass
 from io import BytesIO
 from pathlib import PurePosixPath
@@ -244,40 +243,6 @@ def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:
             f"{point.source_run_id}/checkpoints/latest_checkpointed_iteration.txt",
         )
     return target
-
-
-def wait_for_restored_pointer(
-    volume: Any,
-    point: ResumePoint,
-    *,
-    timeout: float,
-) -> VersionRef:
-    """Block engine startup until the launcher has restored this run's pointer."""
-    target = VersionRef(point.source_run_id, point.version)
-    pointer_path = f"{point.source_run_id}/latest"
-    deadline = time.monotonic() + timeout
-    current = None
-    while time.monotonic() < deadline:
-        volume.reload()
-        try:
-            current = VersionRef.parse(
-                _read_volume_file(volume, pointer_path).decode().strip()
-            )
-        except FileNotFoundError:
-            current = None
-        if current == target:
-            return target
-        if current is not None and (
-            current.run_id != target.run_id or current.version < target.version
-        ):
-            raise ValueError(
-                f"cannot boot {target.identity!r} from {current.identity!r}"
-            )
-        time.sleep(1)
-    actual = current.identity if current is not None else "<unset>"
-    raise TimeoutError(
-        f"latest was not restored to {target.identity}; observed {actual}"
-    )
 
 
 def _validate_save_hf_template(value: str | None) -> str:

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -14,6 +14,7 @@ from cookbook.common.constants import STITCH_PATH
 from stitch.types import WEIGHT_PREFIX, VersionRef
 
 RESUME_POINT_ENV = "STITCH_RESUME_POINT"
+TRAINER_CALL_FILE = "trainer_call_id"
 
 
 class ResumePointNotFound(ValueError):
@@ -161,6 +162,57 @@ def _check_published_version(
     published = int((index.get("metadata") or {})["version"])
     if published != version:
         raise ValueError(f"{index_path} identifies v{published}, not v{version}")
+
+
+def prepare_attempt(
+    volume: Any, *, run_id: str, save_hf: str | None
+) -> ResumePoint | None:
+    """Restore and return one trainer attempt's resume point, or rewind to the
+    boot version and return None when the run has no complete pair yet.
+
+    Every attempt calls this with identical inputs: that is what makes the
+    first attempt, a retry, and a manual re-spawn one path.
+    """
+    try:
+        point = resolve_resume_point(volume, source_run_id=run_id, save_hf=save_hf)
+    except ResumePointNotFound:
+        restore_boot_pointer(volume, run_id)
+        return None
+    restore_resume_point(volume, point)
+    return point
+
+
+def restore_boot_pointer(volume: Any, run_id: str) -> None:
+    """Rewind ``latest`` to the boot version when a run has nothing to resume."""
+    pointer_path = f"{run_id}/latest"
+    try:
+        current = VersionRef.parse(
+            _read_volume_file(volume, pointer_path).decode().strip()
+        )
+    except FileNotFoundError:
+        return  # nothing claimed yet; the attempt's own claim writes v0
+    if current.run_id != run_id:
+        raise ValueError(f"latest belongs to run {current.run_id!r}, not {run_id!r}")
+    if current.version == 0:
+        return
+    with volume.batch_upload(force=True) as upload:
+        upload.put_file(BytesIO(VersionRef(run_id, 0).identity.encode()), pointer_path)
+
+
+def record_trainer_call(volume: Any, run_id: str, call_id: str) -> None:
+    """Record the run's active trainer call, so a takeover can cancel it."""
+    with volume.batch_upload(force=True) as upload:
+        upload.put_file(BytesIO(call_id.encode()), f"{run_id}/{TRAINER_CALL_FILE}")
+
+
+def read_trainer_call(volume: Any, run_id: str) -> str | None:
+    """Return the run's recorded trainer call id, or None before the first spawn."""
+    try:
+        return (
+            _read_volume_file(volume, f"{run_id}/{TRAINER_CALL_FILE}").decode().strip()
+        )
+    except FileNotFoundError:
+        return None
 
 
 def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from io import BytesIO
 from pathlib import PurePosixPath
 from typing import Any
@@ -12,7 +12,6 @@ from typing import Any
 from cookbook.common.constants import STITCH_PATH
 from stitch.types import WEIGHT_PREFIX, VersionRef
 
-RESUME_POINT_ENV = "STITCH_RESUME_POINT"
 TRAINER_CALL_FILE = "trainer_call_id"
 
 
@@ -31,20 +30,6 @@ class ResumePoint:
     trainer_checkpoint: str
     rollout_checkpoint: str
 
-    def to_json(self) -> str:
-        return json.dumps(asdict(self), separators=(",", ":"), sort_keys=True)
-
-    @classmethod
-    def from_json(cls, value: str) -> ResumePoint:
-        data = json.loads(value)
-        return cls(
-            version=int(data["version"]),
-            iteration=int(data["iteration"]),
-            source_run_id=str(data["source_run_id"]),
-            trainer_checkpoint=str(data["trainer_checkpoint"]),
-            rollout_checkpoint=str(data["rollout_checkpoint"]),
-        )
-
 
 def export_version(iteration: int) -> int:
     """The published weight version of the export saved at ``iteration``.
@@ -55,15 +40,15 @@ def export_version(iteration: int) -> int:
     return iteration + 1
 
 
-def validate_auto_resume_config(cfg: Any) -> None:
-    """Require an explicit, resumable checkpoint policy before automatic resume."""
+def validate_resumable_config(cfg: Any) -> None:
+    """Require the checkpoint policy a trainer retry needs to resume a run."""
     validate_resume_config(cfg)
     if (interval := getattr(cfg, "save_interval", None)) is None or int(interval) <= 0:
-        raise ValueError("--auto-resume requires a positive save_interval")
+        raise ValueError("resume requires a positive save_interval")
     if getattr(cfg, "no_save_optim", False):
-        raise ValueError("--auto-resume requires optimizer checkpointing")
+        raise ValueError("resume requires optimizer checkpointing")
     if getattr(cfg, "no_save_rng", False):
-        raise ValueError("--auto-resume requires RNG checkpointing")
+        raise ValueError("resume requires RNG checkpointing")
 
 
 def validate_resume_config(cfg: Any) -> None:

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -11,7 +11,7 @@ from pathlib import PurePosixPath
 from typing import Any
 
 from cookbook.common.constants import STITCH_PATH
-from stitch.types import VersionRef
+from stitch.types import WEIGHT_PREFIX, VersionRef
 
 RESUME_POINT_ENV = "STITCH_RESUME_POINT"
 
@@ -22,9 +22,11 @@ class ResumePointNotFound(ValueError):
 
 @dataclass(frozen=True)
 class ResumePoint:
-    """One paired trainer/rollout checkpoint produced by a run."""
+    """One paired trainer/rollout checkpoint produced by a run: the export's
+    published ``version`` and the Megatron ``iteration`` that produced it."""
 
     version: int
+    iteration: int
     source_run_id: str
     trainer_checkpoint: str
     rollout_checkpoint: str
@@ -37,20 +39,20 @@ class ResumePoint:
         data = json.loads(value)
         return cls(
             version=int(data["version"]),
+            iteration=int(data["iteration"]),
             source_run_id=str(data["source_run_id"]),
             trainer_checkpoint=str(data["trainer_checkpoint"]),
             rollout_checkpoint=str(data["rollout_checkpoint"]),
         )
 
 
-def saved_checkpoint_version(rollout_id: int, *, resumed: bool) -> int:
-    """Return the Stitch version stored by a Miles ``save_hf`` checkpoint.
+def export_version(iteration: int) -> int:
+    """The published weight version of the export saved at ``iteration``.
 
-    A fresh trainer starts rollout 0 from Stitch v0, so save N precedes the
-    publication of vN+1. A resumed trainer starts rollout N+1 from Stitch vN,
-    so subsequent save IDs and Stitch versions are equal.
+    A save at N precedes the publication of vN+1, and the runtime Miles patch
+    keeps a resumed counter there, so this holds for a run's whole lifetime.
     """
-    return rollout_id if resumed else rollout_id + 1
+    return iteration + 1
 
 
 def validate_auto_resume_config(cfg: Any) -> None:
@@ -96,42 +98,69 @@ def resolve_resume_point(
             f"run {source_run_id!r} has no saved Megatron checkpoint"
         ) from exc
     try:
-        tracked_version = int(tracker_value)
+        tracked_iteration = int(tracker_value)
     except ValueError as exc:
         raise ValueError(
             f"invalid checkpoint tracker {tracker}: {tracker_value!r}"
         ) from exc
-    if tracked_version < 0:
-        raise ValueError(f"invalid checkpoint version {tracked_version} in {tracker}")
+    if tracked_iteration < 0:
+        raise ValueError(
+            f"invalid checkpoint iteration {tracked_iteration} in {tracker}"
+        )
 
-    checkpoint_versions = []
+    iterations = []
     for entry in volume.iterdir(str(checkpoint_root), recursive=False):
         if match := re.fullmatch(r"iter_(\d+)", PurePosixPath(entry.path).name):
-            version = int(match.group(1))
-            if version <= tracked_version:
-                checkpoint_versions.append(version)
+            iteration = int(match.group(1))
+            # A fresh actor also reports iteration 0, so it never resumes.
+            if 0 < iteration <= tracked_iteration:
+                iterations.append(iteration)
 
     save_hf = _validate_save_hf_template(save_hf)
-    for version in sorted(checkpoint_versions, reverse=True):
-        relative_hf = save_hf.format(rollout_id=version)
+    for iteration in sorted(iterations, reverse=True):
+        relative_hf = save_hf.format(rollout_id=iteration)
         hf_root = run_root / relative_hf
         try:
             _read_volume_file(volume, str(hf_root / ".complete"))
         except FileNotFoundError:
             continue
+        # A crash between save and publish falls back one save interval.
+        try:
+            _check_published_version(
+                volume, run_root, version=export_version(iteration)
+            )
+        except FileNotFoundError:
+            continue
         break
     else:
         raise ResumePointNotFound(
-            f"run {source_run_id!r} has no complete Megatron/HF checkpoint pair at or "
-            f"before v{tracked_version}"
+            f"run {source_run_id!r} has no complete Megatron/HF checkpoint pair "
+            f"with a published export at or before iteration {tracked_iteration}"
         )
 
     return ResumePoint(
-        version=version,
+        version=export_version(iteration),
+        iteration=iteration,
         source_run_id=source_run_id,
         trainer_checkpoint=str(STITCH_PATH / checkpoint_root),
         rollout_checkpoint=str(STITCH_PATH / hf_root),
     )
+
+
+def _check_published_version(
+    volume: Any, run_root: PurePosixPath, *, version: int
+) -> None:
+    """Require ``updates/weight_vNNNNNN`` to exist and identify itself as ``version``."""
+    index_path = (
+        run_root
+        / "updates"
+        / f"{WEIGHT_PREFIX}{version:06d}"
+        / "model.safetensors.index.json"
+    )
+    index = json.loads(_read_volume_file(volume, str(index_path)))
+    published = int((index.get("metadata") or {})["version"])
+    if published != version:
+        raise ValueError(f"{index_path} identifies v{published}, not v{version}")
 
 
 def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:
@@ -150,7 +179,8 @@ def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:
         raise ValueError(
             f"cannot restore {target.identity!r} from {current.identity!r}"
         )
-    if target.version > current.version:
+    # One ahead is a publish interrupted before its pointer advance.
+    if target.version > current.version + 1:
         raise ValueError(
             f"resume checkpoint v{target.version} is newer than latest v{current.version}"
         )
@@ -158,7 +188,7 @@ def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:
     with volume.batch_upload(force=True) as upload:
         upload.put_file(BytesIO(target.identity.encode()), pointer_path)
         upload.put_file(
-            BytesIO(str(point.version).encode()),
+            BytesIO(str(point.iteration).encode()),
             f"{point.source_run_id}/checkpoints/latest_checkpointed_iteration.txt",
         )
     return target

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -6,7 +6,7 @@ import json
 import re
 from dataclasses import dataclass
 from io import BytesIO
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from cookbook.common.constants import STITCH_PATH
@@ -228,6 +228,29 @@ def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:
             f"{point.source_run_id}/checkpoints/latest_checkpointed_iteration.txt",
         )
     return target
+
+
+def newest_complete_export(
+    run_dir: Path, *, save_hf: str, latest_version: int
+) -> tuple[int, Path] | None:
+    """The newest complete export at or below ``latest_version``, from a mounted
+    run directory — the checkpoint a booting replica should load.
+
+    Returns its published version and directory, or None before the first save.
+    """
+    exports = []
+    export_root = run_dir / PurePosixPath(_validate_save_hf_template(save_hf)).parent
+    for marker in export_root.glob("*/.complete"):
+        export = marker.parent
+        try:
+            iteration = VersionRef.parse(export.name).version
+        except ValueError:
+            continue
+        if export != run_dir / save_hf.format(rollout_id=iteration):
+            continue
+        if (version := export_version(iteration)) <= latest_version:
+            exports.append((version, export))
+    return max(exports) if exports else None
 
 
 def _validate_save_hf_template(value: str | None) -> str:

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -7,6 +7,7 @@ import pytest
 from cookbook.miles_disagg.resume import (
     ResumePoint,
     export_version,
+    newest_complete_export,
     prepare_attempt,
     read_trainer_call,
     record_trainer_call,
@@ -310,3 +311,24 @@ def test_trainer_call_record_round_trip() -> None:
     assert read_trainer_call(volume, "old") == "fc-123"
     record_trainer_call(volume, "old", "fc-456")  # a newer spawn supersedes
     assert read_trainer_call(volume, "old") == "fc-456"
+
+
+def test_newest_complete_export_picks_the_newest_eligible(tmp_path) -> None:
+    for iteration in (7, 19, 39):
+        export = tmp_path / _Config.save_hf.format(rollout_id=iteration)
+        export.mkdir(parents=True)
+        (export / ".complete").touch()
+    (tmp_path / "hf_checkpoints/weight_v000059").mkdir()  # saved, not complete
+    (tmp_path / "hf_checkpoints/scratch").mkdir()  # not an export at all
+
+    # v40 (iteration 39) is published ahead of latest, so v20 is the boot point.
+    assert newest_complete_export(
+        tmp_path, save_hf=_Config.save_hf, latest_version=25
+    ) == (20, tmp_path / "hf_checkpoints/weight_v000019")
+
+
+def test_newest_complete_export_is_none_before_the_first_save(tmp_path) -> None:
+    assert (
+        newest_complete_export(tmp_path, save_hf=_Config.save_hf, latest_version=9)
+        is None
+    )

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -13,7 +13,7 @@ from cookbook.miles_disagg.resume import (
     resolve_resume_point,
     restore_boot_pointer,
     restore_resume_point,
-    validate_auto_resume_config,
+    validate_resumable_config,
     validate_resume_config,
 )
 
@@ -197,12 +197,12 @@ def test_resolve_resume_point_rejects_path_like_run_id() -> None:
         ("no_save_rng", True, "RNG checkpointing"),
     ],
 )
-def test_validate_auto_resume_config(field: str, value: object, message: str) -> None:
+def test_validate_resumable_config(field: str, value: object, message: str) -> None:
     cfg = _Config()
     setattr(cfg, field, value)
 
     with pytest.raises(ValueError, match=message):
-        validate_auto_resume_config(cfg)
+        validate_resumable_config(cfg)
 
 
 @pytest.mark.parametrize(
@@ -226,12 +226,6 @@ def test_validate_resume_requires_per_step_weight_updates() -> None:
 
     with pytest.raises(ValueError, match="update_weights_interval == 1"):
         validate_resume_config(cfg)
-
-
-def test_resume_point_json_round_trip() -> None:
-    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
-
-    assert ResumePoint.from_json(point.to_json()) == point
 
 
 def test_restore_resume_point_overwrites_trackers_but_preserves_updates() -> None:

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -6,13 +6,20 @@ import pytest
 
 from cookbook.miles_disagg.resume import (
     ResumePoint,
+    export_version,
     resolve_resume_point,
     restore_resume_point,
-    saved_checkpoint_version,
     validate_auto_resume_config,
     validate_resume_config,
     wait_for_restored_pointer,
 )
+
+_INDEX = "model.safetensors.index.json"
+
+
+def _published(version: int) -> dict[str, bytes]:
+    name = f"old/updates/weight_v{version:06d}/{_INDEX}"
+    return {name: b'{"metadata": {"version": "%06d"}}' % version}
 
 
 class _Volume:
@@ -62,15 +69,9 @@ class _Config:
     no_save_optim = False
 
 
-@pytest.mark.parametrize(
-    ("rollout_id", "resumed", "version"),
-    [
-        (19, False, 20),
-        (120, True, 120),
-    ],
-)
-def test_saved_checkpoint_version(rollout_id: int, resumed: bool, version: int) -> None:
-    assert saved_checkpoint_version(rollout_id, resumed=resumed) == version
+@pytest.mark.parametrize(("iteration", "version"), [(0, 1), (19, 20), (119, 120)])
+def test_export_version(iteration: int, version: int) -> None:
+    assert export_version(iteration) == version
 
 
 def test_resolve_resume_point_pairs_megatron_and_hf_checkpoints() -> None:
@@ -79,13 +80,15 @@ def test_resolve_resume_point_pairs_megatron_and_hf_checkpoints() -> None:
             "old/checkpoints/latest_checkpointed_iteration.txt": b"119\n",
             "old/checkpoints/iter_0000119/state": b"checkpoint",
             "old/hf_checkpoints/weight_v000119/.complete": b"",
+            **_published(120),
         }
     )
 
     assert resolve_resume_point(
         volume, source_run_id="old", save_hf=_Config.save_hf
     ) == ResumePoint(
-        version=119,
+        version=120,
+        iteration=119,
         source_run_id="old",
         trainer_checkpoint="/stitch/old/checkpoints",
         rollout_checkpoint="/stitch/old/hf_checkpoints/weight_v000119",
@@ -99,17 +102,67 @@ def test_resolve_resume_point_falls_back_to_previous_complete_pair() -> None:
             "old/checkpoints/iter_0000099/state": b"checkpoint",
             "old/checkpoints/iter_0000119/state": b"checkpoint",
             "old/hf_checkpoints/weight_v000099/.complete": b"",
+            **_published(100),
         }
     )
 
     assert resolve_resume_point(
         volume, source_run_id="old", save_hf=_Config.save_hf
     ) == ResumePoint(
-        version=99,
+        version=100,
+        iteration=99,
         source_run_id="old",
         trainer_checkpoint="/stitch/old/checkpoints",
         rollout_checkpoint="/stitch/old/hf_checkpoints/weight_v000099",
     )
+
+
+def test_resolve_resume_point_requires_the_exports_publication() -> None:
+    # No publication for iteration 119: the resume point falls back to 99.
+    volume = _Volume(
+        {
+            "old/checkpoints/latest_checkpointed_iteration.txt": b"119\n",
+            "old/checkpoints/iter_0000099/state": b"checkpoint",
+            "old/checkpoints/iter_0000119/state": b"checkpoint",
+            "old/hf_checkpoints/weight_v000099/.complete": b"",
+            "old/hf_checkpoints/weight_v000119/.complete": b"",
+            **_published(100),
+        }
+    )
+
+    resolved = resolve_resume_point(
+        volume, source_run_id="old", save_hf=_Config.save_hf
+    )
+
+    assert (resolved.version, resolved.iteration) == (100, 99)
+
+
+def test_resolve_resume_point_rejects_a_mislabeled_publication() -> None:
+    volume = _Volume(
+        {
+            "old/checkpoints/latest_checkpointed_iteration.txt": b"119\n",
+            "old/checkpoints/iter_0000119/state": b"checkpoint",
+            "old/hf_checkpoints/weight_v000119/.complete": b"",
+            f"old/updates/weight_v000120/{_INDEX}": b'{"metadata": {"version": "0007"}}',
+        }
+    )
+
+    with pytest.raises(ValueError, match="identifies v7, not v120"):
+        resolve_resume_point(volume, source_run_id="old", save_hf=_Config.save_hf)
+
+
+def test_resolve_resume_point_skips_iteration_zero() -> None:
+    volume = _Volume(
+        {
+            "old/checkpoints/latest_checkpointed_iteration.txt": b"0\n",
+            "old/checkpoints/iter_0000000/state": b"checkpoint",
+            "old/hf_checkpoints/weight_v000000/.complete": b"",
+            **_published(1),
+        }
+    )
+
+    with pytest.raises(ValueError, match="no complete Megatron/HF checkpoint pair"):
+        resolve_resume_point(volume, source_run_id="old", save_hf=_Config.save_hf)
 
 
 def test_resolve_resume_point_requires_a_complete_checkpoint_pair() -> None:
@@ -173,7 +226,7 @@ def test_validate_resume_requires_per_step_weight_updates() -> None:
 
 
 def test_resume_point_json_round_trip() -> None:
-    point = ResumePoint(7, "run", "/trainer", "/rollout")
+    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
 
     assert ResumePoint.from_json(point.to_json()) == point
 
@@ -186,19 +239,28 @@ def test_restore_resume_point_overwrites_trackers_but_preserves_updates() -> Non
             "run/updates/weight_v000009/old": b"preserved",
         }
     )
-    point = ResumePoint(8, "run", "/trainer", "/rollout")
+    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
 
     restored = restore_resume_point(volume, point)
 
     assert restored.identity == "run/weight_v000008"
     assert volume.files["run/latest"] == b"run/weight_v000008"
-    assert volume.files["run/checkpoints/latest_checkpointed_iteration.txt"] == b"8"
+    assert volume.files["run/checkpoints/latest_checkpointed_iteration.txt"] == b"7"
     assert volume.files["run/updates/weight_v000009/old"] == b"preserved"
 
 
-def test_restore_resume_point_rejects_a_checkpoint_ahead_of_latest() -> None:
+def test_restore_resume_point_completes_an_interrupted_publish() -> None:
+    # latest one behind the resume point: an interrupted publish, completed here.
     volume = _Volume({"run/latest": b"run/weight_v000007"})
-    point = ResumePoint(8, "run", "/trainer", "/rollout")
+    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
+
+    assert restore_resume_point(volume, point).identity == "run/weight_v000008"
+    assert volume.files["run/latest"] == b"run/weight_v000008"
+
+
+def test_restore_resume_point_rejects_a_checkpoint_ahead_of_latest() -> None:
+    volume = _Volume({"run/latest": b"run/weight_v000006"})
+    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
 
     with pytest.raises(ValueError, match="newer than latest"):
         restore_resume_point(volume, point)
@@ -206,7 +268,7 @@ def test_restore_resume_point_rejects_a_checkpoint_ahead_of_latest() -> None:
 
 def test_engine_startup_waits_for_exact_restored_pointer() -> None:
     volume = _Volume({"run/latest": b"run/weight_v000008"})
-    point = ResumePoint(8, "run", "/trainer", "/rollout")
+    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
 
     restored = wait_for_restored_pointer(volume, point, timeout=1)
 
@@ -215,7 +277,7 @@ def test_engine_startup_waits_for_exact_restored_pointer() -> None:
 
 def test_engine_startup_does_not_accept_abandoned_suffix(monkeypatch) -> None:
     volume = _Volume({"run/latest": b"run/weight_v000012"})
-    point = ResumePoint(8, "run", "/trainer", "/rollout")
+    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
     reloads = 0
 
     def reload() -> None:

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -7,7 +7,11 @@ import pytest
 from cookbook.miles_disagg.resume import (
     ResumePoint,
     export_version,
+    prepare_attempt,
+    read_trainer_call,
+    record_trainer_call,
     resolve_resume_point,
+    restore_boot_pointer,
     restore_resume_point,
     validate_auto_resume_config,
     validate_resume_config,
@@ -264,6 +268,55 @@ def test_restore_resume_point_rejects_a_checkpoint_ahead_of_latest() -> None:
 
     with pytest.raises(ValueError, match="newer than latest"):
         restore_resume_point(volume, point)
+
+
+def test_prepare_attempt_restores_the_newest_pair() -> None:
+    volume = _Volume(
+        {
+            "old/latest": b"old/weight_v000012",
+            "old/checkpoints/latest_checkpointed_iteration.txt": b"7",
+            "old/checkpoints/iter_0000007/state": b"checkpoint",
+            "old/hf_checkpoints/weight_v000007/.complete": b"",
+            **_published(8),
+        }
+    )
+
+    point = prepare_attempt(volume, run_id="old", save_hf=_Config.save_hf)
+
+    assert point is not None and (point.version, point.iteration) == (8, 7)
+    assert volume.files["old/latest"] == b"old/weight_v000008"
+    assert volume.files["old/checkpoints/latest_checkpointed_iteration.txt"] == b"7"
+
+
+def test_prepare_attempt_restarts_from_scratch_before_the_first_pair() -> None:
+    volume = _Volume({"old/latest": b"old/weight_v000003"})
+
+    assert prepare_attempt(volume, run_id="old", save_hf=_Config.save_hf) is None
+    assert volume.files["old/latest"] == b"old/weight_v000000"
+
+
+def test_prepare_attempt_is_a_noop_on_a_fresh_run() -> None:
+    volume = _Volume({})
+
+    assert prepare_attempt(volume, run_id="old", save_hf=_Config.save_hf) is None
+    assert volume.files == {}
+
+
+def test_restore_boot_pointer_rejects_a_foreign_run() -> None:
+    volume = _Volume({"old/latest": b"other/weight_v000003"})
+
+    with pytest.raises(ValueError, match="belongs to run"):
+        restore_boot_pointer(volume, "old")
+
+
+def test_trainer_call_record_round_trip() -> None:
+    volume = _Volume({})
+
+    assert read_trainer_call(volume, "old") is None
+    record_trainer_call(volume, "old", "fc-123")
+    assert read_trainer_call(volume, "old") == "fc-123"
+    record_trainer_call(volume, "old", "fc-456")  # a newer spawn supersedes
+    assert read_trainer_call(volume, "old") == "fc-456"
 
 
 def test_engine_startup_waits_for_exact_restored_pointer() -> None:

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -15,7 +15,6 @@ from cookbook.miles_disagg.resume import (
     restore_resume_point,
     validate_auto_resume_config,
     validate_resume_config,
-    wait_for_restored_pointer,
 )
 
 _INDEX = "model.safetensors.index.json"
@@ -317,32 +316,3 @@ def test_trainer_call_record_round_trip() -> None:
     assert read_trainer_call(volume, "old") == "fc-123"
     record_trainer_call(volume, "old", "fc-456")  # a newer spawn supersedes
     assert read_trainer_call(volume, "old") == "fc-456"
-
-
-def test_engine_startup_waits_for_exact_restored_pointer() -> None:
-    volume = _Volume({"run/latest": b"run/weight_v000008"})
-    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
-
-    restored = wait_for_restored_pointer(volume, point, timeout=1)
-
-    assert restored.identity == "run/weight_v000008"
-
-
-def test_engine_startup_does_not_accept_abandoned_suffix(monkeypatch) -> None:
-    volume = _Volume({"run/latest": b"run/weight_v000012"})
-    point = ResumePoint(8, 7, "run", "/trainer", "/rollout")
-    reloads = 0
-
-    def reload() -> None:
-        nonlocal reloads
-        reloads += 1
-        if reloads == 2:
-            volume.files["run/latest"] = b"run/weight_v000008"
-
-    volume.reload = reload
-    monkeypatch.setattr("cookbook.miles_disagg.resume.time.sleep", lambda _delay: None)
-
-    restored = wait_for_restored_pointer(volume, point, timeout=1)
-
-    assert restored.identity == "run/weight_v000008"
-    assert reloads == 2

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -28,6 +28,7 @@ MILES_ROOT = "/root/miles"
 # the pin advances.
 MILES_RUNTIME_PATCHES = (
     "/root/cookbook/miles_disagg/patches/miles-stable-weight-versions.patch",
+    "/root/cookbook/miles_disagg/patches/miles-seed-baseline-scalars.patch",
 )
 # Source-only megatron.training must be on PYTHONPATH.
 MEGATRON_PATH = "/root/Megatron-LM"

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -24,6 +24,11 @@ MILES_REPO_URL = "https://github.com/modal-projects/miles.git"
 MILES_REPO_REF = "778a13786471777f81c587557f68cdf03903059a"
 
 MILES_ROOT = "/root/miles"
+# Applied at container start, after any dev overlay; each moves to the fork when
+# the pin advances.
+MILES_RUNTIME_PATCHES = (
+    "/root/cookbook/miles_disagg/patches/miles-stable-weight-versions.patch",
+)
 # Source-only megatron.training must be on PYTHONPATH.
 MEGATRON_PATH = "/root/Megatron-LM"
 TORCH_DIST_CONVERT_WRAPPER = "/root/convert_hf_to_torch_dist_modal.py"

--- a/src/stitch/pools/base.py
+++ b/src/stitch/pools/base.py
@@ -33,6 +33,11 @@ class Pool:
         appearing or disappearing between discovery and use is expected, not an error."""
         raise NotImplementedError
 
+    def replica_request(self, replica: str, path: str) -> tuple[str, dict[str, str]]:
+        """(url, headers) reaching one replica's sidecar endpoint. A pool whose
+        replicas sit behind an edge overrides this to route through it."""
+        return f"{replica.rstrip('/')}{path}", {}
+
     def wake(self, replicas: list[str], ref: VersionRef) -> None:
         """Nudge replicas to reconcile now. Optional — the default relies on their polling."""
 

--- a/src/stitch/pools/modal_flash.py
+++ b/src/stitch/pools/modal_flash.py
@@ -27,11 +27,27 @@ class ModalFlashPool(Pool):
     def __init__(self, app_name: str, cls_name: str) -> None:
         self.app_name = app_name
         self.cls_name = cls_name
+        self._upstream_url_cache: str | None = None
 
     def _server(self):
         import modal
 
         return modal.Server.from_name(self.app_name, self.cls_name)
+
+    def _upstream_url(self) -> str:
+        """The upstream class's own Flash URL, not an LB override. Stable for a
+        deployed app, so it is cached for the client's lifetime."""
+        if self._upstream_url_cache is None:
+            self._upstream_url_cache = self._require_gateway(self._server().get_url())
+        return self._upstream_url_cache
+
+    def replica_request(self, replica: str, path: str) -> tuple[str, dict[str, str]]:
+        # Direct container URLs sit behind relay auth, so a replica is addressed
+        # through the pool URL. The edge keys upstreams by host:port.
+        host = replica.split("://", 1)[-1].rstrip("/")
+        if ":" not in host:
+            host = f"{host}:443"
+        return f"{self._upstream_url()}{path}", {"modal-flash-upstream": host}
 
     def gateway_url(self) -> str:
         return self._require_gateway(self._server().get_url())
@@ -64,7 +80,8 @@ class ModalFlashPool(Pool):
 
             def wake_one(url: str) -> None:
                 try:
-                    client.post(f"{url}/wake").raise_for_status()
+                    target, headers = self.replica_request(url, "/wake")
+                    client.post(target, headers=headers).raise_for_status()
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "failed to wake %s for %s: %s", url, ref.identity, exc
@@ -82,7 +99,10 @@ class ModalFlashPool(Pool):
 
             async def wake_one(url: str) -> None:
                 try:
-                    (await client.post(f"{url}/wake")).raise_for_status()
+                    target, headers = await asyncio.to_thread(
+                        self.replica_request, url, "/wake"
+                    )
+                    (await client.post(target, headers=headers)).raise_for_status()
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "failed to wake %s for %s: %s", url, ref.identity, exc

--- a/src/stitch/pools/modal_flash_test.py
+++ b/src/stitch/pools/modal_flash_test.py
@@ -3,7 +3,35 @@
 
 from __future__ import annotations
 
-from stitch.pools.modal_flash import _host, _normalize_url, _replica_urls
+from stitch.pools.base import Pool
+from stitch.pools.modal_flash import (
+    ModalFlashPool,
+    _host,
+    _normalize_url,
+    _replica_urls,
+)
+
+
+def test_replica_request_routes_through_the_pool_url() -> None:
+    pool = ModalFlashPool("app", "Server")
+    pool._upstream_url_cache = "https://pool.modal.run"
+
+    url, headers = pool.replica_request(
+        "https://h-ta-123.w.modal.host/", "/server_info"
+    )
+
+    assert url == "https://pool.modal.run/server_info"
+    assert headers == {"modal-flash-upstream": "h-ta-123.w.modal.host:443"}
+
+    _url, headers = pool.replica_request("https://h-ta-123.w.modal.host:8443", "/wake")
+    assert headers == {"modal-flash-upstream": "h-ta-123.w.modal.host:8443"}
+
+
+def test_base_pool_replica_request_is_direct() -> None:
+    url, headers = Pool().replica_request("https://replica:8000/", "/wake")
+
+    assert url == "https://replica:8000/wake"
+    assert headers == {}
 
 
 def test_replica_urls_filters_hostless_and_normalizes() -> None:

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -24,7 +24,7 @@ from stitch.engines.base import Engine
 from stitch.pools.base import Pool
 from stitch.stores.base import Store
 from stitch.sync import AdmissionGate, CommitMode, ConstraintUnmet, Reconciler
-from stitch.types import PoolState, ReplicaState, VersionConstraint
+from stitch.types import PoolState, ReplicaState, VersionConstraint, VersionRef
 from stitch.watchdog import (
     EngineWatchdog,
     SidecarWatchdog,
@@ -360,6 +360,7 @@ def await_pool_ready(
     replica_floor: int,
     timeout: float = 60 * 60,
     interval: float = 30.0,
+    latest: VersionRef | None = None,
 ) -> bool:
     """Block until the configured fraction of ``replica_floor`` reports routing readiness.
 
@@ -368,10 +369,24 @@ def await_pool_ready(
     for a large rollout launch. Once the floor is met, the gateway is checked as well so the
     trainer sees a working traffic path. Timeout is terminal so training never starts below the
     requested floor. This launch-script helper is synchronous, unlike :func:`readiness`.
+
+    ``latest`` is the pointer the caller has just claimed: a replica applied past it on
+    the same run is exiting for replacement, so it is not capacity even while its own
+    reconcile pass has yet to notice the rewind.
     """
     if replica_floor < 1:
         raise ValueError(f"replica_floor must be positive, got {replica_floor}")
     min_ready = ceil(POOL_READY_FRACTION * replica_floor)
+
+    def is_capacity(replica: ReplicaState) -> bool:
+        if (
+            latest is not None
+            and replica.applied is not None
+            and replica.applied.run_id == latest.run_id
+            and replica.applied.version > latest.version
+        ):
+            return False
+        return replica.ready
 
     async def wait() -> bool:
         import httpx
@@ -380,18 +395,18 @@ def await_pool_ready(
         last_counts: tuple[int, int] | None = None
         while time.monotonic() < deadline:
             state = await readiness(pool)
-            counts = (
-                sum(replica.ready for replica in state.replicas),
+            tally = (
+                sum(is_capacity(replica) for replica in state.replicas),
                 len(state.replicas),
             )
-            if counts != last_counts:
+            if tally != last_counts:
                 print(
-                    f"Rollout fleet readiness: {counts[0]}/{min_ready} required "
-                    f"({counts[1]} discovered)",
+                    f"Rollout fleet readiness: {tally[0]}/{min_ready} required "
+                    f"({tally[1]} discovered)",
                     flush=True,
                 )
-                last_counts = counts
-            if counts[0] >= min_ready:
+                last_counts = tally
+            if tally[0] >= min_ready:
                 try:
                     gateway = (await pool.gateway_url_async()).rstrip("/")
                     async with httpx.AsyncClient(trust_env=False) as client:

--- a/src/stitch/service.py
+++ b/src/stitch/service.py
@@ -337,7 +337,10 @@ async def readiness(pool: Pool, *, timeout: float = 15.0) -> PoolState:
 
     async def probe(c: Any, url: str) -> ReplicaState:
         try:
-            resp = await c.get(f"{url.rstrip('/')}/server_info", timeout=timeout)
+            target, headers = await asyncio.to_thread(
+                pool.replica_request, url, "/server_info"
+            )
+            resp = await c.get(target, headers=headers, timeout=timeout)
             return ReplicaState.from_dict(resp.json())
         except Exception as exc:  # noqa: BLE001
             return ReplicaState(

--- a/src/stitch/service_test.py
+++ b/src/stitch/service_test.py
@@ -316,6 +316,47 @@ def test_await_pool_ready_waits_for_replica_threshold(monkeypatch) -> None:
     assert stitch_service.await_pool_ready(Pool(), replica_floor=4, interval=0)
 
 
+def test_await_pool_ready_excludes_replicas_ahead_of_latest(monkeypatch) -> None:
+    latest = VersionRef("run", 3)
+    stale = ReplicaState(ready=True, applied=VersionRef("run", 5))
+    replaced = ReplicaState(ready=True, applied=latest)
+    states = iter(
+        [
+            PoolState([stale, stale, ReplicaState()]),
+            PoolState([replaced, replaced, ReplicaState()]),
+        ]
+    )
+
+    async def pool_readiness(_pool):
+        return next(states)
+
+    async def no_sleep(_seconds):
+        pass
+
+    class Pool:
+        async def gateway_url_async(self):
+            return "http://gateway"
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            pass
+
+        async def get(self, _url, **_kwargs):
+            return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(stitch_service, "readiness", pool_readiness)
+    monkeypatch.setattr(stitch_service.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: Client())
+
+    assert stitch_service.await_pool_ready(
+        Pool(), replica_floor=2, interval=0, latest=latest
+    )
+    assert next(states, None) is None  # the stale-but-ready fleet did not pass
+
+
 def test_await_pool_ready_fails_closed_below_threshold(monkeypatch) -> None:
     async def pool_readiness(_pool):
         return PoolState([ReplicaState(ready=True), ReplicaState()])

--- a/src/stitch/sync.py
+++ b/src/stitch/sync.py
@@ -440,6 +440,12 @@ class Reconciler:
             return True
         if self.applied is None or pointer.run_id != self.applied.run_id:
             await self._switch_run(pointer.run_id)
+        if pointer.version < self.applied.version:
+            raise UnrecoverableSidecarError(
+                f"pointer {pointer.identity} is behind applied "
+                f"{self.applied.identity}: the run was restored and this "
+                "replica's suffix is abandoned; exiting for replacement"
+            )
         if not self._behind(pointer):
             return True
 

--- a/src/stitch/sync_test.py
+++ b/src/stitch/sync_test.py
@@ -12,7 +12,7 @@ from functools import partial
 import pytest
 
 from stitch.engines.base import Engine
-from stitch.errors import UnrecoverableEngineError
+from stitch.errors import UnrecoverableEngineError, UnrecoverableSidecarError
 from stitch.stores.base import Store
 from stitch.sync import ConstraintUnmet, Reconciler
 from stitch.types import (
@@ -974,6 +974,42 @@ def test_resumed_replica_applies_only_versions_after_saved_checkpoint() -> None:
         assert engine.staged == [VersionRef("resumed", 120)]
         assert engine.committed == [VersionRef("resumed", 120)]
         assert r.applied == VersionRef("resumed", 120)
+
+    _run(go())
+
+
+def test_pointer_rewind_is_terminal() -> None:
+    async def go() -> None:
+        r = Reconciler(
+            store=FakeStore(VersionRef("resumed", 3)),
+            engine=FakeEngine(),
+            run_id="resumed",
+            boot_version=5,
+            reconcile_interval=0,
+        )
+        await r.startup()
+        with pytest.raises(UnrecoverableSidecarError, match="restored"):
+            await r.wait_for_terminal_error()
+        assert not r.ready
+        await r.shutdown()
+
+    _run(go())
+
+
+def test_run_switch_below_foreign_boot_is_terminal() -> None:
+    # This replica's boot checkpoint is foreign to the new run's lineage.
+    async def go() -> None:
+        r = Reconciler(
+            store=FakeStore(VersionRef("successor", 2)),
+            engine=FakeEngine(),
+            run_id="resumed",
+            boot_version=5,
+            reconcile_interval=0,
+        )
+        await r.startup()
+        with pytest.raises(UnrecoverableSidecarError, match="restored"):
+            await r.wait_for_terminal_error()
+        await r.shutdown()
 
     _run(go())
 

--- a/tools/probes/poller.py
+++ b/tools/probes/poller.py
@@ -50,17 +50,23 @@ async def poll(
                     replicas = await asyncio.to_thread(pool.discover_replicas)
                     last_discover = time.time()
                 for row in await asyncio.gather(
-                    *(_probe(client, url) for url in replicas)
+                    *(_probe(client, pool, url) for url in replicas)
                 ):
                     f.write(json.dumps(row) + "\n")
                 f.flush()
                 await asyncio.sleep(interval)
 
 
-async def _probe(client: Any, url: str) -> dict[str, Any]:
+async def _probe(client: Any, pool: Any, url: str) -> dict[str, Any]:
     row: dict[str, Any] = {"t": time.time(), "replica": url}
     try:
-        row["info"] = (await client.get(f"{url.rstrip('/')}/server_info")).json()
+        if pool is not None:
+            target, headers = await asyncio.to_thread(
+                pool.replica_request, url, "/server_info"
+            )
+        else:
+            target, headers = f"{url.rstrip('/')}/server_info", {}
+        row["info"] = (await client.get(target, headers=headers)).json()
     except Exception as exc:  # noqa: BLE001 — an unreachable replica is itself a data point
         row["error"] = str(exc)[:200]
     return row


### PR DESCRIPTION
Recovery from a trainer preemption or crash becomes Modal's job. The Miles
trainer runs under `retries`, every attempt re-derives its resume state from the
run volume, and the rollout pool is never redeployed — so a run survives a
trainer failure without a launcher attached to it and without the fleet
restarting.

This replaces `--auto-resume`, whose supervisor was a local `subprocess` loop
that redeployed the whole app (`strategy="recreate"`) on every attempt: the pool
died with each recovery, recovery stopped when the laptop did, and attempt state
lived in the serving image's environment, which is why it needed a redeploy at
all.

### What changes

**The trainer is reentrant.** `Trainer.train` now takes only the
attempt-invariant config payload. At the top of every attempt it restores the
newest complete Megatron/Hugging Face checkpoint pair from the run volume — or
rewinds `latest` to the boot version if the run has no pair yet — then claims
that pointer, waits for the rollout floor, and runs. The first attempt, a Modal
retry, and a manual re-spawn all take the identical path.

**Modal owns the retry loop.** `retries=10` with `single_use_containers=True`,
so every attempt is a complete fresh gang whose `@modal.enter()` reruns and
whose Ray bootstrap starts clean.

**Non-rank-zero containers hold.** Single-use containers exit after their single
input, so a worker that returned at the rank gate took its Ray node with it and
the cluster could not form. Workers now block in `ray_cluster.hold_worker_node`
until the Ray head stops answering, which ties a worker's lifetime to the
attempt and releases it inside the window Modal would reap it anyway.

**Servers boot from volume state alone.** The resume point used to be baked into
the serving image's environment; that is the reason a resume had to recreate the
pool. A replica now always self-discovers the newest complete export at or below
`latest`.

**Replicas rewind by replacement.** A same-run pointer moving backward is a
resume restore: every version above it will be republished with different bytes
under the same numbers, so the replica's applied suffix is unusable. It raises
`UnrecoverableSidecarError` and the existing watchdog path replaces it; its
successor boots from the restored lineage. The trainer's readiness gate excludes
replicas applied past its claimed pointer, so it never counts a fleet that is
about to exit.

**Weight versions stay stable across resume.** A runtime Miles patch continues a
resumed version counter at `iteration + 1` instead of restarting it at
`iteration`, which previously relabeled an export's bytes from vN+1 down to vN
and forked the meaning of every later number. One rule now holds for a run's
lifetime: `export_version(iteration) == iteration + 1`.

**The launcher only mints, deploys, and spawns.** `--auto-resume`,
`--run-attempt`, and the resume environment variable are gone. `--resume-from`
reuses a run's identity for a takeover or a run past its retry budget: it cancels
the run's recorded trainer call, waits for the call to settle, and spawns a
successor on the deployed pool. It never deploys — a missing pool fails fast with
the `modal deploy` command instead of silently replacing a live one.

The last commit is a standalone legibility change and reviews independently:
`Server.startup` nested four levels deep to answer one question, so its search
over complete exports becomes a pure, directly testable function.

### Verification

`uv run pytest` green at every commit in the stack; `ruff check` clean. The one
remaining `ruff format --check` failure is `conftest.py`, which this branch does
not touch and which already fails on main. Both Miles runtime patches verified
to apply at pin `778a1378`.

Behavior was measured live in `stitch-dev` on modal 1.5.4.dev11 with throwaway
spikes, which are not part of this diff:

- On a 2×H100:8 gang, a worker's liveness port answered at t+1.0s and stopped
  answering 1.3s after that worker returned at t+20.2s, while rank 0 ran on
  undisturbed to t+84s. That gap is what `hold_worker_node` closes.
- A rank-0 failure scheduled a complete fresh gang 22.5s later: new task ids on
  every rank, `@modal.enter()` rerun, and an identical
  `current_function_call_id()`, which is what makes a recorded trainer call a
  stable identity to cancel.
- Against a real Modal Volume, a fabricated run published v1..v5 with a save at
  iteration 3; one attempt failed and the retry re-derived
  `ResumePoint(version=4, iteration=3)` from volume state alone, with `latest`
  rewound v5 → v4 and the tracker rewritten to 3. Both attempts derived the same
  point, so restoring is idempotent.

Not verified: a real training run through a kill and resume, which needs a
recipe known good against the current Miles image.

### Not included

Unbundled out of `agent/resilient-rollout-recovery` and left for their own
change: the qwen3-30b end-to-end recipe, the Miles single-turn external-endpoint
patch that a plain-dataset recipe needs, and the two checkpoint-writer patches.
