### PR TITLE
cookbook: pass recipe environment to checkpoint converters

### DIFF
--- a/cookbook/miles_disagg/prep.py
+++ b/cookbook/miles_disagg/prep.py
@@ -139,6 +139,7 @@ def prepare_checkpoints(
                 *carveouts,
             ],
             check=True,
+            env={**os.environ, **getattr(exp, "PREP_ENV", {})},
         )
 
     _staged(served_dir, _build_nvfp4)
@@ -200,7 +201,7 @@ def prepare_torch_dist(
         "raw",
         *shlex.split(exp.modal.torch_dist_convert_extra_args),
     ]
-    env = {**os.environ}
+    env = {**os.environ, **getattr(exp, "PREP_ENV", {})}
     if use_wrapper:
         env["SKIP_RELEASE_RENAME"] = "1"
     print(


### PR DESCRIPTION
NVFP4 and TorchDist preparation start converter subprocesses without the recipe's `PREP_ENV`, so quantizer policy and conversion parallelism can differ from the selected recipe. Pass those environment values to both converter entrypoints.

Confirmed-by-probe: the baseline reproduces the missing environment; 12 child-process cases pass in the pinned Modal image with tensor conversion substituted. This exact branch passes 237 Stitch tests and actual training/preparation app imports on Modal (`stitch-dev`, `runc`).
