### PR TITLE
cookbook: persist Miles checkpoints from local disk asynchronously

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -107,8 +107,10 @@ ready. Repeating the command creates a separate run and checkpoint lineage.
 #### Resume a Miles run
 
 Recovery is automatic: the Miles trainer runs under Modal retries, and every
-attempt re-derives its resume state from the run volume — the newest saved
-Megatron checkpoint whose Hugging Face export is complete and published. A
+attempt selects the newest durable Megatron/Hugging Face checkpoint pair with a
+published weight version. Full snapshots use local disk and a separate checkpoint
+Volume; see [checkpoint persistence](miles_disagg/CHECKPOINTING.md) for capacity
+settings and durability semantics. A
 preempted or crashed trainer resumes on its own, without a launcher attached
 and without redeploying the pool; replicas serving abandoned versions exit and
 their replacements boot from the restored checkpoint. If the checkpoint is

--- a/cookbook/common/config.py
+++ b/cookbook/common/config.py
@@ -43,6 +43,9 @@ class ModalConfig:
     torch_dist_convert_extra_args: str = ""
     torch_dist_prep_ephemeral_disk_mib: int | None = None
     trainer_ephemeral_disk_mib: int | None = None
+    checkpoint_upload_mib_per_second: int = 256
+    checkpoint_min_free_disk_mib: int = 65_536
+    checkpoint_upload_timeout_seconds: int = 6 * 60 * 60
 
     def __init__(self, **kwargs: Any) -> None:
         for k, v in kwargs.items():

--- a/cookbook/common/constants.py
+++ b/cookbook/common/constants.py
@@ -9,6 +9,7 @@ HF_CACHE_PATH = Path("/root/.cache/huggingface")
 CHECKPOINTS_PATH = Path("/checkpoints")
 DATA_PATH = Path("/data")
 STITCH_PATH = Path("/stitch")
+TRAINING_CHECKPOINTS_PATH = Path("/training-checkpoints")
 DRAFT_PATH = Path("/draft")
 SGLANG_CACHE_PATH = (
     "/root/.cache/sglang"  # sglang kernel/JIT cache; survives cold starts

--- a/cookbook/miles_disagg/CHECKPOINTING.md
+++ b/cookbook/miles_disagg/CHECKPOINTING.md
@@ -1,0 +1,60 @@
+# Checkpoint persistence
+
+Miles saves model, optimizer, scheduler, RNG, and rollout sampler state to local
+ephemeral disk. Snapshot creation and its collectives pause training. Once the
+files are closed, one uploader per host copies them to
+`<EXPERIMENT_VOLUME_NAME>-checkpoints`, mounted at `/training-checkpoints`.
+
+The `/stitch` Volume holds live weight updates and logs. Its commits do not flush
+checkpoint uploads. Both volumes still share the host's network and memory
+bandwidth; the upload rate limit controls background copying.
+
+## Capacity
+
+Only one snapshot per host can be awaiting persistence. If any host is busy, all
+ranks skip the next periodic save. Explicit and final saves wait for the previous
+upload, create their snapshot, and wait for durability. Normal loop exit drains
+outstanding uploads. Failures reach the next checkpoint operation or final
+drain; local payloads remain available after upload failure.
+
+| Modal setting | Default | Purpose |
+| --- | --- | --- |
+| `checkpoint_upload_mib_per_second` | `256` | Copy rate per host; `0` removes the limit. |
+| `checkpoint_min_free_disk_mib` | `65536` | Free-space reserve checked before a snapshot. |
+| `checkpoint_upload_timeout_seconds` | `21600` | Deadline checked while copying and waiting for host receipts. |
+
+Size `trainer_ephemeral_disk_mib` for a local snapshot, the Volume write cache,
+and runtime scratch. Rank zero also holds the complete HF export. The reserve
+check does not estimate the next snapshot's size. CPU optimizer state and export
+buffers also require host memory. If persistence is slower than the save cadence,
+skipped saves increase the recovery interval.
+
+## Durability and recovery
+
+Each attempt writes immutable snapshots and completion manifests:
+
+```text
+<run>/attempts/<attempt>/snapshots/<iteration>/
+    checkpoints/iter_<iteration>/...
+    checkpoints/rollout/global_dataset_state_dict_<iteration>.pt
+    checkpoints/latest_checkpointed_iteration.txt
+    hf_checkpoints/weight_v<iteration>/...
+    receipts/<iteration>/<host-rank>.json
+<run>/completed/<iteration>-<attempt>.json
+```
+
+Each host commits its files and a receipt containing sizes and SHA-256 checksums.
+The coordinator checks every host's receipt and coverage of the Megatron and HF
+indices before publishing the completion manifest. Hosts remove local payloads
+only after that manifest is durable.
+
+Automatic Volume commits can expose partial files. Discovery therefore trusts
+the completion manifest, not directory presence, the HF `.complete` marker, or
+the Megatron tracker. With Volume-backed updates, trainer recovery also requires
+a matching published weight version; replica boot chooses an export at or below
+the served pointer. Legacy checkpoints on the run Volume remain a fallback.
+
+This supports actor-only Megatron `torch_dist` checkpoints with synchronous local
+serialization (`async_save=False`). A snapshot on ephemeral disk alone is not
+durable; host loss can discard it and require recovery from an older completed
+checkpoint.

--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -46,11 +46,13 @@ from cookbook.common.constants import (
     SGLANG_CACHE_PATH,
     SIDECAR_PORT,
     STITCH_PATH,
+    TRAINING_CHECKPOINTS_PATH,
 )
-from cookbook.miles_disagg import trainer_image
+from cookbook.miles_disagg import checkpoint_hooks, trainer_image
 from cookbook.miles_disagg.config import YAML_CONFIG_FIELDS, MilesConfig
 from cookbook.miles_disagg.resume import (
     newest_complete_export,
+    newest_persisted_export,
     prepare_attempt,
     record_trainer_call,
 )
@@ -76,6 +78,7 @@ miles_cfg = exp.miles
 RUN_ID = os.environ["RUN_ID"]
 APP_NAME = f"{exp.APP_NAME}-{RUN_ID}"
 RUN_DIR = STITCH_PATH / RUN_ID
+TRAINING_CHECKPOINT_DIR = TRAINING_CHECKPOINTS_PATH / RUN_ID
 STORE_DEPLOYMENT = storage.StoreDeployment.from_environment()
 UPDATES_DIR = STORE_DEPLOYMENT.updates_dir(RUN_DIR)
 STORE_SECRETS = STORE_DEPLOYMENT.modal_secrets()
@@ -132,6 +135,9 @@ run_volume = modal.Volume.from_name(
     create_if_missing=True,
     version=2,
 )
+training_checkpoint_volume = modal.Volume.from_name(
+    f"{exp.EXPERIMENT_VOLUME_NAME}-checkpoints", create_if_missing=True, version=2
+)
 sglang_cache_volume = modal.Volume.from_name(
     "sglang-cache", create_if_missing=True, version=2
 )  # survives cold starts
@@ -150,6 +156,7 @@ train_volumes = {
     str(CHECKPOINTS_PATH): checkpoint_volume,
     str(DATA_PATH): data_volume,
     str(STITCH_PATH): run_volume,
+    str(TRAINING_CHECKPOINTS_PATH): training_checkpoint_volume,
 }
 
 app = modal.App(APP_NAME)
@@ -177,6 +184,7 @@ SGLANG_SERVER_ARGS = {
     volumes={
         str(HF_CACHE_PATH): hf_cache_volume,
         str(CHECKPOINTS_PATH): checkpoint_volume,
+        str(TRAINING_CHECKPOINTS_PATH): training_checkpoint_volume.read_only(),
         **(
             {str(STITCH_PATH): run_volume}
             if STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME
@@ -246,8 +254,9 @@ def _boot_checkpoint(store_config: dict) -> tuple[str, int]:
     ):
         return miles_cfg.hf_checkpoint, 0
 
-    # Read the exports and the pointer from one Volume snapshot; a save ahead of
-    # latest is not eligible yet.
+    # Read the served version first, then the separate checkpoint Volume. A
+    # newer checkpoint may finish uploading meanwhile; the version bound keeps
+    # it ineligible until its corresponding delta has been published.
     run_volume.reload()
     store = storage.create_store(
         store_config["stitch_store_backend"],
@@ -260,9 +269,15 @@ def _boot_checkpoint(store_config: dict) -> tuple[str, int]:
         return miles_cfg.hf_checkpoint, 0
     if latest.run_id != RUN_ID:
         raise ValueError(f"latest belongs to run {latest.run_id!r}, not {RUN_ID!r}")
-    export = newest_complete_export(
+    training_checkpoint_volume.reload()
+    export = newest_persisted_export(
+        TRAINING_CHECKPOINT_DIR, latest_version=latest.version
+    )
+    legacy_export = newest_complete_export(
         RUN_DIR, save_hf=save_hf, latest_version=latest.version
     )
+    if legacy_export is not None and (export is None or legacy_export[0] > export[0]):
+        export = legacy_export
     return (str(export[1]), export[0]) if export else (miles_cfg.hf_checkpoint, 0)
 
 
@@ -430,7 +445,10 @@ class Trainer:
         resume_point = None
         if STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME:
             resume_point = prepare_attempt(
-                run_volume, run_id=RUN_ID, save_hf=getattr(cfg, "save_hf", None)
+                run_volume,
+                run_id=RUN_ID,
+                save_hf=getattr(cfg, "save_hf", None),
+                checkpoint_volume=training_checkpoint_volume,
             )
 
         cfg.rollout_endpoint_url = ModalFlashLBPool(APP_NAME, "Server").gateway_url()
@@ -440,16 +458,20 @@ class Trainer:
             cfg.exit_on_missing_checkpoint = True
         # Miles requires this CLI argument; the deployment owns its run-scoped value.
         cfg.update_weight_disk_dir = str(UPDATES_DIR)
-        if getattr(cfg, "save_interval", None) is None:
-            cfg.save = cfg.save_hf = None
-        else:
-            cfg.save = str(RUN_DIR / "checkpoints")
-            if save_hf := getattr(cfg, "save_hf", None):
-                cfg.save_hf = str(RUN_DIR / save_hf)
+        checkpoint_config = checkpoint_hooks.configure_checkpointing(
+            cfg,
+            run_id=RUN_ID,
+            attempt_id=uuid4().hex,
+            volume_name=f"{exp.EXPERIMENT_VOLUME_NAME}-checkpoints",
+            upload_mib_per_second=modal_cfg.checkpoint_upload_mib_per_second,
+            min_free_disk_mib=modal_cfg.checkpoint_min_free_disk_mib,
+            timeout_seconds=modal_cfg.checkpoint_upload_timeout_seconds,
+        )
         # miles setattr's every key onto args for the hooks.
         custom_config = {
             **(cfg.custom_config_path or {}),
             **STORE_DEPLOYMENT.hook_config(APP_NAME),
+            **checkpoint_config,
             "experiment_volume_name": exp.EXPERIMENT_VOLUME_NAME,
             "rollout_modal_flash_app_name": APP_NAME,
             "rollout_modal_flash_server_cls_name": "Server",

--- a/cookbook/miles_disagg/checkpoint.py
+++ b/cookbook/miles_disagg/checkpoint.py
@@ -1,0 +1,325 @@
+"""Copy immutable local checkpoints to a dedicated Volume off the training path.
+
+Each host commits its own files and then a receipt. The first host publishes a
+completion manifest only after every receipt is durable. Readers trust that
+manifest, never the presence of a directory, HF marker, or Megatron tracker.
+Background workers do not use torch.distributed or reload a mounted Volume.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import shutil
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def relative_path(value: str) -> str:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or path.is_absolute()
+        or ".." in path.parts
+        or path == PurePosixPath(".")
+    ):
+        raise ValueError(f"invalid checkpoint-relative path: {value!r}")
+    return path.as_posix()
+
+
+@dataclass(frozen=True)
+class CheckpointUpload:
+    local_root: Path
+    run_id: str
+    attempt_id: str
+    iteration: int
+    host_rank: int
+    host_ranks: tuple[int, ...]
+    hf_directory: str | None
+    required_files: tuple[str, ...] = ()
+
+    def __post_init__(self):
+        for value in (self.run_id, self.attempt_id):
+            if "/" in relative_path(value):
+                raise ValueError("run and attempt IDs must be single path components")
+        if (
+            self.iteration < 0
+            or not self.host_ranks
+            or self.host_rank not in self.host_ranks
+        ):
+            raise ValueError("invalid checkpoint iteration or host membership")
+        if tuple(sorted(set(self.host_ranks))) != self.host_ranks:
+            raise ValueError("host ranks must be sorted and unique")
+        if self.hf_directory is not None:
+            relative_path(self.hf_directory)
+        for path in self.required_files:
+            relative_path(path)
+
+    @property
+    def root(self) -> str:
+        return (
+            f"{self.run_id}/attempts/{self.attempt_id}/snapshots/{self.iteration:07d}"
+        )
+
+    @property
+    def checkpoint_directory(self) -> str:
+        return f"checkpoints/iter_{self.iteration:07d}"
+
+    @property
+    def rollout_file(self) -> str:
+        return f"checkpoints/rollout/global_dataset_state_dict_{self.iteration}.pt"
+
+    @property
+    def manifest_path(self) -> str:
+        return f"{self.run_id}/completed/{self.iteration:07d}-{self.attempt_id}.json"
+
+    def receipt_path(self, rank: int) -> str:
+        return f"{self.root}/receipts/{self.iteration:07d}/{rank}.json"
+
+    def files(self) -> list[Path]:
+        directories = [self.checkpoint_directory]
+        if self.hf_directory:
+            directories.append(self.hf_directory)
+        paths = [
+            path
+            for directory in directories
+            for path in (self.local_root / directory).rglob("*")
+            if path.is_file() and path.name != ".complete"
+        ]
+        rollout = self.local_root / self.rollout_file
+        if rollout.is_file():
+            paths.append(rollout)
+        for path in paths:
+            if path.is_symlink():
+                raise ValueError(
+                    f"checkpoint payload must contain regular files: {path}"
+                )
+        return sorted(paths)
+
+
+class CheckpointUploader:
+    """Persist one immutable snapshot at a time per trainer host."""
+
+    def __init__(
+        self,
+        mount: Path,
+        volume: Any,
+        *,
+        bytes_per_second: int = 256 * 1024**2,
+        timeout_seconds: float = 6 * 60 * 60,
+        poll_seconds: float = 2,
+    ):
+        if bytes_per_second < 0 or timeout_seconds <= 0 or poll_seconds <= 0:
+            raise ValueError("invalid checkpoint upload limits")
+        self.mount = mount
+        self.volume = volume
+        self.bytes_per_second = bytes_per_second
+        self.timeout_seconds = timeout_seconds
+        self.poll_seconds = poll_seconds
+        self._executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="checkpoint-upload"
+        )
+        self._future: Future | None = None
+
+    def check(self) -> None:
+        if self._future is not None and self._future.done():
+            try:
+                self._future.result()
+            except Exception as exc:
+                raise RuntimeError(f"checkpoint upload failed: {exc}") from exc
+            self._future = None
+
+    @property
+    def pending(self) -> int:
+        self.check()
+        return int(self._future is not None)
+
+    @property
+    def has_capacity(self) -> bool:
+        return self.pending == 0
+
+    def submit(self, upload: CheckpointUpload) -> None:
+        if not self.has_capacity:
+            raise RuntimeError("checkpoint uploader has no capacity")
+        self._future = self._executor.submit(self._upload, upload)
+        self._event("queued", upload)
+
+    def close(self) -> None:
+        self._executor.shutdown(wait=True)
+
+    def _event(self, phase: str, upload: CheckpointUpload, **fields) -> None:
+        logger.info(
+            "CHECKPOINT %s",
+            json.dumps(
+                {
+                    "phase": phase,
+                    "iteration": upload.iteration,
+                    "host_rank": upload.host_rank,
+                    **fields,
+                },
+                sort_keys=True,
+            ),
+        )
+
+    def _read_json(self, path: str) -> dict | None:
+        try:
+            return json.loads(b"".join(self.volume.read_file(path)))
+        except FileNotFoundError:
+            return None
+
+    def _write_json(self, path: str, value: dict) -> None:
+        destination = self.mount / path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_suffix(".tmp")
+        temporary.write_text(json.dumps(value, sort_keys=True))
+        temporary.replace(destination)
+
+    def _upload(self, upload: CheckpointUpload) -> None:
+        started = time.monotonic()
+        deadline = started + self.timeout_seconds
+        copied = 0
+        reported = started
+        files = {}
+        try:
+            for source in upload.files():
+                name = source.relative_to(upload.local_root).as_posix()
+                destination = self.mount / upload.root / name
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                checksum = hashlib.sha256()
+                size = 0
+                with source.open("rb") as reader, destination.open("wb") as writer:
+                    while True:
+                        chunk_started = time.monotonic()
+                        chunk = reader.read(4 * 1024**2)
+                        if not chunk:
+                            break
+                        writer.write(chunk)
+                        checksum.update(chunk)
+                        copied += len(chunk)
+                        size += len(chunk)
+                        now = time.monotonic()
+                        if now > deadline:
+                            raise TimeoutError(
+                                "checkpoint copy exceeded upload deadline"
+                            )
+                        if self.bytes_per_second:
+                            delay = len(chunk) / self.bytes_per_second - (
+                                now - chunk_started
+                            )
+                            if delay > 0:
+                                time.sleep(delay)
+                        if now - reported >= 10:
+                            self._event(
+                                "copying",
+                                upload,
+                                bytes=copied,
+                                age_seconds=now - started,
+                            )
+                            reported = now
+                files[name] = {"size": size, "sha256": checksum.hexdigest()}
+            self.volume.commit()
+            receipt = {
+                "iteration": upload.iteration,
+                "attempt_id": upload.attempt_id,
+                "host_rank": upload.host_rank,
+                "host_ranks": list(upload.host_ranks),
+                "files": files,
+                "required_files": list(upload.required_files),
+            }
+            self._write_json(upload.receipt_path(upload.host_rank), receipt)
+            self.volume.commit()
+            self._event("host_committed", upload, bytes=copied)
+            if upload.host_rank == upload.host_ranks[0]:
+                self._complete(upload, deadline)
+            while self._read_json(upload.manifest_path) is None:
+                self._wait(deadline)
+            shutil.rmtree(upload.local_root / upload.checkpoint_directory)
+            if upload.hf_directory:
+                shutil.rmtree(
+                    upload.local_root / upload.hf_directory, ignore_errors=True
+                )
+            (upload.local_root / upload.rollout_file).unlink(missing_ok=True)
+            self._event(
+                "durable", upload, bytes=copied, seconds=time.monotonic() - started
+            )
+        except Exception:
+            self._event("failed", upload, retained_local_root=str(upload.local_root))
+            raise
+
+    def _wait(self, deadline: float) -> None:
+        if time.monotonic() >= deadline:
+            raise TimeoutError("timed out waiting for every checkpoint host to commit")
+        time.sleep(min(self.poll_seconds, max(0, deadline - time.monotonic())))
+
+    def _complete(self, upload: CheckpointUpload, deadline: float) -> None:
+        receipts = {}
+        while len(receipts) != len(upload.host_ranks):
+            for rank in upload.host_ranks:
+                if rank not in receipts:
+                    receipt = self._read_json(upload.receipt_path(rank))
+                    if receipt is not None:
+                        if (
+                            receipt["iteration"],
+                            receipt["attempt_id"],
+                            receipt["host_rank"],
+                            tuple(receipt["host_ranks"]),
+                        ) != (
+                            upload.iteration,
+                            upload.attempt_id,
+                            rank,
+                            upload.host_ranks,
+                        ):
+                            raise ValueError(
+                                "checkpoint receipt belongs to a different snapshot"
+                            )
+                        receipts[rank] = receipt
+            if len(receipts) != len(upload.host_ranks):
+                self._wait(deadline)
+        files = {}
+        required = set()
+        for receipt in receipts.values():
+            for path, entry in receipt["files"].items():
+                if path in files:
+                    raise ValueError(
+                        f"checkpoint file has multiple host writers: {path}"
+                    )
+                files[path] = entry
+            required.update(receipt["required_files"])
+        missing = required - files.keys()
+        if missing:
+            raise ValueError(
+                f"checkpoint is missing referenced files: {sorted(missing)}"
+            )
+        root = self.mount / upload.root
+        # These are compatibility metadata for Megatron/HF loaders. The manifest
+        # below is the sole publication boundary used by cookbook discovery.
+        if upload.hf_directory:
+            (root / upload.hf_directory / ".complete").touch()
+        tracker = root / "checkpoints/latest_checkpointed_iteration.txt"
+        tracker.parent.mkdir(parents=True, exist_ok=True)
+        tracker.write_text(str(upload.iteration))
+        self.volume.commit()
+        self._write_json(
+            upload.manifest_path,
+            {
+                "schema_version": 1,
+                "run_id": upload.run_id,
+                "completed_at_ns": time.time_ns(),
+                "attempt_id": upload.attempt_id,
+                "iteration": upload.iteration,
+                "version": upload.iteration + 1,
+                "host_ranks": list(upload.host_ranks),
+                "checkpoint_root": f"{upload.root}/checkpoints",
+                "hf_directory": f"{upload.root}/{upload.hf_directory}"
+                if upload.hf_directory
+                else None,
+                "files": files,
+            },
+        )
+        self.volume.commit()

--- a/cookbook/miles_disagg/checkpoint_hooks.py
+++ b/cookbook/miles_disagg/checkpoint_hooks.py
@@ -1,0 +1,263 @@
+"""Miles integration for local snapshots and background checkpoint persistence.
+
+All collective calls run on the training thread, in the same order on every
+rank. Only elected host leaders own uploaders. An in-flight upload skips periodic
+saves across the actor group; explicit/final saves wait and then save.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pickle
+import shutil
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from cookbook.common.constants import TRAINING_CHECKPOINTS_PATH
+from cookbook.miles_disagg.checkpoint import CheckpointUpload, CheckpointUploader
+
+logger = logging.getLogger(__name__)
+
+
+def configure_checkpointing(
+    cfg: Any,
+    *,
+    run_id: str,
+    attempt_id: str,
+    volume_name: str,
+    upload_mib_per_second: int = 256,
+    min_free_disk_mib: int = 65536,
+    timeout_seconds: int = 21600,
+) -> dict:
+    """Set launcher-owned local paths; return configuration for Miles hooks."""
+    if getattr(cfg, "save_interval", None) is None:
+        cfg.save = cfg.save_hf = None
+        return {}
+    if getattr(cfg, "train_backend", "megatron") != "megatron" or getattr(
+        cfg, "use_critic", False
+    ):
+        raise ValueError(
+            "local checkpoint staging currently requires a Megatron actor-only recipe"
+        )
+    if getattr(cfg, "async_save", False):
+        raise ValueError(
+            "local checkpoint staging requires async_save=False; persistence is asynchronous"
+        )
+    if upload_mib_per_second < 0 or min_free_disk_mib < 0 or timeout_seconds <= 0:
+        raise ValueError("invalid checkpoint staging limits")
+    from cookbook.miles_disagg.checkpoint import relative_path
+
+    relative_path(run_id)
+    relative_path(attempt_id)
+    root = Path("/tmp/stitch-checkpoints") / run_id / attempt_id
+    hf = getattr(cfg, "save_hf", None)
+    if hf:
+        from cookbook.miles_disagg.resume import _validate_save_hf_template
+
+        _validate_save_hf_template(hf)
+        cfg.save_hf = str(root / hf)
+    cfg.save = str(root / "checkpoints")
+    # Local snapshots must be closed and immutable before the uploader sees them.
+    cfg.async_save = False
+    return {
+        "stitch_checkpoint_local_root": str(root),
+        "stitch_checkpoint_attempt_id": attempt_id,
+        "stitch_checkpoint_volume": volume_name,
+        "custom_checkpoint_persistence_path": "cookbook.miles_disagg.checkpoint_hooks.CheckpointSession",
+        "stitch_checkpoint_upload_mib_per_second": upload_mib_per_second,
+        "stitch_checkpoint_min_free_disk_mib": min_free_disk_mib,
+        "stitch_checkpoint_timeout_seconds": timeout_seconds,
+    }
+
+
+class CheckpointSession:
+    def __init__(self, args: Any):
+        import torch.distributed as dist
+        from miles.utils.distributed_utils import get_gloo_group
+
+        self.args = args
+        self.rank = dist.get_rank()
+        self.group = get_gloo_group()
+        self.local_root = Path(args.stitch_checkpoint_local_root)
+        self.local_root.mkdir(parents=True, exist_ok=True)
+        # Container identity describes shared disk, unlike CUDA local_rank when
+        # Ray places independent actor processes on the same trainer host.
+        host = os.environ.get("MODAL_TASK_ID")
+        if not host:
+            raise RuntimeError("checkpoint host election requires MODAL_TASK_ID")
+        hosts = self.gather(host)
+        self.host_ranks = tuple(
+            i for i, value in enumerate(hosts) if value not in hosts[:i]
+        )
+        self.uploader = None
+        if self.rank in self.host_ranks:
+            import modal
+
+            self.uploader = CheckpointUploader(
+                TRAINING_CHECKPOINTS_PATH,
+                modal.Volume.from_name(args.stitch_checkpoint_volume),
+                bytes_per_second=args.stitch_checkpoint_upload_mib_per_second * 1024**2,
+                timeout_seconds=args.stitch_checkpoint_timeout_seconds,
+            )
+
+    def gather(self, value):
+        import torch.distributed as dist
+
+        values = [None] * dist.get_world_size(self.group)
+        dist.all_gather_object(values, value, group=self.group)
+        return values
+
+    def collectively(self, operation: Callable[[], Any]) -> list[Any]:
+        result, error = None, None
+        try:
+            result = operation()
+        except Exception as exc:
+            error = f"rank {self.rank}: {type(exc).__name__}: {exc}"
+        states = self.gather((result, error))
+        errors = [error for _, error in states if error]
+        if errors:
+            raise RuntimeError("checkpoint persistence failed:\n" + "\n".join(errors))
+        return [result for result, _ in states]
+
+    def wait(self) -> None:
+        deadline = time.monotonic() + self.args.stitch_checkpoint_timeout_seconds + 60
+
+        def pending_on_host():
+            if time.monotonic() >= deadline:
+                raise TimeoutError("checkpoint drain deadline expired")
+            return self.uploader.pending if self.uploader else 0
+
+        # Keep every rank participating in short collectives. Blocking on a
+        # host's upload Future would strand its peers in all_gather long enough
+        # to hit the process-group timeout during a slow final checkpoint.
+        while True:
+            pending = self.collectively(pending_on_host)
+            if not any(pending):
+                return
+            time.sleep(0.5)
+
+    def prepare(self, iteration: int, *, force_sync: bool) -> bool:
+        if force_sync:
+            self.wait()
+        available = self.collectively(
+            lambda: self.uploader.has_capacity if self.uploader else True
+        )
+        if not all(available):
+            if self.rank == 0:
+                logger.warning(
+                    "CHECKPOINT %s",
+                    json.dumps(
+                        {
+                            "phase": "skipped",
+                            "iteration": iteration,
+                            "reason": "upload_in_progress",
+                        }
+                    ),
+                )
+            # The rollout manager saved this small file before entering the actor.
+            (
+                self.local_root
+                / f"checkpoints/rollout/global_dataset_state_dict_{iteration}.pt"
+            ).unlink(missing_ok=True)
+            return False
+
+        def prepare():
+            free = shutil.disk_usage(self.local_root).free
+            if free < self.args.stitch_checkpoint_min_free_disk_mib * 1024**2:
+                raise RuntimeError(
+                    f"insufficient local checkpoint disk: {free} bytes free"
+                )
+            # Megatron creates the directory on global rank 0. Node-local disk
+            # requires that each host creates its own directory before saving.
+            (self.local_root / f"checkpoints/iter_{iteration:07d}").mkdir(
+                parents=True, exist_ok=True
+            )
+
+        self.collectively(prepare)
+        self._snapshot_started = time.monotonic()
+        return True
+
+    def persist(self, iteration: int) -> None:
+        if self.rank == 0:
+            logger.info(
+                "CHECKPOINT %s",
+                json.dumps(
+                    {
+                        "phase": "local_snapshot_complete",
+                        "iteration": iteration,
+                        "seconds": time.monotonic() - self._snapshot_started,
+                    }
+                ),
+            )
+
+        def enqueue():
+            if not self.uploader:
+                return
+            hf = self.args.save_hf
+            hf_directory = (
+                Path(hf.format(rollout_id=iteration))
+                .relative_to(self.local_root)
+                .as_posix()
+                if hf
+                else None
+            )
+            required = ()
+            if self.rank == 0:
+                required = required_snapshot_files(
+                    self.local_root,
+                    iteration,
+                    hf_directory,
+                    include_rollout=bool(self.args.rollout_global_dataset),
+                )
+            self.uploader.submit(
+                CheckpointUpload(
+                    local_root=self.local_root,
+                    run_id=self.args.run_id,
+                    attempt_id=self.args.stitch_checkpoint_attempt_id,
+                    iteration=iteration,
+                    host_rank=self.rank,
+                    host_ranks=self.host_ranks,
+                    hf_directory=hf_directory,
+                    required_files=required,
+                )
+            )
+
+        self.collectively(enqueue)
+
+
+def required_snapshot_files(
+    local_root: Path, iteration: int, hf_directory: str | None, *, include_rollout: bool
+) -> tuple[str, ...]:
+    """Read writer metadata to verify every referenced shard has a durable receipt."""
+    checkpoint = f"checkpoints/iter_{iteration:07d}"
+    metadata_path = local_root / checkpoint / ".metadata"
+    # Only unpickle the checkpoint just produced by our own trainer.
+    with metadata_path.open("rb") as file:
+        metadata = pickle.load(file)
+    required = {
+        f"{checkpoint}/.metadata",
+        f"{checkpoint}/common.pt",
+        f"{checkpoint}/metadata.json",
+    }
+    required.update(
+        f"{checkpoint}/{entry.relative_path}"
+        for entry in metadata.storage_data.values()
+    )
+    if hf_directory:
+        hf = local_root / hf_directory
+        if not (hf / ".complete").is_file():
+            raise RuntimeError("HF export failed: local completion marker is missing")
+        index_path = hf / "model.safetensors.index.json"
+        index = json.loads(index_path.read_text())
+        if not index["weight_map"]:
+            raise RuntimeError("HF export produced no weights")
+        required.add(f"{hf_directory}/model.safetensors.index.json")
+        required.update(
+            f"{hf_directory}/{name}" for name in index["weight_map"].values()
+        )
+    if include_rollout:
+        required.add(f"checkpoints/rollout/global_dataset_state_dict_{iteration}.pt")
+    return tuple(sorted(required))

--- a/cookbook/miles_disagg/checkpoint_hooks_test.py
+++ b/cookbook/miles_disagg/checkpoint_hooks_test.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+import pytest
+
+from cookbook.miles_disagg import checkpoint_hooks
+from cookbook.miles_disagg.checkpoint_hooks import configure_checkpointing
+
+
+def test_full_checkpoints_use_ephemeral_disk_and_a_separate_volume():
+    cfg = SimpleNamespace(
+        save_interval=10, save_hf="hf_checkpoints/weight_v{rollout_id:06d}"
+    )
+    hooks = configure_checkpointing(
+        cfg, run_id="run", attempt_id="attempt", volume_name="run-checkpoints"
+    )
+    assert cfg.save == "/tmp/stitch-checkpoints/run/attempt/checkpoints"
+    assert (
+        cfg.save_hf
+        == "/tmp/stitch-checkpoints/run/attempt/hf_checkpoints/weight_v{rollout_id:06d}"
+    )
+    assert not cfg.async_save
+    assert hooks["stitch_checkpoint_volume"] == "run-checkpoints"
+
+
+def test_disabled_checkpoints_do_not_start_a_persistence_session():
+    cfg = SimpleNamespace(save_interval=None, save_hf="unused")
+    assert (
+        configure_checkpointing(
+            cfg, run_id="run", attempt_id="attempt", volume_name="checkpoints"
+        )
+        == {}
+    )
+    assert cfg.save is None and cfg.save_hf is None
+
+
+def test_async_serialization_cannot_publish_an_unfinished_local_snapshot():
+    cfg = SimpleNamespace(save_interval=10, async_save=True)
+    with pytest.raises(ValueError, match="async_save=False"):
+        configure_checkpointing(
+            cfg, run_id="run", attempt_id="attempt", volume_name="checkpoints"
+        )
+
+
+
+def test_final_drain_keeps_collective_participants_polling(monkeypatch):
+    """A host must not wait on network I/O while its peers enter a collective."""
+    from unittest.mock import Mock, PropertyMock
+
+    worker = Mock()
+    type(worker).pending = PropertyMock(side_effect=[1, 0])
+    session = checkpoint_hooks.CheckpointSession.__new__(
+        checkpoint_hooks.CheckpointSession
+    )
+    session.args = SimpleNamespace(stitch_checkpoint_timeout_seconds=1)
+    session.rank = 0
+    session.uploader = worker
+    states = []
+    session.gather = lambda value: states.append(value) or [value]
+    monkeypatch.setattr(checkpoint_hooks.time, "sleep", lambda seconds: None)
+    session.wait()
+    assert states == [(1, None), (0, None)]

--- a/cookbook/miles_disagg/checkpoint_test.py
+++ b/cookbook/miles_disagg/checkpoint_test.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from cookbook.miles_disagg.checkpoint import CheckpointUpload, CheckpointUploader
+
+
+class MemoryVolume:
+    """Distinct mounts see files only after the writing mount commits."""
+
+    def __init__(self, mount: Path, durable: dict[str, bytes]):
+        self.mount = mount
+        self.durable = durable
+        self.commit_started = threading.Event()
+        self.allow_commit = threading.Event()
+        self.allow_commit.set()
+        self.fail_commit = False
+
+    def commit(self):
+        self.commit_started.set()
+        assert self.allow_commit.wait(5), "test commit was never released"
+        if self.fail_commit:
+            raise OSError("injected commit failure")
+        for path in self.mount.rglob("*"):
+            if path.is_file():
+                self.durable[path.relative_to(self.mount).as_posix()] = (
+                    path.read_bytes()
+                )
+
+    def read_file(self, path):
+        try:
+            yield self.durable[path]
+        except KeyError:
+            raise FileNotFoundError(path) from None
+
+
+def make_upload(tmp_path, host, *, iteration=9, hosts=(0, 8)):
+    local = tmp_path / f"local-{host}"
+    checkpoint = local / f"checkpoints/iter_{iteration:07d}"
+    checkpoint.mkdir(parents=True)
+    (checkpoint / f"__{host}_0.distcp").write_bytes(f"weights-{host}".encode())
+    hf_dir = f"hf_checkpoints/weight_v{iteration:06d}"
+    if host == 0:
+        (checkpoint / ".metadata").write_bytes(b"metadata")
+        (checkpoint / "common.pt").write_bytes(b"optimizer-scheduler-rng")
+        hf = local / hf_dir
+        hf.mkdir(parents=True)
+        (hf / "model.safetensors").write_bytes(b"hf-weights")
+        (hf / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": {"weight": "model.safetensors"}})
+        )
+        (hf / ".complete").touch()
+    return CheckpointUpload(
+        local_root=local,
+        run_id="run",
+        attempt_id="attempt",
+        iteration=iteration,
+        host_rank=host,
+        host_ranks=hosts,
+        hf_directory=hf_dir,
+    )
+
+
+def uploader(tmp_path, host, durable, **kwargs):
+    mount = tmp_path / f"mount-{host}"
+    mount.mkdir()
+    volume = MemoryVolume(mount, durable)
+    return CheckpointUploader(
+        mount,
+        volume,
+        bytes_per_second=0,
+        poll_seconds=0.01,
+        timeout_seconds=4,
+        **kwargs,
+    ), volume
+
+
+def wait_for_upload(worker):
+    deadline = time.monotonic() + 5
+    while worker.pending:
+        assert time.monotonic() < deadline, "upload did not finish"
+        time.sleep(0.01)
+
+
+def test_slow_commit_does_not_block_submit_or_publish_partial_checkpoint(tmp_path):
+    durable = {}
+    first, volume0 = uploader(tmp_path, 0, durable)
+    second, _ = uploader(tmp_path, 8, durable)
+    upload0 = make_upload(tmp_path, 0)
+    upload8 = make_upload(tmp_path, 8)
+    volume0.allow_commit.clear()
+    try:
+        first.submit(upload0)
+        assert volume0.commit_started.wait(2)
+        second.submit(upload8)
+        assert first.pending == 1
+        assert not first.has_capacity
+        assert not any(path.startswith("run/completed/") for path in durable)
+        assert upload0.local_root.exists()
+        volume0.allow_commit.set()
+        wait_for_upload(first)
+        wait_for_upload(second)
+        manifest = json.loads(durable[upload0.manifest_path])
+        assert manifest["version"] == 10
+        assert set(manifest["host_ranks"]) == {0, 8}
+        root = "run/attempts/attempt/snapshots/0000009"
+        for rank in (0, 8):
+            assert (
+                durable[f"{root}/checkpoints/iter_0000009/__{rank}_0.distcp"]
+                == f"weights-{rank}".encode()
+            )
+        assert durable[f"{root}/checkpoints/latest_checkpointed_iteration.txt"] == b"9"
+        assert not (upload0.local_root / "checkpoints/iter_0000009").exists()
+        assert not (upload8.local_root / "checkpoints/iter_0000009").exists()
+    finally:
+        volume0.allow_commit.set()
+        first.close()
+        second.close()
+
+
+def test_failed_upload_retains_local_snapshot_and_never_advertises_completion(tmp_path):
+    worker, volume = uploader(tmp_path, 0, {})
+    upload = make_upload(tmp_path, 0, hosts=(0,))
+    volume.fail_commit = True
+    try:
+        worker.submit(upload)
+        with pytest.raises(RuntimeError, match="injected commit failure"):
+            wait_for_upload(worker)
+        assert (upload.local_root / "checkpoints/iter_0000009").exists()
+        assert upload.manifest_path not in volume.durable
+    finally:
+        worker.close()
+
+
+def test_only_one_snapshot_is_accepted_at_a_time(tmp_path):
+    worker, volume = uploader(tmp_path, 0, {})
+    volume.allow_commit.clear()
+    try:
+        worker.submit(make_upload(tmp_path, 0, hosts=(0,)))
+        assert volume.commit_started.wait(2)
+        with pytest.raises(RuntimeError, match="capacity"):
+            worker.submit(make_upload(tmp_path, 0, iteration=19, hosts=(0,)))
+    finally:
+        volume.allow_commit.set()
+        worker.close()
+
+
+
+def test_missing_shard_receipt_prevents_completion(tmp_path):
+    from dataclasses import replace
+
+    worker, volume = uploader(tmp_path, 0, {})
+    upload = replace(
+        make_upload(tmp_path, 0, hosts=(0,)),
+        required_files=("checkpoints/iter_0000009/missing.distcp",),
+    )
+    try:
+        worker.submit(upload)
+        with pytest.raises(RuntimeError, match="missing referenced files"):
+            wait_for_upload(worker)
+        assert upload.manifest_path not in volume.durable
+        assert (upload.local_root / upload.checkpoint_directory).is_dir()
+    finally:
+        worker.close()
+
+
+def test_completed_upload_releases_capacity_for_the_next_snapshot(tmp_path):
+    worker, volume = uploader(tmp_path, 0, {})
+    try:
+        for iteration in (9, 19):
+            upload = make_upload(tmp_path, 0, iteration=iteration, hosts=(0,))
+            worker.submit(upload)
+            wait_for_upload(worker)
+            assert worker.has_capacity
+            assert upload.manifest_path in volume.durable
+    finally:
+        worker.close()

--- a/cookbook/miles_disagg/patches/miles-disk-delta-hf-save.patch
+++ b/cookbook/miles_disagg/patches/miles-disk-delta-hf-save.patch
@@ -1,0 +1,14 @@
+--- a/miles/backends/megatron_utils/hf_export.py
++++ b/miles/backends/megatron_utils/hf_export.py
+@@ -135,7 +135,10 @@
+         if should_log:
+             logger.info(f"Saving model in HuggingFace format to {path}")
+ 
+-        if args.megatron_to_hf_mode == "raw" and not is_lora_model(model):
++        if not is_lora_model(model) and (
++            args.megatron_to_hf_mode == "raw"
++            or getattr(args, "update_weight_transfer_mode", None) == "disk-delta"
++        ):
+             # LoRA keeps the bridge (adapter merging).
+             hf_config = load_hf_config(args.hf_checkpoint)
+             export_hf_model_direct(

--- a/cookbook/miles_disagg/patches/miles-hf-export-static-tensors.patch
+++ b/cookbook/miles_disagg/patches/miles-hf-export-static-tensors.patch
@@ -1,0 +1,40 @@
+--- a/miles/backends/megatron_utils/hf_export.py
++++ b/miles/backends/megatron_utils/hf_export.py
+@@ -35,6 +35,29 @@
+     """Tokenizer/config files worth copying into an export — not weights, and not the
+     base checkpoint's weight index, which would clobber the one the export writes."""
+     return path.is_file() and path.suffix not in HF_WEIGHT_SUFFIXES and not path.name.endswith(".index.json")
++
++
++def _copy_source_static_tensors(base_checkpoint: Path, path: Path, weight_map: dict[str, str]) -> int:
++    """Preserve fixed calibration and rotary buffers omitted by Megatron."""
++    index_path = base_checkpoint / "model.safetensors.index.json"
++    if not index_path.exists():
++        return 0
++    source_map = json.loads(index_path.read_text())["weight_map"]
++    by_shard: dict[str, list[str]] = {}
++    for name, shard in source_map.items():
++        if name.endswith((".input_scale", ".rotary_emb.inv_freq")) and name not in weight_map:
++            by_shard.setdefault(shard, []).append(name)
++    tensors = {}
++    for shard, names in by_shard.items():
++        with safetensors.safe_open(base_checkpoint / shard, framework="pt", device="cpu") as source:
++            for name in names:
++                tensors[name] = source.get_tensor(name).contiguous()
++    if not tensors:
++        return 0
++    shard_name = "model-static.safetensors"
++    safetensors.torch.save_file(tensors, path / shard_name)
++    weight_map.update({name: shard_name for name in tensors})
++    return sum(t.numel() * t.element_size() for t in tensors.values())
+ 
+ 
+ def export_hf_model_direct(
+@@ -82,6 +105,7 @@
+             assert weight_map, f"HF export to {path} produced no weights"
+             base_checkpoint = Path(args.hf_checkpoint)
+             if base_checkpoint.is_dir():
++                total_size += _copy_source_static_tensors(base_checkpoint, path, weight_map)
+                 for meta_file in base_checkpoint.iterdir():
+                     if _is_hf_metadata_file(meta_file):
+                         shutil.copy2(meta_file, path / meta_file.name)

--- a/cookbook/miles_disagg/patches/miles-hf-router-bias-dtype.patch
+++ b/cookbook/miles_disagg/patches/miles-hf-router-bias-dtype.patch
@@ -1,0 +1,57 @@
+--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
++++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+@@ -1,3 +1,5 @@
++from miles.backends.megatron_utils.megatron_to_hf.checkpoint_schema import _restore_checkpoint_bias_dtype
++
+ from .deepseekv3 import convert_deepseekv3_to_hf
+ from .deepseekv4 import convert_deepseekv4_to_hf
+ from .glm4 import convert_glm4_to_hf
+@@ -24,7 +26,10 @@
+ def convert_to_hf(args, model_name, name, param, quantization_config=None):
+     param = remove_padding(name, param, args.vocab_size)
+ 
+-    converted_named_tensors = _convert_to_hf_core(args, model_name, name, param)
++    converted_named_tensors = [
++        (hf_name, _restore_checkpoint_bias_dtype(args, hf_name, weight))
++        for hf_name, weight in _convert_to_hf_core(args, model_name, name, param)
++    ]
+ 
+     return quantize_params(args, name, converted_named_tensors, quantization_config)
+ 
+--- /dev/null
++++ b/miles/backends/megatron_utils/megatron_to_hf/checkpoint_schema.py
+@@ -0,0 +1,34 @@
++"""Preserve checkpoint storage dtypes for Megatron's FP32 router buffers."""
++
++import json
++from functools import lru_cache
++from pathlib import Path
++
++import torch
++from safetensors import safe_open
++
++
++def _restore_checkpoint_bias_dtype(args, name, param):
++    if (
++        getattr(args, "update_weight_transfer_mode", None) != "disk-delta"
++        or not name.endswith(".e_score_correction_bias")
++    ):
++        return param
++    dtype = _checkpoint_bias_dtypes(args.hf_checkpoint).get(name)
++    return param.to(dtype) if dtype is not None else param
++
++
++@lru_cache(maxsize=8)
++def _checkpoint_bias_dtypes(checkpoint):
++    root = Path(checkpoint)
++    index = root / "model.safetensors.index.json"
++    if not index.exists():
++        return {}
++    names = json.loads(index.read_text())["weight_map"]
++    dtypes = {"BF16": torch.bfloat16, "F16": torch.float16, "F32": torch.float32}
++    result = {}
++    for name, shard in names.items():
++        if name.endswith(".e_score_correction_bias"):
++            with safe_open(root / shard, framework="pt") as source:
++                result[name] = dtypes[source.get_slice(name).get_dtype()]
++    return result

--- a/cookbook/miles_disagg/patches/miles-local-checkpoints.patch
+++ b/cookbook/miles_disagg/patches/miles-local-checkpoints.patch
@@ -1,0 +1,139 @@
+diff --git a/miles/backends/megatron_utils/actor.py b/miles/backends/megatron_utils/actor.py
+--- a/miles/backends/megatron_utils/actor.py
++++ b/miles/backends/megatron_utils/actor.py
+@@ -24,6 +24,8 @@
+ from miles.utils.ft_utils.indep_dp import IndepDPInfo
+ from miles.utils.hf_config import load_hf_config
+ from miles.utils.memory_utils import clear_memory, print_memory
++from miles.backends.megatron_utils.checkpoint_persistence import CheckpointPersistence
++from miles.utils.misc import load_function
+ from miles.utils.multi_lora import is_multi_lora_enabled
+ from miles.utils.processing_utils import load_tokenizer
+ from miles.utils.ray_utils import Box
+@@ -694,8 +696,30 @@
+             for name in cleanup_names - loaded_names:
+                 ray.get(get_multi_lora_controller().free_slot.remote(name))
+ 
++    def _get_checkpoint_persistence(self) -> CheckpointPersistence | None:
++        path = getattr(self.args, "custom_checkpoint_persistence_path", None)
++        if not path:
++            return None
++        if not hasattr(self, "_checkpoint_persistence"):
++            self._checkpoint_persistence = load_function(path)(self.args)
++        return self._checkpoint_persistence
++
+     @timer
+     def save_model(self, rollout_id: int, force_sync: bool = False) -> None:
++        persistence = self._get_checkpoint_persistence()
++        if persistence and not persistence.prepare(rollout_id, force_sync=force_sync):
++            return
++        self._save_model(rollout_id, force_sync)
++        if persistence:
++            persistence.persist(rollout_id)
++            if force_sync:
++                persistence.wait()
++
++    def finish_checkpoint_persistence(self) -> None:
++        if persistence := self._get_checkpoint_persistence():
++            persistence.wait()
++
++    def _save_model(self, rollout_id: int, force_sync: bool = False) -> None:
+         self._heartbeat.bump()
+         if self.args.debug_rollout_only:
+             return
+diff --git a/miles/backends/megatron_utils/checkpoint_persistence.py b/miles/backends/megatron_utils/checkpoint_persistence.py
+new file mode 100644
+--- /dev/null
++++ b/miles/backends/megatron_utils/checkpoint_persistence.py
+@@ -0,0 +1,23 @@
++from typing import Protocol
++
++
++class CheckpointPersistence(Protocol):
++    """Persistence for synchronous, rank-local checkpoint snapshots.
++
++    Miles calls every method on all actor ranks in the same order. Implementations
++    coordinate admission and failures across ranks and retain snapshot files until
++    durable. Periodic saves may be skipped; forced saves and normal shutdown wait
++    for durability. Abrupt process loss may discard pending snapshots.
++    """
++
++    def prepare(self, iteration: int, *, force_sync: bool) -> bool:
++        """Prepare local paths and agree to save; forced saves must wait for capacity."""
++        ...
++
++    def persist(self, iteration: int) -> None:
++        """Accept the closed model, optimizer, and sampler files for background persistence."""
++        ...
++
++    def wait(self) -> None:
++        """Wait for all accepted snapshots to become durable, propagating failures."""
++        ...
+diff --git a/miles/ray/actor_group.py b/miles/ray/actor_group.py
+--- a/miles/ray/actor_group.py
++++ b/miles/ray/actor_group.py
+@@ -112,6 +112,9 @@
+         """Save actor model"""
+         await self._broadcast("save_model", rollout_id, force_sync=force_sync)
+ 
++    async def finish_checkpoint_persistence(self):
++        await self._broadcast("finish_checkpoint_persistence")
++
+     async def export_hf(self, rollout_id: int, path: str):
+         """Export current weights as an HF checkpoint (collective across all ranks)."""
+         await self._broadcast("export_hf", rollout_id, path)
+diff --git a/train.py b/train.py
+--- a/train.py
++++ b/train.py
+@@ -84,11 +84,14 @@
+             if args.use_critic and args.offload_train:
+                 await model.offload()
+ 
++        if getattr(args, "custom_checkpoint_persistence_path", None):
++            await rollout_manager.save.remote(rollout_id)
+         if (not args.use_critic) or (rollout_id >= args.num_critic_only_steps):
+             await save_training_model(actor_model)
+         if args.use_critic:
+             await save_training_model(critic_model)
+-        await rollout_manager.save.remote(rollout_id)
++        if not getattr(args, "custom_checkpoint_persistence_path", None):
++            await rollout_manager.save.remote(rollout_id)
+ 
+     # train loop.
+     # note that for async training, one can change the position of the sync operation(ray.get).
+@@ -147,6 +150,8 @@
+             )
+             break
+ 
++    if getattr(args, "custom_checkpoint_persistence_path", None):
++        await actor_model.finish_checkpoint_persistence()
+     await rollout_manager.dispose.remote()
+ 
+ 
+diff --git a/train_async.py b/train_async.py
+--- a/train_async.py
++++ b/train_async.py
+@@ -118,10 +118,13 @@
+             rollout_id, args.save_interval, num_rollout_per_epoch, args.num_rollout
+         ):
+             force_sync = external_save or rollout_id == args.num_rollout - 1
++            if getattr(args, "custom_checkpoint_persistence_path", None):
++                await rollout_manager.save.remote(rollout_id)
+             await save_training_model(actor_model, rollout_id, force_sync)
+             if args.use_critic:
+                 await save_training_model(critic_model, rollout_id, force_sync)
+-            await rollout_manager.save.remote(rollout_id)
++            if not getattr(args, "custom_checkpoint_persistence_path", None):
++                await rollout_manager.save.remote(rollout_id)
+             if external_save:
+                 os.remove(args.save_trigger_sentinel)
+ 
+@@ -148,6 +151,8 @@
+             break
+ 
+     await eval_dispatcher.drain()
++    if getattr(args, "custom_checkpoint_persistence_path", None):
++        await actor_model.finish_checkpoint_persistence()
+     await rollout_manager.dispose.remote()
+ 
+ 

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -9,7 +9,8 @@ from io import BytesIO
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from cookbook.common.constants import STITCH_PATH
+from cookbook.common.constants import STITCH_PATH, TRAINING_CHECKPOINTS_PATH
+from cookbook.miles_disagg.checkpoint import relative_path
 from stitch.types import WEIGHT_PREFIX, VersionRef
 
 TRAINER_CALL_FILE = "trainer_call_id"
@@ -29,6 +30,7 @@ class ResumePoint:
     source_run_id: str
     trainer_checkpoint: str
     rollout_checkpoint: str
+    staged: bool = False
 
 
 def export_version(iteration: int) -> int:
@@ -68,11 +70,31 @@ def resolve_resume_point(
     *,
     source_run_id: str,
     save_hf: str | None,
+    checkpoint_volume: Any = None,
 ) -> ResumePoint:
     """Resolve the newest complete Megatron/HF checkpoint pair for a run."""
     if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", source_run_id) is None:
         raise ValueError(f"invalid resume run id: {source_run_id!r}")
 
+    point = (
+        _resolve_staged_resume_point(volume, checkpoint_volume, source_run_id)
+        if checkpoint_volume is not None
+        else None
+    )
+    try:
+        legacy = _resolve_legacy_resume_point(volume, source_run_id, save_hf)
+    except ResumePointNotFound:
+        if point is not None:
+            return point
+        raise
+    if point is not None and point.iteration >= legacy.iteration:
+        return point
+    return legacy
+
+
+def _resolve_legacy_resume_point(
+    volume: Any, source_run_id: str, save_hf: str | None
+) -> ResumePoint:
     run_root = PurePosixPath(source_run_id)
     checkpoint_root = run_root / "checkpoints"
     tracker = checkpoint_root / "latest_checkpointed_iteration.txt"
@@ -149,7 +171,7 @@ def _check_published_version(
 
 
 def prepare_attempt(
-    volume: Any, *, run_id: str, save_hf: str | None
+    volume: Any, *, run_id: str, save_hf: str | None, checkpoint_volume: Any = None
 ) -> ResumePoint | None:
     """Restore and return one trainer attempt's resume point, or rewind to the
     boot version and return None when the run has no complete pair yet.
@@ -158,7 +180,12 @@ def prepare_attempt(
     first attempt, a retry, and a manual re-spawn one path.
     """
     try:
-        point = resolve_resume_point(volume, source_run_id=run_id, save_hf=save_hf)
+        point = resolve_resume_point(
+            volume,
+            source_run_id=run_id,
+            save_hf=save_hf,
+            checkpoint_volume=checkpoint_volume,
+        )
     except ResumePointNotFound:
         restore_boot_pointer(volume, run_id)
         return None
@@ -223,11 +250,94 @@ def restore_resume_point(volume: Any, point: ResumePoint) -> VersionRef:
 
     with volume.batch_upload(force=True) as upload:
         upload.put_file(BytesIO(target.identity.encode()), pointer_path)
-        upload.put_file(
-            BytesIO(str(point.iteration).encode()),
-            f"{point.source_run_id}/checkpoints/latest_checkpointed_iteration.txt",
-        )
+        if not point.staged:
+            upload.put_file(
+                BytesIO(str(point.iteration).encode()),
+                f"{point.source_run_id}/checkpoints/latest_checkpointed_iteration.txt",
+            )
     return target
+
+
+def _validate_checkpoint_manifest(manifest: dict, run_id: str) -> None:
+    """Validate the immutable checkpoint address before giving it to a loader."""
+    iteration = manifest["iteration"]
+    attempt = manifest["attempt_id"]
+    if manifest["schema_version"] != 1 or manifest["run_id"] != run_id:
+        raise ValueError("checkpoint manifest schema or run identity mismatch")
+    if (
+        not isinstance(iteration, int)
+        or iteration < 0
+        or manifest["version"] != export_version(iteration)
+    ):
+        raise ValueError("checkpoint manifest iteration/version mismatch")
+    if "/" in relative_path(attempt):
+        raise ValueError("invalid checkpoint attempt ID")
+    root = f"{run_id}/attempts/{attempt}/snapshots/{iteration:07d}"
+    if manifest["checkpoint_root"] != f"{root}/checkpoints":
+        raise ValueError("checkpoint manifest points outside its snapshot")
+    if hf := manifest["hf_directory"]:
+        if not relative_path(hf).startswith(root + "/"):
+            raise ValueError("HF checkpoint points outside its snapshot")
+
+
+def _resolve_staged_resume_point(
+    run_volume: Any, checkpoint_volume: Any, run_id: str
+) -> ResumePoint | None:
+    from modal.exception import NotFoundError
+
+    try:
+        entries = list(
+            checkpoint_volume.iterdir(f"{run_id}/completed", recursive=False)
+        )
+    except (FileNotFoundError, NotFoundError):
+        return None
+    manifests = []
+    for entry in entries:
+        if PurePosixPath(entry.path).suffix != ".json":
+            continue
+        manifest = json.loads(_read_volume_file(checkpoint_volume, entry.path))
+        _validate_checkpoint_manifest(manifest, run_id)
+        if manifest["iteration"] > 0 and manifest["hf_directory"]:
+            manifests.append(manifest)
+    manifests.sort(
+        key=lambda item: (item["iteration"], item["completed_at_ns"]), reverse=True
+    )
+    for manifest in manifests:
+        try:
+            _check_published_version(
+                run_volume, PurePosixPath(run_id), version=manifest["version"]
+            )
+        except FileNotFoundError:
+            continue
+        return ResumePoint(
+            version=manifest["version"],
+            iteration=manifest["iteration"],
+            source_run_id=run_id,
+            trainer_checkpoint=str(
+                TRAINING_CHECKPOINTS_PATH / manifest["checkpoint_root"]
+            ),
+            rollout_checkpoint=str(
+                TRAINING_CHECKPOINTS_PATH / manifest["hf_directory"]
+            ),
+            staged=True,
+        )
+    return None
+
+
+def newest_persisted_export(
+    run_dir: Path, *, latest_version: int
+) -> tuple[int, Path] | None:
+    """Select a fully committed checkpoint from one snapshot of the mounted Volume."""
+    manifests = []
+    for path in (run_dir / "completed").glob("*.json"):
+        manifest = json.loads(path.read_text())
+        _validate_checkpoint_manifest(manifest, run_dir.name)
+        if manifest["hf_directory"] and manifest["version"] <= latest_version:
+            manifests.append(manifest)
+    if not manifests:
+        return None
+    latest = max(manifests, key=lambda item: (item["version"], item["completed_at_ns"]))
+    return latest["version"], run_dir.parent / latest["hf_directory"]
 
 
 def newest_complete_export(

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -8,6 +9,7 @@ from cookbook.miles_disagg.resume import (
     ResumePoint,
     export_version,
     newest_complete_export,
+    newest_persisted_export,
     prepare_attempt,
     read_trainer_call,
     record_trainer_call,
@@ -332,3 +334,136 @@ def test_newest_complete_export_is_none_before_the_first_save(tmp_path) -> None:
         newest_complete_export(tmp_path, save_hf=_Config.save_hf, latest_version=9)
         is None
     )
+
+
+def _staged_manifest(iteration=19, attempt="attempt"):
+    root = f"old/attempts/{attempt}/snapshots/{iteration:07d}"
+    return {
+        "schema_version": 1,
+        "run_id": "old",
+        "attempt_id": attempt,
+        "iteration": iteration,
+        "version": iteration + 1,
+        "completed_at_ns": iteration,
+        "checkpoint_root": f"{root}/checkpoints",
+        "hf_directory": f"{root}/hf_checkpoints/weight_v{iteration:06d}",
+    }
+
+
+def test_staged_resume_ignores_partial_uploads_and_requires_matching_publication():
+    checkpoint_volume = _Volume(
+        {
+            "old/attempts/partial/snapshots/0000039/hf_checkpoints/weight_v000039/.complete": b"",
+            "old/completed/0000019-attempt.json": json.dumps(
+                _staged_manifest()
+            ).encode(),
+            "old/completed/0000029-attempt.json": json.dumps(
+                _staged_manifest(29)
+            ).encode(),
+        }
+    )
+    run_volume = _Volume({**_published(20), "old/latest": b"old/weight_v000025"})
+    point = prepare_attempt(
+        run_volume,
+        run_id="old",
+        save_hf=_Config.save_hf,
+        checkpoint_volume=checkpoint_volume,
+    )
+    assert point.staged
+    assert point.iteration == 19
+    assert (
+        point.trainer_checkpoint
+        == "/training-checkpoints/old/attempts/attempt/snapshots/0000019/checkpoints"
+    )
+    assert point.rollout_checkpoint.endswith("/hf_checkpoints/weight_v000019")
+    assert run_volume.files["old/latest"] == b"old/weight_v000020"
+    assert "old/checkpoints/latest_checkpointed_iteration.txt" not in run_volume.files
+
+
+def test_staged_resume_falls_back_to_legacy_checkpoint_before_first_upload():
+    volume = _Volume(
+        {
+            "old/checkpoints/latest_checkpointed_iteration.txt": b"19",
+            "old/checkpoints/iter_0000019/state": b"state",
+            "old/hf_checkpoints/weight_v000019/.complete": b"",
+            **_published(20),
+        }
+    )
+    point = resolve_resume_point(
+        volume,
+        source_run_id="old",
+        save_hf=_Config.save_hf,
+        checkpoint_volume=_Volume({}),
+    )
+    assert not point.staged
+    assert point.version == 20
+
+
+def test_fresh_run_handles_modal_missing_completed_directory():
+    from modal.exception import NotFoundError
+
+    class EmptyCheckpointVolume:
+        def iterdir(self, *args, **kwargs):
+            raise NotFoundError('path "/old/completed" does not exist')
+
+    assert (
+        prepare_attempt(
+            _Volume({}),
+            run_id="old",
+            save_hf=_Config.save_hf,
+            checkpoint_volume=EmptyCheckpointVolume(),
+        )
+        is None
+    )
+
+
+def test_boot_selects_persisted_manifest_at_or_below_served_version(tmp_path):
+    run_dir = tmp_path / "old"
+    completed = run_dir / "completed"
+    completed.mkdir(parents=True)
+    for iteration in (19, 29):
+        (completed / f"{iteration:07d}-attempt.json").write_text(
+            json.dumps(_staged_manifest(iteration))
+        )
+    version, path = newest_persisted_export(run_dir, latest_version=25)
+    assert version == 20
+    assert path == tmp_path / _staged_manifest()["hf_directory"]
+
+
+def test_staged_manifest_cannot_redirect_loader_outside_snapshot(tmp_path):
+    run_dir = tmp_path / "old"
+    (run_dir / "completed").mkdir(parents=True)
+    manifest = {**_staged_manifest(), "hf_directory": "old/../../another-run"}
+    (run_dir / "completed/0000019-attempt.json").write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="relative path"):
+        newest_persisted_export(run_dir, latest_version=20)
+
+
+@pytest.mark.parametrize("staged_iteration,expected", [(19, 29), (39, 39)])
+def test_resume_selects_newest_published_checkpoint_across_both_volumes(
+    staged_iteration, expected
+):
+    run_volume = _Volume(
+        {
+            "old/checkpoints/latest_checkpointed_iteration.txt": b"29",
+            "old/checkpoints/iter_0000029/state": b"state",
+            "old/hf_checkpoints/weight_v000029/.complete": b"",
+            **_published(30),
+            **_published(staged_iteration + 1),
+        }
+    )
+    checkpoint_volume = _Volume(
+        {
+            f"old/completed/{staged_iteration:07d}-attempt.json": json.dumps(
+                _staged_manifest(staged_iteration)
+            ).encode(),
+        }
+    )
+    point = resolve_resume_point(
+        run_volume,
+        source_run_id="old",
+        save_hf=_Config.save_hf,
+        checkpoint_volume=checkpoint_volume,
+    )
+    assert point.iteration == expected
+    assert point.staged == (expected == staged_iteration)

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -29,6 +29,10 @@ MILES_ROOT = "/root/miles"
 MILES_RUNTIME_PATCHES = (
     "/root/cookbook/miles_disagg/patches/miles-stable-weight-versions.patch",
     "/root/cookbook/miles_disagg/patches/miles-seed-baseline-scalars.patch",
+    "/root/cookbook/miles_disagg/patches/miles-hf-router-bias-dtype.patch",
+    "/root/cookbook/miles_disagg/patches/miles-disk-delta-hf-save.patch",
+    "/root/cookbook/miles_disagg/patches/miles-hf-export-static-tensors.patch",
+    "/root/cookbook/miles_disagg/patches/miles-local-checkpoints.patch",
 )
 # Source-only megatron.training must be on PYTHONPATH.
 MEGATRON_PATH = "/root/Megatron-LM"


### PR DESCRIPTION
Full model/optimizer checkpoint writes currently block training on Volume I/O. Stage synchronous snapshots on host-local disk, then upload their closed files and commit a dedicated checkpoint Volume in the background. Resume and rollout startup select only completed durable checkpoints.

Periodic saves skip while an upload is pending; forced saves and normal shutdown drain. Each rank participates in an explicit `prepare` / `persist` / `wait` lifecycle. Failed uploads retain the local snapshot and propagate to every rank. An abrupt process loss can still discard an undurable snapshot.

Keep the published Miles pin and carry the lifecycle plus three required HF-export fixes as local patches. The HF fixes preserve canonical save dispatch, router-bias dtype and fixed buffers. Modal storage, coordination, upload limits and retention stay in the cookbook; the Miles extension does not wrap weight synchronization.

The separate Volume isolates commit/reload operations. It does not isolate network bandwidth; no measured advantage over using a subdirectory on the run Volume is claimed.

Confirmed-by-probe:

- 253 Stitch tests pass locally and on Modal.
- The real trainer image fetches public Miles, applies all runtime patches and passes 30 direct-import checkpoint/export regressions.
- The unchanged lifecycle passes a two-host/16-rank Megatron checkpoint roundtrip with exact model, Adam next-step and RNG restoration, continued training while commits are blocked, and a fresh reader verifying 38 files.
- CPU fault injection verifies collective error propagation, local retention and no false completion.

All Modal checks used `stitch-dev` and `runc`. The public-pin image check is [ap-d4use8Bn0Itv6auLSqwH5X](https://modal.com/apps/modal-labs/stitch-dev/ap-d4use8Bn0Itv6auLSqwH5X); the multi-host lifecycle check is [ap-69OUSNYEE8CiSaPGuj7lwl](https://modal.com/apps/modal-labs/stitch-dev/ap-69OUSNYEE8CiSaPGuj7lwl). Full GLM throughput is not qualified by these checks.
