### PR TITLE
cookbook: preserve Slime recipe hook configuration

### DIFF
--- a/cookbook/slime_disagg/app.py
+++ b/cookbook/slime_disagg/app.py
@@ -331,6 +331,7 @@ class Trainer:
         # Slime requires this CLI argument; the deployment owns its run-scoped value.
         cfg.update_weight_disk_dir = str(UPDATES_DIR)
         hook_knobs = {
+            **(getattr(cfg, "custom_config_path", None) or {}),
             **STORE_DEPLOYMENT.hook_config(APP_NAME),
             "experiment_volume_name": exp.EXPERIMENT_VOLUME_NAME,
             "rollout_modal_flash_app_name": APP_NAME,

--- a/cookbook/slime_disagg/app_test.py
+++ b/cookbook/slime_disagg/app_test.py
@@ -1,0 +1,70 @@
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "recipe",
+    [
+        "qwen3_4b_delta_flash",
+        "qwen3_4b_delta_flash_hillclimb",
+        "moonlight",
+        "moonlight_int4",
+    ],
+)
+def test_hook_settings_travel_as_custom_config(recipe):
+    cfg = importlib.import_module(f"cookbook.slime_disagg.configs.{recipe}").slime
+
+    assert not any(arg.startswith("--rollout-request-") for arg in cfg.cli_args())
+    assert cfg.custom_config_path["rollout_request_retry_attempts"] == 240
+
+
+@pytest.mark.parametrize(
+    "custom",
+    [
+        None,
+        {
+            "rollout_request_retry_attempts": 17,
+            "run_id": "stale",
+            "rollout_modal_flash_app_name": "stale",
+        },
+    ],
+)
+def test_trainer_preserves_hook_settings_and_owns_run_identity(monkeypatch, custom):
+    monkeypatch.setenv("EXPERIMENT_CONFIG", "qwen3_4b_delta_flash")
+    monkeypatch.setenv("RUN_ID", "current")
+    monkeypatch.delenv("STITCH_STORE_BACKEND", raising=False)
+    monkeypatch.delitem(sys.modules, "cookbook.slime_disagg.app", raising=False)
+    app = importlib.import_module("cookbook.slime_disagg.app")
+    monkeypatch.setattr(app, "train_volumes", {})
+    monkeypatch.setattr(
+        app,
+        "ModalFlashLBPool",
+        lambda *args: SimpleNamespace(gateway_url=lambda: "http://pool"),
+    )
+    resolve = Mock()
+    monkeypatch.setattr(app.launch, "resolve_config", resolve)
+    monkeypatch.setattr(app.subprocess, "run", Mock())
+    from cookbook.common import hooks
+
+    claim = Mock()
+    monkeypatch.setattr(hooks, "claim_pool", claim)
+    cfg = app.SlimeConfig.from_payload(app.slime_cfg.to_payload())
+    cfg.custom_config_path = custom
+    trainer = app.Trainer._get_user_cls()()
+    trainer.rank = 0
+
+    trainer.train(cfg.to_payload())
+
+    resolved = resolve.call_args.args[0]
+    settings = resolved.custom_config_path
+    assert settings["run_id"] == "current"
+    assert settings["rollout_modal_flash_app_name"] == app.APP_NAME
+    assert settings.get("rollout_request_retry_attempts") == (17 if custom else None)
+    assert vars(claim.call_args.args[0]) == {
+        "update_weight_disk_dir": str(app.UPDATES_DIR),
+        **settings,
+    }

--- a/cookbook/slime_disagg/configs/moonlight.py
+++ b/cookbook/slime_disagg/configs/moonlight.py
@@ -60,10 +60,12 @@ class _Slime(SlimeConfig):
     custom_rollout_request_hook_path = (
         "cookbook.common.hooks.gated_rollout_request_hook"
     )
-    rollout_request_weight_version_mode = "min"
-    rollout_request_weight_version_lag = 1
-    rollout_request_retry_attempts = 240
-    rollout_request_retry_sleep = 1.0
+    custom_config_path = {
+        "rollout_request_weight_version_mode": "min",
+        "rollout_request_weight_version_lag": 1,
+        "rollout_request_retry_attempts": 240,
+        "rollout_request_retry_sleep": 1.0,
+    }
 
     async_mode = True
     update_weights_interval = 1

--- a/cookbook/slime_disagg/configs/moonlight.py
+++ b/cookbook/slime_disagg/configs/moonlight.py
@@ -134,6 +134,8 @@ class _Slime(SlimeConfig):
     # R3 (arxiv 2510.11370): replay the rollout engine's expert routing in the train forward.
     use_rollout_routing_replay = True
 
+    environment = {"CUDA_DEVICE_MAX_CONNECTIONS": "1"}
+
     def prepare_data(self) -> None:
         from datasets import load_dataset
 

--- a/cookbook/slime_disagg/configs/moonlight_int4.py
+++ b/cookbook/slime_disagg/configs/moonlight_int4.py
@@ -62,10 +62,12 @@ class _Slime(SlimeConfig):
     custom_rollout_request_hook_path = (
         "cookbook.common.hooks.gated_rollout_request_hook"
     )
-    rollout_request_weight_version_mode = "min"
-    rollout_request_weight_version_lag = 1
-    rollout_request_retry_attempts = 240
-    rollout_request_retry_sleep = 1.0
+    custom_config_path = {
+        "rollout_request_weight_version_mode": "min",
+        "rollout_request_weight_version_lag": 1,
+        "rollout_request_retry_attempts": 240,
+        "rollout_request_retry_sleep": 1.0,
+    }
 
     async_mode = True
     update_weights_interval = 1

--- a/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
+++ b/cookbook/slime_disagg/configs/qwen3_4b_delta_flash.py
@@ -54,10 +54,12 @@ class _Slime(SlimeConfig):
     custom_rollout_request_hook_path = (
         "cookbook.common.hooks.gated_rollout_request_hook"
     )
-    rollout_request_weight_version_mode = "exact"
-    rollout_request_weight_version_lag = 0
-    rollout_request_retry_attempts = 240
-    rollout_request_retry_sleep = 1.0
+    custom_config_path = {
+        "rollout_request_weight_version_mode": "exact",
+        "rollout_request_weight_version_lag": 0,
+        "rollout_request_retry_attempts": 240,
+        "rollout_request_retry_sleep": 1.0,
+    }
 
     # disk-delta publish-only: slime writes weight_v{N}/ + `latest`; the hook commits and wakes the pool.
     update_weight_mode = "delta"


### PR DESCRIPTION
Stitch hook settings on the top-level Slime config become unsupported CLI arguments. Move them into custom YAML and preserve that recipe dictionary when the launcher adds its run identity and external endpoint settings. This lets the math recipes retain their request/version hooks through actual Slime argument parsing.

Also set `CUDA_DEVICE_MAX_CONNECTIONS=1` for the Moonlight BF16 recipe, whose tensor/context parallel configuration requires it in the pinned Megatron validator. The two fixes remain separate commits.

Confirmed-by-probe: real Slime parsing and YAML consumption cover all four affected recipes; trainer method checks verify merging and launcher ownership. The Megatron validator rejects the missing environment and accepts the configured value. This branch passes 243 tests and actual app imports locally/on Modal (`stitch-dev`, `runc`). CPU probes substitute Ray/GPU startup and pool effects.
