### PR TITLE
cookbook: route Miles rollouts through the external inference fleet

### DIFF
--- a/cookbook/miles_disagg/configs/glm45_air_bf16.py
+++ b/cookbook/miles_disagg/configs/glm45_air_bf16.py
@@ -83,6 +83,8 @@ class _Miles(MilesConfig):
     rollout_num_gpus_per_engine = 8
     rollout_endpoint_url = None
     use_miles_router = True
+    use_session_server = "v2"
+    custom_generate_function_path = "cookbook.miles_disagg.rollout.generate"
 
     custom_rollout_request_hook_path = (
         "cookbook.common.hooks.gated_rollout_request_hook"

--- a/cookbook/miles_disagg/configs/glm45_air_fp8.py
+++ b/cookbook/miles_disagg/configs/glm45_air_fp8.py
@@ -79,6 +79,8 @@ class _Miles(MilesConfig):
     rollout_num_gpus_per_engine = 4
     rollout_endpoint_url = None  # filled at launch from the pool gateway
     use_miles_router = True
+    use_session_server = "v2"
+    custom_generate_function_path = "cookbook.miles_disagg.rollout.generate"
 
     custom_rollout_request_hook_path = (
         "cookbook.common.hooks.gated_rollout_request_hook"

--- a/cookbook/miles_disagg/configs/moonlight_nvfp4.py
+++ b/cookbook/miles_disagg/configs/moonlight_nvfp4.py
@@ -78,6 +78,8 @@ class _Miles(MilesConfig):
     )
     rollout_endpoint_url = None
     use_miles_router = True
+    use_session_server = "v2"
+    custom_generate_function_path = "cookbook.miles_disagg.rollout.generate"
 
     # Staleness gate; the knobs ride in custom_config_path (read by the hook, not miles core).
     custom_rollout_request_hook_path = (

--- a/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
+++ b/cookbook/miles_disagg/configs/qwen3_30b_a3b_nvfp4_46.py
@@ -146,6 +146,8 @@ class _Miles(MilesConfig):
     rollout_num_gpus_per_engine = 1  # 30B NVFP4 is ~17 GB packed; 1 B200 per engine
     rollout_endpoint_url = None
     use_miles_router = True
+    use_session_server = "v2"
+    custom_generate_function_path = "cookbook.miles_disagg.rollout.generate"
 
     custom_rollout_request_hook_path = (
         "cookbook.common.hooks.gated_rollout_request_hook"

--- a/cookbook/miles_disagg/patches/miles-external-rollout-drain.patch
+++ b/cookbook/miles_disagg/patches/miles-external-rollout-drain.patch
@@ -1,0 +1,12 @@
+--- a/miles/rollout/inference_rollout/inference_rollout_train.py
++++ b/miles/rollout/inference_rollout/inference_rollout_train.py
+@@ -27,7 +27,8 @@
+     assert not state.aborted
+     state.aborted = True
+ 
+-    urls = await get_worker_urls(args)
++    # External endpoints have no managed worker registry.
++    urls = [] if args.rollout_endpoint_url else await get_worker_urls(args)
+     logger.info(f"Abort request for {urls}")
+     await asyncio.gather(*[post(f"{url}/abort_request", {"abort_all": True}) for url in urls])
+ 

--- a/cookbook/miles_disagg/rollout.py
+++ b/cookbook/miles_disagg/rollout.py
@@ -1,0 +1,54 @@
+"""Token-based math rollouts through Stitch's external inference endpoint."""
+
+from miles.rollout.base_types import GenerateFnInput, GenerateFnOutput
+from miles.rollout.generate_utils.generate_endpoint_utils import (
+    compute_prompt_ids_from_sample,
+    compute_request_payload,
+    compute_routing_headers,
+    update_sample_from_response,
+)
+from miles.rollout.generate_utils.rollout_request import (
+    RolloutRequestContext,
+    prepare_rollout_request,
+)
+from miles.utils.http_utils import post
+from miles.utils.types import Sample
+
+from cookbook.common.hooks import sample_affinity_key
+
+
+async def generate(input: GenerateFnInput) -> GenerateFnOutput:
+    """Generate through the external endpoint with session affinity and a version gate."""
+    args, sample = input.args, input.sample
+    assert sample.status in {Sample.Status.PENDING, Sample.Status.ABORTED}
+    prompt_ids = compute_prompt_ids_from_sample(input.state, sample)
+    sampling_params = dict(input.sampling_params)
+    if sample.response:
+        sampling_params["max_new_tokens"] -= len(sample.tokens) - len(prompt_ids)
+        input_ids = sample.tokens
+    else:
+        input_ids = prompt_ids
+    payload, halt_status = compute_request_payload(
+        args, input_ids, sampling_params, sample.multimodal_inputs
+    )
+    if payload is None:
+        sample.status = halt_status
+        return GenerateFnOutput(samples=sample)
+
+    request = await prepare_rollout_request(
+        args,
+        RolloutRequestContext(session_id=sample_affinity_key(sample)),
+        url=f"{args.rollout_endpoint_url.rstrip('/')}/generate",
+        payload=payload,
+        headers=compute_routing_headers(args, sample),
+    )
+    if request["retry_sleep"] != 1.0:
+        raise ValueError("Miles token rollouts require rollout_request_retry_sleep=1")
+    output = await post(
+        request["url"],
+        request["payload"],
+        headers=request["headers"],
+        max_retries=request["max_retries"],
+    )
+    await update_sample_from_response(args, sample, payload, output)
+    return GenerateFnOutput(samples=sample)

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -29,6 +29,7 @@ MILES_ROOT = "/root/miles"
 MILES_RUNTIME_PATCHES = (
     "/root/cookbook/miles_disagg/patches/miles-stable-weight-versions.patch",
     "/root/cookbook/miles_disagg/patches/miles-seed-baseline-scalars.patch",
+    "/root/cookbook/miles_disagg/patches/miles-external-rollout-drain.patch",
 )
 # Source-only megatron.training must be on PYTHONPATH.
 MEGATRON_PATH = "/root/Megatron-LM"


### PR DESCRIPTION
Miles math recipes use an external Stitch inference fleet, but the default single-turn generator constructs `http://None:None/generate` and cleanup tries to enumerate nonexistent managed workers. Route single-turn requests through the resolved external endpoint, preserving sample continuation, routing affinity and weight-version hooks. Select session v2 in the four active math recipes.

Keep the published Miles pin and apply a one-line behavior change as a local patch: external endpoints skip managed-worker lookup while still draining pending requests and propagating failures. Managed fleets retain their abort path.

Confirmed-by-probe: the baseline reproduces the invalid generation/worker URLs. The real HTTP helper checks retries, continuation, exhausted token budgets, external draining and managed aborts. The branch passes 237 Stitch tests locally and on Modal. Validation uses CPU containers in `stitch-dev` with `runc`; it qualifies the request lifecycle, not full training or convergence.

Confirmed-by-probe for this exact public-pin packaging: 237 Stitch tests and actual app imports pass; the original invalid URLs are reproduced, nine real-HTTP request/cleanup scenarios pass, and 31 Miles drain/export regression cases pass. [Modal check](https://modal.com/apps/modal-labs/stitch-dev/ap-9bRUvrnLlnsULKGZqV6C3t).
