### PR TITLE
cookbook: add Qwen3.6 SWE-bench Pro training

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -181,6 +181,48 @@ EXPERIMENT_CONFIG=your_config_name RUN_ID=your_run_id \
 Modal rolls replicas to the new configuration without changing the run's
 checkpoint lineage.
 
+## Qwen3.6 SWE-bench Pro training
+
+[`qwen3_6_35b_a3b_swebench_pro.py`](miles_disagg/configs/qwen3_6_35b_a3b_swebench_pro.py)
+runs fully asynchronous GRPO on SWE-bench Pro, using a pinned
+`Qwen/Qwen3.6-35B-A3B` BF16 checkpoint.
+
+| Component | Configuration |
+| --- | --- |
+| Trainer | 2 nodes × 8 B300 GPUs |
+| Rollouts | 16 warm replicas × 1 B200-or-better GPU; autoscale without a cap |
+| Training | 500 batches; 32 prompts × 8 samples = 256 trajectories per batch |
+| Checkpoints | Every 20 batches and at the end of training |
+| Concurrency | 256 agent episodes; up to two completed batches buffered |
+| Episode limits | 256 agent steps, 2 hours, 64K total tokens |
+| Per-response limit | 8,192 tokens |
+
+Preparation exposes fused experts individually without changing their weight
+bytes, matching Miles' checkpoint-delta export layout.
+
+After creating the shared secrets, run each preparation command to completion
+before launching:
+
+```bash
+export EXPERIMENT_CONFIG=qwen3_6_35b_a3b_swebench_pro
+export MODAL_ENVIRONMENT=your_environment
+
+uv run --extra modal modal run -e "$MODAL_ENVIRONMENT" \
+  -m cookbook.miles_disagg.prep_app::prepare_checkpoints
+uv run --extra modal modal run -e "$MODAL_ENVIRONMENT" \
+  -m cookbook.miles_disagg.prep_app::prepare_torch_dist
+uv run --extra modal modal run -e "$MODAL_ENVIRONMENT" \
+  -m cookbook.miles_disagg.prep_app::prepare_dataset
+uv run --extra modal python -m cookbook.miles_disagg.launch
+```
+
+The trainer stops after 500 batches. Stop its deployed app when finished
+to release the rollout fleet:
+
+```bash
+uv run --extra modal modal app stop -e "$MODAL_ENVIRONMENT" "$APP_NAME"
+```
+
 ## GLM-4.7 Flash example
 
 `glm47_flash_swebench_pro` is a complete example of the workflow above. It runs

--- a/cookbook/miles_disagg/configs/qwen3_6_35b_a3b_swebench_pro.py
+++ b/cookbook/miles_disagg/configs/qwen3_6_35b_a3b_swebench_pro.py
@@ -1,0 +1,106 @@
+"""Fully asynchronous Qwen3.6-35B-A3B GRPO on SWE-bench Pro."""
+
+from copy import deepcopy
+
+from cookbook.common.config import ModalConfig
+from cookbook.common.constants import CHECKPOINTS_PATH
+from cookbook.miles_disagg.configs import glm47_flash_swebench_pro as base
+
+APP_NAME = "stitch-qwen3-6-35b-swebench-pro"
+EXPERIMENT_VOLUME_NAME = "stitch-miles-qwen3-6-35b-swebench-pro"
+SOURCE_MODEL = "Qwen/Qwen3.6-35B-A3B"
+SOURCE_REVISION = "995ad96eacd98c81ed38be0c5b274b04031597b0"
+BF16_CHECKPOINT_PATH = CHECKPOINTS_PATH / "qwen3-6-35b-a3b-995ad96e-bf16-unpacked"
+ROLLOUT_CHECKPOINT_PATH = BF16_CHECKPOINT_PATH
+TORCH_DIST_CHECKPOINT_PATH = (
+    CHECKPOINTS_PATH / "qwen3-6-35b-a3b-995ad96e-torch-dist-tp2-ep8"
+)
+SERVED_CHECKPOINT_FORMAT = "bf16"
+CHECKPOINT_PREP_REQUIRES_GPU = False
+UNPACK_FUSED_EXPERTS = True
+LOCAL_CHECKPOINT_PATH = None
+PREP_ENV = dict(base.PREP_ENV)
+TRAINER_EXTRA_PIP_PACKAGES = base.TRAINER_EXTRA_PIP_PACKAGES
+MEGATRON_RUNTIME_PATCHES = [
+    "/root/cookbook/miles_disagg/patches/megatron-r3-dispatch.patch",
+    *base.MEGATRON_RUNTIME_PATCHES,
+]
+
+MAX_SEQ_LEN = 65_536
+AGENT_PROCESSES = 16
+AGENT_THREADS_PER_PROCESS = 16
+ROLLOUT_CONCURRENT_SAMPLES = AGENT_PROCESSES * AGENT_THREADS_PER_PROCESS
+SIDECAR_COMMIT_MODE = "in_place"
+SIDECAR_FLUSH_CACHE_ON_COMMIT = False
+SGLANG_DELTA_UPDATE_MODE = "cpu"
+SGLANG_SERVER_ENV = dict(base.SGLANG_SERVER_ENV)
+SGLANG_SERVER_ARGS = {
+    **base.SGLANG_SERVER_ARGS,
+    "--reasoning-parser": "qwen3",
+    "--tool-call-parser": "qwen3_coder",
+    "--context-length": str(MAX_SEQ_LEN + 8),
+    "--max-running-requests": "16",
+    "--max-queued-requests": "4",
+    "--cuda-graph-max-bs-decode": "16",
+    "--moe-runner-backend": "triton",
+}
+
+modal = ModalConfig(
+    gpu="B300",
+    rollout_gpu="B200+",
+    trainer_memory_mib=(262_144, 786_432),
+    rollout_memory_mib=(262_144, 524_288),
+    rollout_min_containers=16,
+    rollout_max_containers=None,
+    rollout_target_inputs=8,
+    rollout_ephemeral_disk_mib=524_288,
+    trainer_ephemeral_disk_mib=524_288,
+    torch_dist_prep_nodes=1,
+    torch_dist_prep_gpus_per_node=8,
+    torch_dist_convert_extra_args=(
+        "--tensor-model-parallel-size 2 "
+        "--pipeline-model-parallel-size 1 "
+        "--context-parallel-size 1 "
+        "--expert-model-parallel-size 8 "
+        "--expert-tensor-parallel-size 1 "
+        "--sequence-parallel "
+        "--moe-token-dispatcher-type alltoall"
+    ),
+    torch_dist_prep_ephemeral_disk_mib=524_288,
+)
+
+miles = deepcopy(base.miles)
+miles.megatron_model_type = "qwen3.6-35B-A3B"
+miles.hf_checkpoint = str(ROLLOUT_CHECKPOINT_PATH)
+miles.ref_load = str(TORCH_DIST_CHECKPOINT_PATH)
+miles.actor_num_nodes = 2
+miles.actor_num_gpus_per_node = 8
+miles.num_gpus_per_node = 8
+miles.rollout_num_gpus_per_engine = 1
+miles.sglang_server_concurrency = ROLLOUT_CONCURRENT_SAMPLES
+miles.session_server_port = [30000, 30008]
+miles.session_server_startup_timeout_seconds = 600
+miles.tito_model = "qwen35"
+miles.num_rollout = 500
+miles.save_interval = 20
+miles.rollout_batch_size = 32
+miles.n_samples_per_prompt = 8
+miles.global_batch_size = miles.rollout_batch_size * miles.n_samples_per_prompt
+miles.max_seq_len = MAX_SEQ_LEN
+miles.rollout_max_response_len = 8192
+miles.rollout_top_k = 20
+miles.context_parallel_size = 1
+miles.max_tokens_per_gpu = 4096
+miles.log_probs_max_tokens_per_gpu = 4096
+miles.async_max_concurrent_samples = ROLLOUT_CONCURRENT_SAMPLES
+miles.async_data_buffer_capacity_factor = 2.0
+miles.wandb_group = "qwen3-6-35b-swebench-pro"
+miles.prometheus_run_name = miles.wandb_group
+miles.environment = {
+    **base.miles.environment,
+    "MODAL_SWE_SANDBOX_APP": "qwen3-6-35b-swebench-pro-sandbox",
+    "MODAL_SWE_MAX_STEPS": "256",
+    "MODAL_SWE_EPISODE_TIMEOUT": "7200",
+    "MODAL_SWE_AGENT_PROCESSES": str(AGENT_PROCESSES),
+    "MODAL_SWE_AGENT_THREADS_PER_PROCESS": str(AGENT_THREADS_PER_PROCESS),
+}

--- a/cookbook/miles_disagg/patches/miles-hf-checkpoint-dtypes.patch
+++ b/cookbook/miles_disagg/patches/miles-hf-checkpoint-dtypes.patch
@@ -1,0 +1,57 @@
+--- a/miles/backends/megatron_utils/megatron_to_hf/__init__.py
++++ b/miles/backends/megatron_utils/megatron_to_hf/__init__.py
+@@ -1,3 +1,5 @@
++from miles.backends.megatron_utils.megatron_to_hf.checkpoint_schema import _restore_checkpoint_dtype
++
+ from .deepseekv3 import convert_deepseekv3_to_hf
+ from .deepseekv4 import convert_deepseekv4_to_hf
+ from .glm4 import convert_glm4_to_hf
+@@ -24,7 +26,10 @@
+ def convert_to_hf(args, model_name, name, param, quantization_config=None):
+     param = remove_padding(name, param, args.vocab_size)
+ 
+-    converted_named_tensors = _convert_to_hf_core(args, model_name, name, param)
++    converted_named_tensors = [
++        (hf_name, _restore_checkpoint_dtype(args, hf_name, weight))
++        for hf_name, weight in _convert_to_hf_core(args, model_name, name, param)
++    ]
+ 
+     return quantize_params(args, name, converted_named_tensors, quantization_config)
+ 
+--- /dev/null
++++ b/miles/backends/megatron_utils/megatron_to_hf/checkpoint_schema.py
+@@ -0,0 +1,34 @@
++"""Preserve checkpoint storage dtypes for parameters kept in FP32 by Megatron."""
++
++import json
++from functools import lru_cache
++from pathlib import Path
++
++import torch
++from safetensors import safe_open
++
++
++def _restore_checkpoint_dtype(args, name, param):
++    if (
++        getattr(args, "update_weight_transfer_mode", None) != "disk-delta"
++        or not name.endswith((".e_score_correction_bias", ".linear_attn.A_log"))
++    ):
++        return param
++    dtype = _checkpoint_dtypes(args.hf_checkpoint).get(name)
++    return param.to(dtype) if dtype is not None else param
++
++
++@lru_cache(maxsize=8)
++def _checkpoint_dtypes(checkpoint):
++    root = Path(checkpoint)
++    index = root / "model.safetensors.index.json"
++    if not index.exists():
++        return {}
++    names = json.loads(index.read_text())["weight_map"]
++    dtypes = {"BF16": torch.bfloat16, "F16": torch.float16, "F32": torch.float32}
++    result = {}
++    for name, shard in names.items():
++        if name.endswith((".e_score_correction_bias", ".linear_attn.A_log")):
++            with safe_open(root / shard, framework="pt") as source:
++                result[name] = dtypes[source.get_slice(name).get_dtype()]
++    return result

--- a/cookbook/miles_disagg/prep.py
+++ b/cookbook/miles_disagg/prep.py
@@ -82,6 +82,10 @@ def prepare_checkpoints(
         else:
             _copy_tree("bf16 masters", src, out)
         _strip_stale_quant_config(os.path.join(out, "config.json"))
+        if getattr(exp, "UNPACK_FUSED_EXPERTS", False):
+            from cookbook.miles_disagg.unpack_experts import unpack_fused_experts
+
+            unpack_fused_experts(out)
 
     if is_int4 or getattr(exp, "MATERIALIZE_BF16_MASTERS", True):
         _staged(materialized_bf16_dir, _build_bf16)

--- a/cookbook/miles_disagg/trainer_image.py
+++ b/cookbook/miles_disagg/trainer_image.py
@@ -29,6 +29,7 @@ MILES_ROOT = "/root/miles"
 MILES_RUNTIME_PATCHES = (
     "/root/cookbook/miles_disagg/patches/miles-stable-weight-versions.patch",
     "/root/cookbook/miles_disagg/patches/miles-seed-baseline-scalars.patch",
+    "/root/cookbook/miles_disagg/patches/miles-hf-checkpoint-dtypes.patch",
 )
 # Source-only megatron.training must be on PYTHONPATH.
 MEGATRON_PATH = "/root/Megatron-LM"

--- a/cookbook/miles_disagg/unpack_experts.py
+++ b/cookbook/miles_disagg/unpack_experts.py
@@ -1,0 +1,69 @@
+"""Expose fused Hugging Face experts individually without changing tensor bytes."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import struct
+from pathlib import Path
+
+_FUSED_EXPERT = re.compile(r"(.+\.experts)\.(gate_up_proj|down_proj)$")
+
+
+def unpack_fused_experts(checkpoint: str) -> None:
+    """Rewrite a staged checkpoint to the individual-expert layout Miles exports."""
+    root = Path(checkpoint)
+    weight_map = {}
+    converted = 0
+    for shard in sorted(root.glob("*.safetensors")):
+        with shard.open("rb") as source:
+            (header_size,) = struct.unpack("<Q", source.read(8))
+            header = json.loads(source.read(header_size))
+            output = {}
+            for name, info in header.items():
+                match = _FUSED_EXPERT.fullmatch(name)
+                if not match:
+                    output[name] = info
+                    continue
+                prefix, projection = match.groups()
+                experts, rows, columns = info["shape"]
+                pieces = 2 if projection == "gate_up_proj" else 1
+                start, end = info["data_offsets"]
+                if rows % pieces or (end - start) % (experts * pieces):
+                    raise ValueError(f"Invalid fused expert layout: {name}: {info}")
+                size = (end - start) // (experts * pieces)
+                projections = (
+                    ("gate_proj", "up_proj") if pieces == 2 else ("down_proj",)
+                )
+                for expert in range(experts):
+                    for part, proj in enumerate(projections):
+                        offset = start + (expert * pieces + part) * size
+                        target = f"{prefix}.{expert}.{proj}.weight"
+                        if target in header or target in output:
+                            raise ValueError(f"Duplicate expert tensor: {target}")
+                        output[target] = {
+                            "dtype": info["dtype"],
+                            "shape": [rows // pieces, columns],
+                            "data_offsets": [offset, offset + size],
+                        }
+                converted += 1
+            encoded = json.dumps(output, separators=(",", ":")).encode()
+            encoded += b" " * (-len(encoded) % 8)
+            temporary = shard.with_suffix(".safetensors.partial")
+            with temporary.open("wb") as destination:
+                destination.write(struct.pack("<Q", len(encoded)))
+                destination.write(encoded)
+                shutil.copyfileobj(source, destination, length=16 << 20)
+        temporary.replace(shard)
+        weight_map.update(
+            {name: shard.name for name in output if name != "__metadata__"}
+        )
+        print(f"Unpacked expert headers: {shard.name}", flush=True)
+    if not weight_map:
+        raise ValueError(f"No checkpoint tensors in {checkpoint}")
+    index_path = root / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text()) if index_path.exists() else {}
+    index["weight_map"] = weight_map
+    index_path.write_text(json.dumps(index, indent=2) + "\n")
+    print(f"Unpacked {converted} fused expert tensors", flush=True)

--- a/cookbook/miles_disagg/unpack_experts_test.py
+++ b/cookbook/miles_disagg/unpack_experts_test.py
@@ -1,0 +1,90 @@
+import json
+import struct
+
+import pytest
+from safetensors import deserialize
+
+from cookbook.miles_disagg.unpack_experts import unpack_fused_experts
+
+
+def _serialize(tensors):
+    header = {"__metadata__": {"format": "pt"}}
+    data = b""
+    for name, tensor in tensors.items():
+        end = len(data) + len(tensor["data"])
+        header[name] = {
+            "dtype": tensor["dtype"],
+            "shape": tensor["shape"],
+            "data_offsets": [len(data), end],
+        }
+        data += tensor["data"]
+    encoded = json.dumps(header).encode()
+    encoded += b" " * (-len(encoded) % 8)
+    return struct.pack("<Q", len(encoded)) + encoded + data
+
+
+def test_unpack_preserves_expert_values_and_other_tensors(tmp_path):
+    prefix = "model.language_model.layers.0.mlp.experts"
+    gate_up = bytes(range(32))
+    down = bytes(range(100, 116))
+    tensors = {
+        f"{prefix}.gate_up_proj": {
+            "dtype": "BF16",
+            "shape": [2, 4, 2],
+            "data": gate_up,
+        },
+        f"{prefix}.down_proj": {"dtype": "BF16", "shape": [2, 2, 2], "data": down},
+        "norm.weight": {"dtype": "F32", "shape": [1], "data": struct.pack("<f", 1.5)},
+    }
+    shard = tmp_path / "model.safetensors"
+    shard.write_bytes(_serialize(tensors))
+    index = tmp_path / "model.safetensors.index.json"
+    index.write_text(json.dumps({"metadata": {"total_size": 52}, "weight_map": {}}))
+
+    unpack_fused_experts(str(tmp_path))
+
+    result = dict(deserialize(shard.read_bytes()))
+    expected = {"norm.weight": tensors["norm.weight"]}
+    for expert in range(2):
+        for part, projection in enumerate(("gate_proj", "up_proj")):
+            offset = expert * 16 + part * 8
+            expected[f"{prefix}.{expert}.{projection}.weight"] = {
+                "dtype": "BF16",
+                "shape": [2, 2],
+                "data": gate_up[offset : offset + 8],
+            }
+        expected[f"{prefix}.{expert}.down_proj.weight"] = {
+            "dtype": "BF16",
+            "shape": [2, 2],
+            "data": down[expert * 8 : (expert + 1) * 8],
+        }
+    assert result == expected
+    assert json.loads(index.read_text()) == {
+        "metadata": {"total_size": 52},
+        "weight_map": dict.fromkeys(expected, shard.name),
+    }
+    before = shard.read_bytes()
+    unpack_fused_experts(str(tmp_path))
+    assert shard.read_bytes() == before
+
+
+def test_unpack_rejects_conflicting_individual_expert(tmp_path):
+    prefix = "model.layers.0.mlp.experts"
+    (tmp_path / "model.safetensors").write_bytes(
+        _serialize(
+            {
+                f"{prefix}.gate_up_proj": {
+                    "dtype": "BF16",
+                    "shape": [1, 2, 1],
+                    "data": b"\0" * 4,
+                },
+                f"{prefix}.0.gate_proj.weight": {
+                    "dtype": "BF16",
+                    "shape": [1, 1],
+                    "data": b"\0" * 2,
+                },
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="Duplicate expert tensor"):
+        unpack_fused_experts(str(tmp_path))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
     "modal>=1.5.4.dev11",
     "fastapi",
     "httpx",
+    "safetensors",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -1032,6 +1032,30 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/" }
+sdist = { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/safetensors/0.8.0/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://modal-labs-459781239556.d.codeartifact.us-east-1.amazonaws.com/pypi/modal-pypi/simple/" }
@@ -1078,6 +1102,7 @@ dev = [
     { name = "modal" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "safetensors" },
 ]
 
 [package.metadata]
@@ -1097,6 +1122,7 @@ dev = [
     { name = "modal", specifier = ">=1.5.4.dev11" },
     { name = "pytest" },
     { name = "ruff", specifier = "==0.15.1" },
+    { name = "safetensors" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a pinned Qwen3.6-35B-A3B BF16 recipe for sustained asynchronous GRPO training on SWE-bench Pro:

- Two trainer nodes with eight B300 GPUs each.
- A warm floor of 16 single-GPU B200+ rollout replicas, with no autoscaling maximum.
- 500 batches of 32 prompts × 8 samples = 256 trajectories, with checkpoints every 20 batches.
- 256 concurrent agent episodes, eight session servers, and space for two completed batches in the asynchronous buffer.
- 64K context, 8,192 tokens per response, and up to 256 agent steps or two hours per episode.

Checkpoint preparation exposes fused experts through safetensors header rewrites without changing tensor bytes. The Miles export patch preserves checkpoint storage dtypes for `linear_attn.A_log` during delta export. The recipe selects Triton for CPU weight staging and uses `top_k=20`. The cookbook documents preparation and launch.

This PR is based directly on `main`. Native Modal KV routing is handled independently in #217; the active training run combines both changes.

Validation — **confirmed-by-probe**:

- `uv run pytest`: **239 passed** on this independent Qwen branch. The expert-layout tests verify exact tensor bytes, metadata/index preservation, repeatability, and collision rejection.
- CPU Modal image checks passed for the current serving arguments, batch sizes, context limits, and agent concurrency. Full Miles/Megatron argument parsing passed on B300 for the 500-batch schedule, 256-trajectory batches, 64K context, eight session servers, and TP2/CP1/EP8 topology.
- All 26 checkpoint shard payload hashes remained unchanged after expanding 82 fused expert tensors. Export probes verified all 30 `A_log` tensors against canonical bytes while retaining FP32 runtime parameters.
- An earlier, smaller integration run completed three learner steps. It measured **95.16%, 94.22%, and 94.64%** prefix-cache hits across 1,341 requests at weight version 0. A subsequent native-routing serving probe at weight version 3 measured **97.71%** warm-prefix reuse.

Validation limits — **confirmed-by-probe**: the smaller run logged a NaN gradient norm at learner step 0 and zero gradients at steps 1 and 2. Its training and serving checks were separate; those cache measurements do not establish clean training numerics or throughput for the larger workload.

Larger-load validation — **confirmed-by-probe**: repeated SGLang `request queue is full` responses abort episodes after startup. A clean learner update under this workload has not yet been verified.

**Code-read inference**: the pinned session transport retries 409/429 responses but passes through the engine's queue-full 503; the inherited agent configuration permits one model attempt. The adapter classifies these failures as infrastructure aborts rather than zero-reward policy outcomes. This transport/configuration limitation remains unresolved.
