### PR TITLE
cookbook: reload trainer mount after restoring Miles resume state

### DIFF
--- a/cookbook/miles_disagg/app.py
+++ b/cookbook/miles_disagg/app.py
@@ -328,6 +328,19 @@ class Trainer:
             "Miles patch",
         )
         self.rank = rank
+        # Every rank's Megatron reads the tracker this rewrites, so the restore has to
+        # land before the first reload of the mount in train(); a clustered method call
+        # starts only after every container's enter returns. Resolved here, not from the
+        # payload, so it cannot disagree with the Server's boot-checkpoint search.
+        self.resume_point = (
+            prepare_attempt(
+                run_volume,
+                run_id=RUN_ID,
+                save_hf=getattr(miles_cfg, "save_hf", None),
+            )
+            if self.rank == 0 and STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME
+            else None
+        )
         process.start_host_mem_monitor()  # per-node host-RAM trace
         ray_cluster.start_ray_node(
             rank,
@@ -353,6 +366,7 @@ class Trainer:
         first publish fails its claim's rewind guard instead of relabeling
         history.
         """
+        # Makes rank 0's enter-time resume restore visible to this rank.
         for volume in train_volumes.values():
             volume.reload()
 
@@ -363,11 +377,7 @@ class Trainer:
             ray_cluster.hold_worker_node(self.master_addr, ray_port=RAY_PORT)
             return
 
-        resume_point = None
-        if STORE_DEPLOYMENT.backend == storage.MODAL_VOLUME:
-            resume_point = prepare_attempt(
-                run_volume, run_id=RUN_ID, save_hf=getattr(cfg, "save_hf", None)
-            )
+        resume_point = self.resume_point
 
         cfg.rollout_endpoint_url = ModalFlashPool(APP_NAME, "Server").gateway_url()
         if resume_point is not None:

--- a/cookbook/miles_disagg/resume.py
+++ b/cookbook/miles_disagg/resume.py
@@ -160,9 +160,14 @@ def prepare_attempt(
     try:
         point = resolve_resume_point(volume, source_run_id=run_id, save_hf=save_hf)
     except ResumePointNotFound:
+        point = None
+    if point is None:
         restore_boot_pointer(volume, run_id)
-        return None
-    restore_resume_point(volume, point)
+    else:
+        restore_resume_point(volume, point)
+    # API uploads do not refresh the mounted pointer or Megatron tracker.
+    # The subsequent claim and checkpoint loader read those mounted files.
+    volume.reload()
     return point
 
 

--- a/cookbook/miles_disagg/resume_test.py
+++ b/cookbook/miles_disagg/resume_test.py
@@ -296,6 +296,44 @@ def test_prepare_attempt_is_a_noop_on_a_fresh_run() -> None:
     assert volume.files == {}
 
 
+@pytest.mark.parametrize("resumable", [True, False])
+def test_prepare_attempt_refreshes_the_mount_before_the_claim(
+    tmp_path, resumable
+) -> None:
+    """The restore writes through the Volume API; a mount sees those writes only
+    after a reload, and the claim that follows reads the mount."""
+    from stitch.publish import claim_run
+    from stitch.stores.modal_volume import ModalVolumeStore
+
+    class MountedVolume(_Volume):
+        def reload(self) -> None:
+            for name, value in self.files.items():
+                path = tmp_path / name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(value)
+
+    files: dict[str, bytes] = {"old/latest": b"old/weight_v000042"}
+    if resumable:
+        files.update(
+            {
+                "old/checkpoints/latest_checkpointed_iteration.txt": b"39",
+                "old/checkpoints/iter_0000029/state": b"checkpoint",
+                "old/hf_checkpoints/weight_v000029/.complete": b"",
+                **_published(30),
+            }
+        )
+    volume = MountedVolume(files)
+    volume.reload()
+    store = ModalVolumeStore(tmp_path / "old", run_id="old")
+    assert store.read_pointer().version == 42
+
+    point = prepare_attempt(volume, run_id="old", save_hf=_Config.save_hf)
+    boot_version = point.version if point is not None else 0
+    claim_run(store, None, "old", boot_version=boot_version)
+
+    assert store.read_pointer().version == boot_version
+
+
 def test_restore_boot_pointer_rejects_a_foreign_run() -> None:
     volume = _Volume({"old/latest": b"other/weight_v000003"})
 


### PR DESCRIPTION
Follow-up to #210 

Miles retries restore `latest` and the checkpoint tracker through the Volume API, then read them from a mount that still contains the preceding attempt's state. A retry can therefore raise `PointerRewind` even though the durable pointer was restored successfully.

Reload the trainer Volume after restoring either a saved checkpoint or the initial model. This ports the mount-refresh fix from the GLM debugging worktree onto `main` independently.

Validation — **confirmed-by-probe**:

- A CPU-only probe in the Qwen trainer image reproduced both stale-mount cases with an isolated Modal Volume. Both cases passed with this change, including the restored checkpoint tracker.
- `uv run pytest`: **226 passed**.

This fixes the retry failure. Separate non-finite gradient norms and a likely host-memory termination observed in the training run remain unresolved; no full training recovery is claimed.
